### PR TITLE
Improve autodiff generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,17 @@ ast = parser.parse_file("example.f90")
 # List all subroutine names in the file
 print(parser.find_subroutines(ast))
 ```
+
+## Generating AD code
+
+For simple examples the ``fautodiff.generator`` module can create a reverse
+mode automatic differentiation version of a Fortran source file. The generator
+parses the input via :mod:`fautodiff.parser` (which internally relies on
+``fparser2``) and retains the original structure with ``_ad`` appended to
+routine names.
+
+Generate the AD code for ``examples/simple_math.f90``:
+
+```bash
+python -m fautodiff.generator examples/simple_math.f90 examples/simple_math_ad.f90
+```

--- a/examples/simple_math_ad.f90
+++ b/examples/simple_math_ad.f90
@@ -1,0 +1,30 @@
+module simple_math_ad
+contains
+  subroutine add_numbers_ad(a, a_ad, b, b_ad, c_ad)
+    real, intent(in)  :: a
+    real, intent(out) :: a_ad
+    real, intent(in)  :: b
+    real, intent(out) :: b_ad
+    real, intent(in)  :: c_ad
+    real :: dc_da
+    real :: dc_db
+    dc_da = 1.0
+    dc_db = 1.0
+    a_ad = c_ad * dc_da
+    b_ad = c_ad * dc_db
+  end subroutine add_numbers_ad
+
+  subroutine multiply_numbers_ad(a, a_ad, b, b_ad, result_ad)
+    real, intent(in)  :: a
+    real, intent(out) :: a_ad
+    real, intent(in)  :: b
+    real, intent(out) :: b_ad
+    real, intent(in)  :: result_ad
+    real :: dresult_da
+    real :: dresult_db
+    dresult_da = b
+    dresult_db = a
+    a_ad = result_ad * dresult_da
+    b_ad = result_ad * dresult_db
+  end subroutine multiply_numbers_ad
+end module simple_math_ad

--- a/fautodiff/__init__.py
+++ b/fautodiff/__init__.py
@@ -1,0 +1,6 @@
+"""Public API for fautodiff."""
+
+from . import parser
+from .generator import generate_ad
+
+__all__ = ["parser", "generate_ad"]

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -1,0 +1,144 @@
+from pathlib import Path
+
+from . import parser
+from .parser import Fortran2003, walk
+
+
+def _decl_names(stmt):
+    """Return variable names from a ``Type_Declaration_Stmt``."""
+    return [str(ed.items[0]) for ed in stmt.items[2].items]
+
+
+def _parse_decls(spec):
+    """Return a mapping of variable name to (type, intent) from declarations."""
+    decl_map = {}
+    for decl in spec.content:
+        type_str = decl.items[0].tofortran().lower()
+        text = decl.tofortran().upper()
+        if "INTENT(INOUT)" in text:
+            intent = "inout"
+        elif "INTENT(OUT)" in text:
+            intent = "out"
+        elif "INTENT(IN)" in text:
+            intent = "in"
+        else:
+            intent = None
+        for name in _decl_names(decl):
+            decl_map[name] = (type_str, intent)
+    return decl_map
+
+
+def _assign_ad_lines(stmt, indent):
+    """Generate reverse-mode derivative lines for a simple assignment."""
+    lhs = str(stmt.items[0])
+    rhs_str = stmt.items[2].tofortran().strip()
+
+    if "+" in rhs_str:
+        left, right = [s.strip() for s in rhs_str.split("+")]
+        parts = {left: "1.0", right: "1.0"}
+    elif "*" in rhs_str:
+        left, right = [s.strip() for s in rhs_str.split("*")]
+        parts = {left: right, right: left}
+    else:
+        return []
+
+    lines = []
+    for var in parts:
+        lines.append(f"{indent}real :: d{lhs}_d{var}\n")
+    for var, expr in parts.items():
+        lines.append(f"{indent}d{lhs}_d{var} = {expr}\n")
+    for var in parts:
+        lines.append(f"{indent}{var}_ad = {lhs}_ad * d{lhs}_d{var}\n")
+    return lines
+
+
+def _generate_ad_subroutine(routine, indent):
+    lines = []
+
+    if isinstance(routine, Fortran2003.Function_Subprogram):
+        stmt = routine.content[0]
+        name = str(stmt.get_name())
+        args = [str(a) for a in (stmt.items[2].items if stmt.items[2] else [])]
+        result = str(stmt.items[3].items[0])
+    else:
+        stmt = routine.content[0]
+        name = str(stmt.get_name())
+        args = [str(a) for a in (stmt.items[2].items if stmt.items[2] else [])]
+        result = None
+
+    spec = routine.content[1]
+    decl_map = _parse_decls(spec)
+
+    ad_args = []
+    outputs = []
+    if result is not None:
+        outputs.append(result)
+    for arg in args:
+        typ_int = decl_map.get(arg, (None, None))[1]
+        if typ_int == "out":
+            outputs.append(arg)
+            ad_args.append(f"{arg}_ad")
+        else:
+            ad_args.extend([arg, f"{arg}_ad"])
+    for outv in outputs:
+        if outv not in args:
+            ad_args.append(f"{outv}_ad")
+
+    lines.append(f"{indent}subroutine {name}_ad({', '.join(ad_args)})\n")
+
+    def _space(intent):
+        return "  " if intent == "in" else " "
+
+    for arg in args:
+        typ, intent = decl_map.get(arg, ("real", "in"))
+        arg_int = intent or "in"
+        if arg_int == "out":
+            lines.append(f"{indent}  real, intent(in){_space('in')}:: {arg}_ad\n")
+        else:
+            if arg_int == "inout":
+                ad_int = "inout"
+            else:
+                ad_int = "out"
+            lines.append(f"{indent}  {typ}, intent({arg_int}){_space(arg_int)}:: {arg}\n")
+            lines.append(f"{indent}  real, intent({ad_int}){_space(ad_int)}:: {arg}_ad\n")
+
+    for outv in outputs:
+        if outv not in args:
+            lines.append(f"{indent}  real, intent(in){_space('in')}:: {outv}_ad\n")
+
+    exec_part = routine.content[2]
+    for stmt in exec_part.content:
+        if isinstance(stmt, Fortran2003.Assignment_Stmt):
+            lines.extend(_assign_ad_lines(stmt, indent + "  "))
+
+    lines.append(f"{indent}end subroutine {name}_ad\n")
+    return lines
+
+
+def generate_ad(in_file, out_file):
+    """Generate a very small reverse-mode AD version of ``in_file``."""
+    ast = parser.parse_file(in_file)
+    output = []
+    for module in walk(ast, Fortran2003.Module):
+        name = str(module.content[0].get_name())
+        output.append(f"module {name}_ad\n")
+        output.append("contains\n")
+        children = [c for c in module.content[1].content if isinstance(c, (Fortran2003.Function_Subprogram, Fortran2003.Subroutine_Subprogram))]
+        for i, child in enumerate(children):
+            output.extend(_generate_ad_subroutine(child, "  "))
+            if i != len(children) - 1:
+                output.append("\n")
+        output.append(f"end module {name}_ad\n")
+
+    Path(out_file).write_text("".join(output))
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser_arg = argparse.ArgumentParser(description="Generate simple reverse-mode AD code")
+    parser_arg.add_argument("input", help="path to original Fortran file")
+    parser_arg.add_argument("output", help="path for generated Fortran file")
+    args = parser_arg.parse_args()
+
+    generate_ad(args.input, args.output)

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -10,7 +10,7 @@ def _decl_names(stmt):
 
 
 def _parse_decls(spec):
-    """Return a mapping of variable name to (type, intent) from declarations."""
+    """Map variable names to their declared type and intent."""
     decl_map = {}
     for decl in spec.content:
         type_str = decl.items[0].tofortran().lower()
@@ -93,18 +93,28 @@ def _generate_ad_subroutine(routine, indent):
         typ, intent = decl_map.get(arg, ("real", "in"))
         arg_int = intent or "in"
         if arg_int == "out":
-            lines.append(f"{indent}  real, intent(in){_space('in')}:: {arg}_ad\n")
+            lines.append(
+                f"{indent}  real, intent(in){_space('in')}:: {arg}_ad\n"
+            )
         else:
             if arg_int == "inout":
                 ad_int = "inout"
             else:
                 ad_int = "out"
-            lines.append(f"{indent}  {typ}, intent({arg_int}){_space(arg_int)}:: {arg}\n")
-            lines.append(f"{indent}  real, intent({ad_int}){_space(ad_int)}:: {arg}_ad\n")
+            lines.append(
+                f"{indent}  {typ}, intent({arg_int})"
+                f"{_space(arg_int)}:: {arg}\n"
+            )
+            lines.append(
+                f"{indent}  real, intent({ad_int})"
+                f"{_space(ad_int)}:: {arg}_ad\n"
+            )
 
     for outv in outputs:
         if outv not in args:
-            lines.append(f"{indent}  real, intent(in){_space('in')}:: {outv}_ad\n")
+            lines.append(
+                f"{indent}  real, intent(in){_space('in')}:: {outv}_ad\n"
+            )
 
     exec_part = routine.content[2]
     for stmt in exec_part.content:
@@ -123,7 +133,17 @@ def generate_ad(in_file, out_file):
         name = str(module.content[0].get_name())
         output.append(f"module {name}_ad\n")
         output.append("contains\n")
-        children = [c for c in module.content[1].content if isinstance(c, (Fortran2003.Function_Subprogram, Fortran2003.Subroutine_Subprogram))]
+        children = [
+            c
+            for c in module.content[1].content
+            if isinstance(
+                c,
+                (
+                    Fortran2003.Function_Subprogram,
+                    Fortran2003.Subroutine_Subprogram,
+                ),
+            )
+        ]
         for i, child in enumerate(children):
             output.extend(_generate_ad_subroutine(child, "  "))
             if i != len(children) - 1:
@@ -136,7 +156,9 @@ def generate_ad(in_file, out_file):
 if __name__ == "__main__":
     import argparse
 
-    parser_arg = argparse.ArgumentParser(description="Generate simple reverse-mode AD code")
+    parser_arg = argparse.ArgumentParser(
+        description="Generate simple reverse-mode AD code"
+    )
     parser_arg.add_argument("input", help="path to original Fortran file")
     parser_arg.add_argument("output", help="path for generated Fortran file")
     args = parser_arg.parse_args()

--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -5,6 +5,11 @@ from fparser.two.parser import ParserFactory
 from fparser.two import Fortran2003
 from fparser.two.utils import walk
 
+# Re-export commonly used classes and utilities so other modules do not need
+# to import ``fparser2`` directly.
+
+__all__ = ["parse_file", "find_subroutines", "Fortran2003", "walk"]
+
 
 def parse_file(path):
     """Parse a Fortran source file and return the ``fparser`` AST."""


### PR DESCRIPTION
## Summary
- rewrite AD generator to produce reverse-mode subroutines
- adjust README to mention reverse mode
- update example `simple_math_ad.f90`

## Testing
- `python -m py_compile fautodiff/generator.py fautodiff/__init__.py fautodiff/parser.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6848dc3f9224832db95cd7b862a13912