### PR TITLE
Add control flow examples

### DIFF
--- a/examples/control_flow.f90
+++ b/examples/control_flow.f90
@@ -1,0 +1,70 @@
+module control_flow
+  implicit none
+
+contains
+
+  subroutine if_example(x, y, z)
+    real, intent(in) :: x
+    real, intent(inout) :: y
+    real, intent(out) :: z
+
+    z = 0.0
+    if (x > 0.0) then
+      y = y + 1.0
+      z = x
+    else if (x < 0.0) then
+      y = y - 1.0
+      z = -x
+    else
+      z = 0.0
+    end if
+
+    return
+  end subroutine if_example
+
+  subroutine select_example(i, z)
+    integer, intent(in) :: i
+    real, intent(out) :: z
+
+    select case(i)
+    case(1)
+      z = 1.0
+    case(2)
+      z = 2.0
+    case default
+      z = 0.0
+    end select
+
+    return
+  end subroutine select_example
+
+  subroutine do_example(n, sum)
+    integer, intent(in) :: n
+    real, intent(out) :: sum
+    integer :: i
+
+    sum = 0.0
+    do i = 1, n
+      sum = sum + i
+    end do
+
+    return
+  end subroutine do_example
+
+  subroutine do_while_example(x, limit, count)
+    real, intent(in) :: x
+    real, intent(in) :: limit
+    integer, intent(out) :: count
+    real :: y
+
+    y = x
+    count = 0
+    do while (y < limit)
+      y = y * 2.0
+      count = count + 1
+    end do
+
+    return
+  end subroutine do_while_example
+
+end module control_flow

--- a/examples/control_flow_ad.f90
+++ b/examples/control_flow_ad.f90
@@ -1,0 +1,46 @@
+module control_flow_ad
+  implicit none
+
+contains
+
+  subroutine if_example_ad(x, x_ad, y, y_ad, z_ad)
+    real, intent(in)  :: x
+    real, intent(out) :: x_ad
+    real, intent(inout) :: y
+    real, intent(inout) :: y_ad
+    real, intent(in)  :: z_ad
+
+
+    return
+  end subroutine if_example_ad
+
+  subroutine select_example_ad(i, i_ad, z_ad)
+    integer, intent(in)  :: i
+    real, intent(out) :: i_ad
+    real, intent(in)  :: z_ad
+
+
+    return
+  end subroutine select_example_ad
+
+  subroutine do_example_ad(n, n_ad, sum_ad)
+    integer, intent(in)  :: n
+    real, intent(out) :: n_ad
+    real, intent(in)  :: sum_ad
+
+
+    return
+  end subroutine do_example_ad
+
+  subroutine do_while_example_ad(x, x_ad, limit, limit_ad, count_ad)
+    real, intent(in)  :: x
+    real, intent(out) :: x_ad
+    real, intent(in)  :: limit
+    real, intent(out) :: limit_ad
+    real, intent(in)  :: count_ad
+
+
+    return
+  end subroutine do_while_example_ad
+
+end module control_flow_ad


### PR DESCRIPTION
## Summary
- add Fortran sample exercising control flow statements
- include generated `_ad` version

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_684964a849ec832d9f0174350832bad9