### PR TITLE
Add stdout default and example tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,15 @@ This file provides guidelines for contributors about the repository and develop 
 - Aim for one topic per commit and write clear messages.
 - When opening a PR, explain the changes and test steps.
 - Run the tests before pushing.
+  Use ``python tests/test_generator.py`` to run the unit tests.
 - Messages such as commits and PRs should be in English.
 - Branch names **must** be in English (ASCII only) to avoid issues with non-English characters.
 
 ## 5. Tests and Examples
 - Place the original Fortran code samples under “examples” and the test scripts under “tests.”
+- The provided test script reads code from ``examples`` and checks the generated
+  AD output against the expected Fortran code.
+
+## 6. Generator Usage
+- By default ``fautodiff.generator`` prints the generated code to standard
+  output. Provide an output path if you want the code written to a file.

--- a/README.md
+++ b/README.md
@@ -40,5 +40,15 @@ routine names.
 Generate the AD code for ``examples/simple_math.f90``:
 
 ```bash
+# print to standard output
+python -m fautodiff.generator examples/simple_math.f90
+
+# or write to a file
 python -m fautodiff.generator examples/simple_math.f90 examples/simple_math_ad.f90
+```
+
+Run the included tests with:
+
+```bash
+python tests/test_generator.py
 ```

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -125,8 +125,12 @@ def _generate_ad_subroutine(routine, indent):
     return lines
 
 
-def generate_ad(in_file, out_file):
-    """Generate a very small reverse-mode AD version of ``in_file``."""
+def generate_ad(in_file, out_file=None):
+    """Generate a very small reverse-mode AD version of ``in_file``.
+
+    If ``out_file`` is ``None`` the generated code is returned as a string.
+    When ``out_file`` is provided the code is also written to that path.
+    """
     ast = parser.parse_file(in_file)
     output = []
     for module in walk(ast, Fortran2003.Module):
@@ -150,7 +154,10 @@ def generate_ad(in_file, out_file):
                 output.append("\n")
         output.append(f"end module {name}_ad\n")
 
-    Path(out_file).write_text("".join(output))
+    code = "".join(output)
+    if out_file:
+        Path(out_file).write_text(code)
+    return code
 
 
 if __name__ == "__main__":
@@ -160,7 +167,15 @@ if __name__ == "__main__":
         description="Generate simple reverse-mode AD code"
     )
     parser_arg.add_argument("input", help="path to original Fortran file")
-    parser_arg.add_argument("output", help="path for generated Fortran file")
+    parser_arg.add_argument(
+        "output",
+        nargs="?",
+        help=(
+            "path for generated Fortran file; if omitted, the code is printed"
+        ),
+    )
     args = parser_arg.parse_args()
 
-    generate_ad(args.input, args.output)
+    code = generate_ad(args.input, args.output)
+    if args.output is None:
+        print(code, end="")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fautodiff import generator
+
+class TestGenerator(unittest.TestCase):
+    def test_simple_math(self):
+        examples = Path('examples')
+        generated = generator.generate_ad(str(examples / 'simple_math.f90'))
+        expected = (examples / 'simple_math_ad.f90').read_text()
+        self.assertEqual(generated, expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow generator to output to stdout when no output path is provided
- update README with usage instructions and how to run tests
- document testing and generator usage in AGENTS
- add unit test that compares generated AD code against example

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_6848f7bea17c832da529cff5ccc661d8