### PR TITLE
Update AGENTS to require English branch names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@ This file provides guidelines for contributors about the repository and develop 
 - Aim for one topic per commit and write clear messages.
 - When opening a PR, explain the changes and test steps.
 - Run the tests before pushing.
-- Messages such as commits and PRs, as well as branch names, should be in English.
+- Messages such as commits and PRs should be in English.
+- Branch names **must** be in English (ASCII only) to avoid issues with non-English characters.
 
 ## 5. Tests and Examples
 - Place the original Fortran code samples under “examples” and the test scripts under “tests.”


### PR DESCRIPTION
## Summary
- clarify that branch names must be in English only

## Testing
- `python -m fautodiff.generator examples/simple_math.f90 examples/simple_math_gen.f90`

------
https://chatgpt.com/codex/tasks/task_b_6848ebf8ccf0832da3626f28c156ecc0