### PR TITLE
Add derivative warning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ python -m fautodiff.generator examples/simple_math.f90 examples/simple_math_ad.f
 ```
 Additional examples illustrating Fortran intrinsic routines are available in ``examples/intrinsic_func.f90``.
 
+By default the generator prints warnings when it encounters code it cannot
+differentiate.  Use ``--no-warn`` to silence these messages:
+
+```bash
+python -m fautodiff.generator --no-warn examples/simple_math.f90
+```
+
 Run the included tests with:
 
 ```bash

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -12,7 +12,7 @@ class TestGenerator(unittest.TestCase):
         for src in sorted(examples.glob('*.f90')):
             if src.name.endswith('_ad.f90'):
                 continue
-            generated = generator.generate_ad(str(src))
+            generated = generator.generate_ad(str(src), warn=False)
             expected = src.with_name(src.stem + '_ad.f90').read_text()
             self.assertEqual(generated, expected, msg=f"Mismatch for {src.name}")
 


### PR DESCRIPTION
## Summary
- warn when generator cannot differentiate an expression
- allow suppressing warnings via `--no-warn` option or `warn=False`
- document warning behaviour in README
- silence warnings during tests

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_684946ed2268832dafb4b0aacc216cd8