### PR TITLE
Add Fortran parser utilities with fparser2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # fautodiff
 Autodiff code generator for Fortran
+
+This repository includes utilities for parsing Fortran source code using
+[fparser2](https://fparser.readthedocs.io/en/latest/index.html) (specifically
+the ``fparser.two`` API).
+
+## Installation
+
+The parser relies on the `fparser` package which can be installed via pip:
+
+```bash
+pip install fparser
+```
+
+## Parsing Fortran
+
+The ``fautodiff.parser`` module exposes helper functions for creating an AST
+from Fortran code and for finding subroutines. These helpers rely on
+``fparser.two``'s `ParserFactory` under the hood. Example usage:
+
+```python
+from fautodiff import parser
+
+# Parse a Fortran source file
+ast = parser.parse_file("example.f90")
+
+# List all subroutine names in the file
+print(parser.find_subroutines(ast))
+```

--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -1,0 +1,22 @@
+"""Utility functions for parsing Fortran using ``fparser.two``."""
+
+from fparser.common.readfortran import FortranFileReader
+from fparser.two.parser import ParserFactory
+from fparser.two import Fortran2003
+from fparser.two.utils import walk
+
+
+def parse_file(path):
+    """Parse a Fortran source file and return the ``fparser`` AST."""
+    reader = FortranFileReader(path)
+    parser = ParserFactory().create(std="f2008")
+    return parser(reader)
+
+
+def find_subroutines(ast):
+    """Return a list of subroutine names defined in the given AST."""
+    names = []
+    for node in walk(ast, Fortran2003.Subroutine_Subprogram):
+        stmt = node.children[0]  # Subroutine_Stmt
+        names.append(str(stmt.get_name()))
+    return names


### PR DESCRIPTION
## Summary
- add a `fautodiff` package containing `parser.py` with helper functions
- document `fparser` install and parser usage in README
- switch parser to use `fparser.two`

## Testing
- `python3 -m pip show fparser`

------
https://chatgpt.com/codex/tasks/task_b_68484c9e3668832da65063e1ab01c9e9