### PR TITLE
Update AD generator for new example

### DIFF
--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -12,7 +12,11 @@ def _decl_names(stmt):
 def _parse_decls(spec):
     """Map variable names to their declared type and intent."""
     decl_map = {}
+    if spec is None:
+        return decl_map
     for decl in spec.content:
+        if not isinstance(decl, Fortran2003.Type_Declaration_Stmt):
+            continue
         type_str = decl.items[0].tofortran().lower()
         text = decl.tofortran().upper()
         if "INTENT(INOUT)" in text:
@@ -28,28 +32,52 @@ def _parse_decls(spec):
     return decl_map
 
 
-def _assign_ad_lines(stmt, indent):
-    """Generate reverse-mode derivative lines for a simple assignment."""
+def _routine_parts(routine):
+    """Return the specification and execution parts of a routine."""
+    spec = None
+    exec_part = None
+    for part in routine.content:
+        if isinstance(part, Fortran2003.Specification_Part):
+            spec = part
+        elif isinstance(part, Fortran2003.Execution_Part):
+            exec_part = part
+    return spec, exec_part
+
+
+def _assignment_parts(stmt):
+    """Return mapping of variables to partial derivative expressions."""
     lhs = str(stmt.items[0])
     rhs_str = stmt.items[2].tofortran().strip()
 
-    if "+" in rhs_str:
-        left, right = [s.strip() for s in rhs_str.split("+")]
-        parts = {left: "1.0", right: "1.0"}
-    elif "*" in rhs_str:
-        left, right = [s.strip() for s in rhs_str.split("*")]
-        parts = {left: right, right: left}
-    else:
-        return []
+    def _is_number(text):
+        try:
+            float(text)
+            return True
+        except ValueError:
+            return False
 
-    lines = []
-    for var in parts:
-        lines.append(f"{indent}real :: d{lhs}_d{var}\n")
-    for var, expr in parts.items():
-        lines.append(f"{indent}d{lhs}_d{var} = {expr}\n")
-    for var in parts:
-        lines.append(f"{indent}{var}_ad = {lhs}_ad * d{lhs}_d{var}\n")
-    return lines
+    parts = {}
+
+    if "+" in rhs_str:
+        add_terms = [t.strip() for t in rhs_str.split("+")]
+        for term in add_terms:
+            if "*" in term:
+                mul_left, mul_right = [s.strip() for s in term.split("*")]
+                if _is_number(mul_left) and not _is_number(mul_right):
+                    parts[mul_right] = mul_left
+                elif _is_number(mul_right) and not _is_number(mul_left):
+                    parts[mul_left] = mul_right
+            elif not _is_number(term):
+                parts[term] = "1.0"
+    elif "*" in rhs_str:
+        mul_left, mul_right = [s.strip() for s in rhs_str.split("*")]
+        if not _is_number(mul_left):
+            parts[mul_left] = mul_right
+        if not _is_number(mul_right):
+            parts[mul_right] = mul_left
+    else:
+        return {}
+    return parts
 
 
 def _generate_ad_subroutine(routine, indent):
@@ -66,7 +94,7 @@ def _generate_ad_subroutine(routine, indent):
         args = [str(a) for a in (stmt.items[2].items if stmt.items[2] else [])]
         result = None
 
-    spec = routine.content[1]
+    spec, exec_part = _routine_parts(routine)
     decl_map = _parse_decls(spec)
 
     ad_args = []
@@ -116,10 +144,61 @@ def _generate_ad_subroutine(routine, indent):
                 f"{indent}  real, intent(in){_space('in')}:: {outv}_ad\n"
             )
 
-    exec_part = routine.content[2]
-    for stmt in exec_part.content:
-        if isinstance(stmt, Fortran2003.Assignment_Stmt):
-            lines.extend(_assign_ad_lines(stmt, indent + "  "))
+    statements = [
+        s for s in exec_part.content if isinstance(s, Fortran2003.Assignment_Stmt)
+    ]
+    defined = set()
+    grad_var = {v: f"{v}_ad" for v in outputs}
+    decls = []
+    decl_set = set()
+    assign_lines = []
+
+    for stmt in reversed(statements):
+        lhs = str(stmt.items[0])
+        parts = _assignment_parts(stmt)
+        for var in parts:
+            name_d = f"d{lhs}_d{var}"
+            if name_d not in decl_set:
+                decls.append(name_d)
+                decl_set.add(name_d)
+            if var not in args and var not in outputs:
+                name_ad = f"{var}_ad"
+                if name_ad not in decl_set:
+                    decls.append(name_ad)
+                    decl_set.add(name_ad)
+        if lhs in parts:
+            name_ad = f"{lhs}_ad_"
+            if name_ad not in decl_set:
+                decls.append(name_ad)
+                decl_set.add(name_ad)
+
+        block = []
+        for var, expr in parts.items():
+            block.append(f"{indent}  d{lhs}_d{var} = {expr}\n")
+        lhs_grad = grad_var.get(lhs, f"{lhs}_ad")
+        for var in reversed(list(parts.keys())):
+            if var == lhs:
+                continue
+            update = f"{lhs_grad} * d{lhs}_d{var}"
+            if var in defined:
+                block.append(f"{indent}  {var}_ad = {update} + {var}_ad\n")
+            else:
+                block.append(f"{indent}  {var}_ad = {update}\n")
+                defined.add(var)
+        if lhs in parts:
+            new_grad = f"{lhs}_ad_"
+            block.append(f"{indent}  {new_grad} = {lhs_grad} * d{lhs}_d{lhs}\n")
+            grad_var[lhs] = new_grad
+        assign_lines.append(block)
+
+    for dname in decls:
+        lines.append(f"{indent}  real :: {dname}\n")
+    lines.append("\n")
+    for block in assign_lines:
+        for l in block:
+            lines.append(l)
+    lines.append("\n")
+    lines.append(f"{indent}  return\n")
 
     lines.append(f"{indent}end subroutine {name}_ad\n")
     return lines
@@ -136,22 +215,26 @@ def generate_ad(in_file, out_file=None):
     for module in walk(ast, Fortran2003.Module):
         name = parser._stmt_name(module.content[0])
         output.append(f"module {name}_ad\n")
-        output.append("contains\n")
-        children = [
-            c
-            for c in module.content[1].content
-            if isinstance(
-                c,
-                (
-                    Fortran2003.Function_Subprogram,
-                    Fortran2003.Subroutine_Subprogram,
-                ),
-            )
-        ]
-        for i, child in enumerate(children):
+        output.append("  implicit none\n\n")
+        output.append("contains\n\n")
+        children = []
+        for part in module.content:
+            if isinstance(part, Fortran2003.Module_Subprogram_Part):
+                children = [
+                    c
+                    for c in part.content
+                    if isinstance(
+                        c,
+                        (
+                            Fortran2003.Function_Subprogram,
+                            Fortran2003.Subroutine_Subprogram,
+                        ),
+                    )
+                ]
+                break
+        for child in children:
             output.extend(_generate_ad_subroutine(child, "  "))
-            if i != len(children) - 1:
-                output.append("\n")
+            output.append("\n")
         output.append(f"end module {name}_ad\n")
 
     code = "".join(output)


### PR DESCRIPTION
## Summary
- handle specification parts with implicit none
- improve assignment parser and reverse-mode derivative logic
- output module header with implicit none and proper formatting
- keep subroutine gradient variables in correct order

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_684901e99f64832d85176582197f2577