### PR TITLE
Add Fortran casting intrinsics

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ python -m fautodiff.generator examples/simple_math.f90
 # or write to a file
 python -m fautodiff.generator examples/simple_math.f90 examples/simple_math_ad.f90
 ```
+Additional examples illustrating Fortran intrinsic routines are available in ``examples/intrinsic_func.f90``.
 
 Run the included tests with:
 

--- a/examples/intrinsic_func.f90
+++ b/examples/intrinsic_func.f90
@@ -1,0 +1,56 @@
+module intrinsic_func
+  implicit none
+contains
+  subroutine math_intrinsics(x, y, z)
+    real, intent(in) :: x
+    real, intent(inout) :: y
+    real, intent(out) :: z
+    real :: pi
+    pi = acos(-1.0)
+    y = sqrt(abs(x)) + exp(y) + log(x) + log10(abs(y) + 1.0)
+    y = y + sin(x) + cos(y) + tan(x)
+    y = y + asin(x / pi) + acos(y / (pi + 1.0)) + atan(x)
+    y = y + atan2(x, y) + cosh(x) + sinh(y) + tanh(x)
+    y = y + sign(x, y) + max(x, y) + min(x, y)
+    z = mod(x, y) + epsilon(x) + huge(x) / tiny(x)
+    return
+  end subroutine math_intrinsics
+
+  subroutine non_math_intrinsics(str, arr, mat, idx, lb, ub)
+    character(len=*), intent(in) :: str
+    real, intent(in) :: arr(:)
+    real, allocatable, intent(out) :: mat(:,:)
+    integer, intent(out) :: idx, lb, ub
+    integer :: n, len_trimmed
+
+    len_trimmed = len_trim(adjustl(str))
+    idx = index(str, 'a')
+    lb = lbound(arr, 1)
+    ub = ubound(arr, 1)
+    n = size(arr)
+
+    allocate(mat(2, n))
+    mat(1, :) = arr
+    mat(2, :) = arr
+    mat = transpose(mat)
+    mat = cshift(mat, 1, 2)
+  end subroutine non_math_intrinsics
+
+  subroutine casting_intrinsics(i, r, d, c, n)
+    integer, intent(in) :: i
+    real, intent(in) :: r
+    double precision, intent(out) :: d
+    character(len=1), intent(inout) :: c
+    integer, intent(out) :: n
+    integer :: i2
+    real :: r2
+
+    i2 = int(r)
+    r2 = real(i)
+    d = dble(r) + dble(i2)
+    n = nint(r)
+    c = achar(ichar(c) + i2)
+    return
+  end subroutine casting_intrinsics
+end module intrinsic_func
+


### PR DESCRIPTION
## Summary
- extend `intrinsic_func.f90` with `casting_intrinsics` for type conversion intrinsics

## Testing
- `python tests/test_generator.py` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_b_68490fecc448832d8ee0ce465704c5ab