### PR TITLE
Fix derivative mapping and detection logic

### DIFF
--- a/examples/intrinsic_func_ad.f90
+++ b/examples/intrinsic_func_ad.f90
@@ -32,6 +32,7 @@ contains
     real :: dz_dq
     real :: q_ad
     real :: dq_dx
+    real :: dq_dy
     real :: dp_dx
     real :: dp_dy
     real :: do_dx
@@ -44,6 +45,9 @@ contains
     real :: de_dx
     real :: de_dy
     real :: dd_dx
+    real :: dd_dpi
+    real :: pi_ad
+    real :: dd_dy
     real :: dc_dx
     real :: dc_dy
     real :: db_dx
@@ -73,10 +77,12 @@ contains
     b_ad = z_ad * dz_db
     a_ad = z_ad * dz_da
     dq_dx = 1.0
+    dq_dy = -real(int(x / y), kind(x))
+    y_ad = q_ad * dq_dy
     x_ad = q_ad * dq_dx
     dp_dx = 2.0 / sqrt(acos(-1.0)) * exp(-(x)**2)
     dp_dy = -2.0 / sqrt(acos(-1.0)) * exp(-(y)**2)
-    y_ad = p_ad * dp_dy
+    y_ad = p_ad * dp_dy + y_ad
     x_ad = p_ad * dp_dx + x_ad
     do_dx = merge(1.0, 0.0, x <= y)
     do_dy = merge(0.0, 1.0, x <= y)
@@ -97,15 +103,19 @@ contains
     x_ad = e_ad * de_dx + x_ad
     y_ad = e_ad * de_dy + y_ad
     dd_dx = 1.0 / sqrt(1.0 - (x / pi)**2) * 1.0 / pi + 1.0 / (1.0 + (x)**2)
+    dd_dpi = 1.0 / sqrt(1.0 - (x / pi)**2) * - x / (pi)**2 + -1.0 / sqrt(1.0 - (y / (pi + 1.0))**2) * - y / (pi + 1.0)**2
+    dd_dy = -1.0 / sqrt(1.0 - (y / (pi + 1.0))**2) * 1.0 / (pi + 1.0)
     x_ad = d_ad * dd_dx + x_ad
+    pi_ad = d_ad * dd_dpi
+    y_ad = d_ad * dd_dy + y_ad
     dc_dx = cos(x) + 1.0 / cos(x)**2
     dc_dy = -sin(y)
     x_ad = c_ad * dc_dx + x_ad
     y_ad = c_ad * dc_dy + y_ad
-    db_dx = exp(x) + 1.0 / (ABS(x) + 1.0 * log(10.0)) * sign(1.0, x)
+    db_dx = exp(x) + 1.0 / ((ABS(x) + 1.0) * log(10.0)) * sign(1.0, x)
     db_dy = 1.0 / y
-    y_ad = b_ad * db_dy + y_ad
     x_ad = b_ad * db_dx + x_ad
+    y_ad = b_ad * db_dy + y_ad
     da_dx = 0.5 / sqrt(ABS(x)) * sign(1.0, x)
     x_ad = a_ad * da_dx + x_ad
 

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -59,7 +59,10 @@ def _collect_names(expr, names, unique=True):
         if name in INTRINSIC_DERIVATIVES:
             args = expr.items[1]
             for arg in getattr(args, "items", []):
-                subexpr = arg.items[1] if hasattr(arg, "items") and len(arg.items) > 1 else arg
+                if isinstance(arg, Fortran2003.Actual_Arg_Spec):
+                    subexpr = arg.items[1]
+                else:
+                    subexpr = arg
                 _collect_names(subexpr, names, unique=unique)
             return
     if isinstance(expr, Fortran2003.Name):

--- a/fautodiff/intrinsic_derivatives.py
+++ b/fautodiff/intrinsic_derivatives.py
@@ -11,7 +11,7 @@ INTRINSIC_DERIVATIVES = {
     'sqrt': '0.5 / sqrt({arg})',
     'exp': 'exp({arg})',
     'log': '1.0 / {arg}',
-    'log10': '1.0 / ({arg} * log(10.0))',
+    'log10': '1.0 / (({arg}) * log(10.0))',
     'sin': 'cos({arg})',
     'cos': '-sin({arg})',
     'tan': '1.0 / cos({arg})**2',
@@ -28,7 +28,7 @@ INTRINSIC_DERIVATIVES = {
     'erfc': '-2.0 / sqrt(acos(-1.0)) * exp(-({arg})**2)',
     # Two argument intrinsics map to a tuple of partial derivative expressions
     # (d/darg1, d/darg2)
-    'mod': ('1.0', '0.0'),
+    'mod': ('1.0', '-real(int({arg1} / {arg2}), kind({arg1}))'),
     'min': ('merge(1.0, 0.0, {arg1} <= {arg2})',
             'merge(0.0, 1.0, {arg1} <= {arg2})'),
     'max': ('merge(1.0, 0.0, {arg1} >= {arg2})',


### PR DESCRIPTION
## Summary
- handle Actual_Arg_Spec correctly when collecting variable names
- fix derivatives for `mod` and `log10`
- update expected AD output for intrinsic functions

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_68495051930c832d9fdf4beb6071902a