### PR TITLE
Fix select_example_ad parameters

### DIFF
--- a/examples/control_flow_ad.f90
+++ b/examples/control_flow_ad.f90
@@ -25,16 +25,24 @@ contains
     return
   end subroutine if_example_ad
 
-  subroutine select_example_ad(i, i_ad, z_ad)
+  subroutine select_example_ad(i, i_ad, x, x_ad, z_ad)
     integer, intent(in)  :: i
     real, intent(out) :: i_ad
+    real, intent(in)  :: x
+    real, intent(out) :: x_ad
     real, intent(in)  :: z_ad
+    real :: dz_dx
 
     i_ad = 0.0
+    x_ad = 0.0
 
     SELECT CASE (i)
     CASE (1)
+      dz_dx = 1.0
+      x_ad = z_ad * dz_dx + x_ad
     CASE (2)
+      dz_dx = 1.0
+      x_ad = z_ad * dz_dx
     CASE DEFAULT
     END SELECT
 


### PR DESCRIPTION
## Summary
- update `select_example_ad` to match new example arguments

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_68498552bf7c832d9da3a3b9420c7075