### PR TITLE
Fix undefined variable in AD code and add validation

### DIFF
--- a/examples/intrinsic_func_ad.f90
+++ b/examples/intrinsic_func_ad.f90
@@ -171,14 +171,11 @@ contains
     real :: dd_dr
     real :: dd_di2
     real :: i2_ad
-    real :: dr2_di
 
     dd_dr = 1.0
     dd_di2 = 1.0
     i2_ad = d_ad * dd_di2
     r_ad = d_ad * dd_dr
-    dr2_di = 1.0
-    i_ad = r2_ad * dr2_di
 
     return
   end subroutine casting_intrinsics_ad


### PR DESCRIPTION
## Summary
- skip gradient generation for assignments whose lhs is never used
- update expected AD output for `casting_intrinsics_ad`
- add check for undefined or uninitialised variables in generated code

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_68495fafb0b8832db6c38fcc41c37e5f