### PR TITLE
Support old fparser name APIs

### DIFF
--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -57,12 +57,12 @@ def _generate_ad_subroutine(routine, indent):
 
     if isinstance(routine, Fortran2003.Function_Subprogram):
         stmt = routine.content[0]
-        name = str(stmt.get_name())
+        name = parser._stmt_name(stmt)
         args = [str(a) for a in (stmt.items[2].items if stmt.items[2] else [])]
         result = str(stmt.items[3].items[0])
     else:
         stmt = routine.content[0]
-        name = str(stmt.get_name())
+        name = parser._stmt_name(stmt)
         args = [str(a) for a in (stmt.items[2].items if stmt.items[2] else [])]
         result = None
 
@@ -134,7 +134,7 @@ def generate_ad(in_file, out_file=None):
     ast = parser.parse_file(in_file)
     output = []
     for module in walk(ast, Fortran2003.Module):
-        name = str(module.content[0].get_name())
+        name = parser._stmt_name(module.content[0])
         output.append(f"module {name}_ad\n")
         output.append("contains\n")
         children = [

--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -5,6 +5,22 @@ from fparser.two.parser import ParserFactory
 from fparser.two import Fortran2003
 from fparser.two.utils import walk
 
+
+def _stmt_name(stmt):
+    """Return the name from a program unit statement.
+
+    This helper works with both new and old versions of ``fparser`` by
+    falling back to simple string parsing when ``get_name`` is not
+    available.
+    """
+    if hasattr(stmt, "get_name"):
+        return str(stmt.get_name())
+    text = stmt.tofortran().strip()
+    parts = text.split()
+    if len(parts) >= 2:
+        return parts[1].split("(")[0]
+    raise AttributeError("Could not determine statement name")
+
 # Re-export commonly used classes and utilities so other modules do not need
 # to import ``fparser2`` directly.
 
@@ -23,5 +39,5 @@ def find_subroutines(ast):
     names = []
     for node in walk(ast, Fortran2003.Subroutine_Subprogram):
         stmt = node.children[0]  # Subroutine_Stmt
-        names.append(str(stmt.get_name()))
+        names.append(_stmt_name(stmt))
     return names


### PR DESCRIPTION
## Summary
- provide a helper to obtain the name of a module/subroutine/function
- use this helper in generator and parser so older fparser versions work

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_6848fab23abc832daf6c135495364343