### PR TITLE
Handle extra intrinsic derivatives

### DIFF
--- a/examples/intrinsic_func_ad.f90
+++ b/examples/intrinsic_func_ad.f90
@@ -31,8 +31,18 @@ contains
     real :: p_ad
     real :: dz_dq
     real :: q_ad
+    real :: dq_dx
+    real :: dp_dx
+    real :: dp_dy
+    real :: do_dx
+    real :: do_dy
+    real :: dh_dx
+    real :: dh_dy
+    real :: dg_dx
     real :: df_dx
     real :: df_dy
+    real :: de_dx
+    real :: de_dy
     real :: dd_dx
     real :: dc_dx
     real :: dc_dy
@@ -62,10 +72,30 @@ contains
     c_ad = z_ad * dz_dc
     b_ad = z_ad * dz_db
     a_ad = z_ad * dz_da
-    df_dx = sinh(x) + 1.0 / cosh(x)**2
-    df_dy = cosh(y)
-    x_ad = f_ad * df_dx
-    y_ad = f_ad * df_dy
+    dq_dx = 1.0
+    x_ad = q_ad * dq_dx
+    dp_dx = 2.0 / sqrt(acos(-1.0)) * exp(-(x)**2)
+    dp_dy = -2.0 / sqrt(acos(-1.0)) * exp(-(y)**2)
+    y_ad = p_ad * dp_dy
+    x_ad = p_ad * dp_dx + x_ad
+    do_dx = merge(1.0, 0.0, x <= y)
+    do_dy = merge(0.0, 1.0, x <= y)
+    y_ad = o_ad * do_dy + y_ad
+    x_ad = o_ad * do_dx + x_ad
+    dh_dx = merge(1.0, 0.0, x >= y)
+    dh_dy = merge(0.0, 1.0, x >= y)
+    y_ad = h_ad * dh_dy + y_ad
+    x_ad = h_ad * dh_dx + x_ad
+    dg_dx = sign(1.0, x) * sign(1.0, y)
+    x_ad = g_ad * dg_dx + x_ad
+    df_dx = y / (x**2 + y**2) + sinh(x) + 1.0 / cosh(x)**2
+    df_dy = -x / (x**2 + y**2) + cosh(y)
+    x_ad = f_ad * df_dx + x_ad
+    y_ad = f_ad * df_dy + y_ad
+    de_dx = 1.0 / sqrt((x)**2 + 1.0) + 1.0 / (1.0 - (x)**2)
+    de_dy = 1.0 / sqrt(y - 1.0) / sqrt(y + 1.0)
+    x_ad = e_ad * de_dx + x_ad
+    y_ad = e_ad * de_dy + y_ad
     dd_dx = 1.0 / sqrt(1.0 - (x / pi)**2) * 1.0 / pi + 1.0 / (1.0 + (x)**2)
     x_ad = d_ad * dd_dx + x_ad
     dc_dx = cos(x) + 1.0 / cos(x)**2

--- a/fautodiff/intrinsic_derivatives.py
+++ b/fautodiff/intrinsic_derivatives.py
@@ -1,7 +1,10 @@
-"""Mapping of Fortran intrinsic functions to derivative expressions."""
+"""Mapping of Fortran intrinsic functions to derivative expressions.
 
-# Map intrinsic function name (lowercase) to a format string for its derivative.
-# The placeholder ``{arg}`` is replaced with the argument expression.
+Each entry maps the lowercase intrinsic name to either a single format string
+for unary functions or a tuple of strings for multi argument functions.  The
+placeholders ``{arg}``, ``{arg1}``, ``{arg2}``, ... are replaced with the
+corresponding argument expressions when forming the derivative.
+"""
 
 INTRINSIC_DERIVATIVES = {
     'abs': 'sign(1.0, {arg})',
@@ -21,4 +24,16 @@ INTRINSIC_DERIVATIVES = {
     'asinh': '1.0 / sqrt(({arg})**2 + 1.0)',
     'acosh': '1.0 / sqrt({arg} - 1.0) / sqrt({arg} + 1.0)',
     'atanh': '1.0 / (1.0 - ({arg})**2)',
+    'erf': '2.0 / sqrt(acos(-1.0)) * exp(-({arg})**2)',
+    'erfc': '-2.0 / sqrt(acos(-1.0)) * exp(-({arg})**2)',
+    # Two argument intrinsics map to a tuple of partial derivative expressions
+    # (d/darg1, d/darg2)
+    'mod': ('1.0', '0.0'),
+    'min': ('merge(1.0, 0.0, {arg1} <= {arg2})',
+            'merge(0.0, 1.0, {arg1} <= {arg2})'),
+    'max': ('merge(1.0, 0.0, {arg1} >= {arg2})',
+            'merge(0.0, 1.0, {arg1} >= {arg2})'),
+    'sign': ('sign(1.0, {arg1}) * sign(1.0, {arg2})', '0.0'),
+    'atan2': ('{arg2} / ({arg1}**2 + {arg2}**2)',
+              '-{arg1} / ({arg1}**2 + {arg2}**2)'),
 }


### PR DESCRIPTION
## Summary
- add support for derivatives of more intrinsics and for two-argument functions
- recognise intrinsics parsed as `Part_Ref`
- regenerate example AD output

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_68494a0e91c0832d9d4580228b14aa27