### PR TITLE
Handle non-differentiable intrinsics

### DIFF
--- a/examples/intrinsic_func.f90
+++ b/examples/intrinsic_func.f90
@@ -28,11 +28,9 @@ contains
     return
   end subroutine math_intrinsics
 
-  subroutine non_differentiable_intrinsics(str, arr, mat_in, mat_out, idx, lb, ub, x, y)
+  subroutine non_differentiable_intrinsics(str, arr, idx, lb, ub, x, y)
     character(len=*), intent(in) :: str
     real, intent(in) :: arr(:)
-    real, intent(in) :: mat_in(:,:)
-    real, intent(out) :: mat_out(:,:)
     integer, intent(out) :: idx, lb, ub
     real, intent(in) :: x
     real, intent(out) :: y

--- a/examples/intrinsic_func.f90
+++ b/examples/intrinsic_func.f90
@@ -47,9 +47,6 @@ contains
     ub = ubound(arr, 1)
     n = size(arr)
 
-    mat_out = transpose(mat_in)
-    mat_out = cshift(mat_out, 1, 2)
-
     a = epsilon(x)
     b = huge(x)
     c = tiny(x)
@@ -57,6 +54,16 @@ contains
 
     return
   end subroutine non_differentiable_intrinsics
+
+  subroutine special_intrinsics(mat_in, mat_out)
+    real, intent(in)  :: mat_in(:,:)
+    real, intent(out) :: mat_out(:,:)
+
+    mat_out = transpose(mat_in)
+    mat_out = cshift(mat_out, 1, 2)
+
+    return
+  end subroutine special_intrinsics
 
   subroutine casting_intrinsics(i, r, d, c, n)
     integer, intent(in) :: i

--- a/examples/intrinsic_func_ad.f90
+++ b/examples/intrinsic_func_ad.f90
@@ -121,13 +121,10 @@ contains
     return
   end subroutine math_intrinsics_ad
 
-  subroutine non_differentiable_intrinsics_ad(str, arr, arr_ad, mat_in, mat_in_ad, mat_out_ad, idx_ad, lb_ad, ub_ad, x, x_ad, y_ad)
+  subroutine non_differentiable_intrinsics_ad(str, arr, arr_ad, idx_ad, lb_ad, ub_ad, x, x_ad, y_ad)
     character(len = *), intent(in)  :: str
-    real, intent(in)  :: arr
-    real, intent(out) :: arr_ad
-    real, intent(in)  :: mat_in
-    real, intent(out) :: mat_in_ad
-    real, intent(in)  :: mat_out_ad
+    real, dimension(:), intent(in)  :: arr
+    real, dimension(:), intent(out) :: arr_ad
     real, intent(in)  :: idx_ad
     real, intent(in)  :: lb_ad
     real, intent(in)  :: ub_ad
@@ -152,10 +149,10 @@ contains
   end subroutine non_differentiable_intrinsics_ad
 
   subroutine special_intrinsics_ad(mat_in, mat_in_ad, mat_out_ad)
-    real, intent(in)  :: mat_in
-    real, intent(out) :: mat_in_ad
-    real, intent(in)  :: mat_out_ad
-    real :: mat_out_ad_
+    real, dimension(:, :), intent(in)  :: mat_in
+    real, dimension(:, :), intent(out) :: mat_in_ad
+    real, dimension(:, :), intent(in)  :: mat_out_ad
+    real, dimension(:, :) :: mat_out_ad_
 
     mat_out_ad_ = cshift(mat_out_ad, -1, 2)
     mat_in_ad = transpose(mat_out_ad_)

--- a/examples/intrinsic_func_ad.f90
+++ b/examples/intrinsic_func_ad.f90
@@ -151,6 +151,18 @@ contains
     return
   end subroutine non_differentiable_intrinsics_ad
 
+  subroutine special_intrinsics_ad(mat_in, mat_in_ad, mat_out_ad)
+    real, intent(in)  :: mat_in
+    real, intent(out) :: mat_in_ad
+    real, intent(in)  :: mat_out_ad
+    real :: mat_out_ad_
+
+    mat_out_ad_ = cshift(mat_out_ad, -1, 2)
+    mat_in_ad = transpose(mat_out_ad_)
+
+    return
+  end subroutine special_intrinsics_ad
+
   subroutine casting_intrinsics_ad(i, i_ad, r, r_ad, d_ad, c, n_ad)
     integer, intent(in)  :: i
     real, intent(out) :: i_ad

--- a/examples/intrinsic_func_ad.f90
+++ b/examples/intrinsic_func_ad.f90
@@ -152,7 +152,7 @@ contains
     real, dimension(:, :), intent(in)  :: mat_in
     real, dimension(:, :), intent(out) :: mat_in_ad
     real, dimension(:, :), intent(in)  :: mat_out_ad
-    real, dimension(:, :) :: mat_out_ad_
+    real, dimension(size(mat_out_ad, 1), size(mat_out_ad, 2)) :: mat_out_ad_
 
     mat_out_ad_ = cshift(mat_out_ad, -1, 2)
     mat_in_ad = transpose(mat_out_ad_)

--- a/fautodiff/intrinsic_derivatives.py
+++ b/fautodiff/intrinsic_derivatives.py
@@ -41,3 +41,22 @@ INTRINSIC_DERIVATIVES = {
     'atan2': ('{arg2} / ({arg1}**2 + {arg2}**2)',
               '-{arg1} / ({arg1}**2 + {arg2}**2)'),
 }
+
+# Intrinsic functions that are constant or otherwise not differentiable.
+# Derivatives of these functions are treated as zero and no warnings are
+# produced when they are encountered during AD code generation.  Derivatives for
+# ``transpose`` and ``cshift`` are implemented directly in the generator.
+NONDIFF_INTRINSICS = {
+    'len',
+    'len_trim',
+    'adjustl',
+    'index',
+    'lbound',
+    'ubound',
+    'size',
+    'epsilon',
+    'huge',
+    'tiny',
+    'ichar',
+    'achar',
+}


### PR DESCRIPTION
## Summary
- avoid warnings for intrinsics without derivatives
- list non-differentiable intrinsics
- move transpose and cshift handling into a new example subroutine
- declare intermediate gradient for cshift updates

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_684956e6865c832d90883ff16ea7a525