### PR TITLE
Remove redundant AD initializations

### DIFF
--- a/examples/control_flow_ad.f90
+++ b/examples/control_flow_ad.f90
@@ -11,11 +11,10 @@ contains
     real, intent(in)  :: z_ad
     real :: dz_dx
 
-    x_ad = 0.0
 
     IF (x > 0.0) THEN
       dz_dx = 1.0
-      x_ad = z_ad * dz_dx + x_ad
+      x_ad = z_ad * dz_dx
     ELSE IF (x < 0.0) THEN
       dz_dx = - 1.0
       x_ad = z_ad * dz_dx
@@ -32,12 +31,11 @@ contains
     real, intent(in)  :: z_ad
     real :: dz_dx
 
-    x_ad = 0.0
 
     SELECT CASE (i)
     CASE (1)
       dz_dx = 1.0
-      x_ad = z_ad * dz_dx + x_ad
+      x_ad = z_ad * dz_dx
     CASE (2)
       dz_dx = 1.0
       x_ad = z_ad * dz_dx
@@ -50,13 +48,6 @@ contains
   subroutine do_example_ad(n, sum_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: sum_ad
-    real :: dsum_dsum
-    real :: sum_ad_
-
-    DO i = n, 1, -1
-      dsum_dsum = 1.0
-      sum_ad_ = sum_ad * dsum_dsum
-    END DO
 
     return
   end subroutine do_example_ad

--- a/examples/intrinsic_func_ad.f90
+++ b/examples/intrinsic_func_ad.f90
@@ -53,7 +53,6 @@ contains
     real :: db_dy
     real :: da_dx
 
-    x_ad = 0.0
 
     pi = ACOS(- 1.0)
 
@@ -156,7 +155,6 @@ contains
     real, dimension(:, :), intent(in)  :: mat_out_ad
     real, dimension(size(mat_out_ad, 1), size(mat_out_ad, 2)) :: mat_out_ad_
 
-    mat_in_ad = 0.0
 
     mat_out_ad_ = cshift(mat_out_ad, -1, 2)
     mat_in_ad = transpose(mat_out_ad_)
@@ -172,7 +170,6 @@ contains
     character(len = 1), intent(inout) :: c
     real :: dd_dr
 
-    r_ad = 0.0
 
     dd_dr = 1.0
     r_ad = d_ad * dd_dr

--- a/examples/simple_math_ad.f90
+++ b/examples/simple_math_ad.f90
@@ -17,8 +17,6 @@ contains
     real :: dwork_da
     real :: dwork_db
 
-    a_ad = 0.0
-    b_ad = 0.0
 
     dc_dc = 1.0
     dc_dwork = 1.0
@@ -45,8 +43,6 @@ contains
     real :: c_ad_
     real :: dc_da
 
-    a_ad = 0.0
-    b_ad = 0.0
 
     dc_dc = - 1.0
     dc_db = 1.0
@@ -71,8 +67,6 @@ contains
     real :: c_ad_
     real :: dc_db
 
-    a_ad = 0.0
-    b_ad = 0.0
 
     dc_dc = 3.0
     dc_da = 1.0
@@ -97,8 +91,6 @@ contains
     real :: c_ad_
     real :: dc_db
 
-    a_ad = 0.0
-    b_ad = 0.0
 
     dc_dc = 1.0 / 2.0
     dc_da = 1.0
@@ -123,8 +115,6 @@ contains
     real :: dc_db
     real :: c_ad_
 
-    a_ad = 0.0
-    b_ad = 0.0
 
     dc_dc = 1.0
     dc_da = b * a**(b - 1.0) + b * (4.0 * a + 2.0)**(b - 1.0) * 4.0 + (b * 5.0 + 3.0) * a**(b * 5.0 + 2.0)

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -323,6 +323,37 @@ def _assignment_parts(stmt, warn_info=None, warnings=None):
 def _generate_ad_subroutine(routine, indent, filename, warnings):
     lines = []
 
+    def _optimize_lines(raw_lines):
+        """Remove redundant initializations and unused assignments."""
+        result = list(raw_lines)
+        init_pat = re.compile(r"^\s*(\w+_ad)\s*=\s*0\.0\s*$")
+        i = 0
+        while i < len(result):
+            m = init_pat.match(result[i].strip())
+            if m:
+                var = m.group(1)
+                var_pat = re.compile(rf"\b{re.escape(var)}\b")
+                assign_pat = re.compile(rf"^\s*{re.escape(var)}\s*=")
+                j = i + 1
+                used = False
+                assign_idx = None
+                while j < len(result):
+                    if var_pat.search(result[j]):
+                        if assign_pat.match(result[j]):
+                            assign_idx = j
+                            break
+                        used = True
+                        break
+                    j += 1
+                if assign_idx is not None and not used:
+                    line = result[assign_idx]
+                    line = re.sub(rf"\s*\+\s*{re.escape(var)}\b", "", line)
+                    result[assign_idx] = line
+                    del result[i]
+                    continue
+            i += 1
+        return result
+
     if isinstance(routine, Fortran2003.Function_Subprogram):
         stmt = routine.content[0]
         name = parser._stmt_name(stmt)
@@ -424,6 +455,13 @@ def _generate_ad_subroutine(routine, indent, filename, warnings):
             lines.append(
                 f"{indent}  {out_typ}, intent(in){_space('in')}:: {outv}_ad\n"
             )
+
+    # If there are no input gradients to propagate we can exit early
+    if not out_grad_args:
+        lines.append("\n")
+        lines.append(f"{indent}  return\n")
+        lines.append(f"{indent}end subroutine {name}_ad\n")
+        return lines
 
     def _find_assignments(node, out_list, top=True):
         if isinstance(node, Fortran2003.Assignment_Stmt):
@@ -738,7 +776,7 @@ def _generate_ad_subroutine(routine, indent, filename, warnings):
     lines.append(f"{indent}  return\n")
 
     lines.append(f"{indent}end subroutine {name}_ad\n")
-    return lines
+    return _optimize_lines(lines)
 
 
 def generate_ad(in_file, out_file=None, warn=True):


### PR DESCRIPTION
## Summary
- skip generating statements when no input gradients are present
- remove unused initialisations in generated code via a post pass
- update expected AD examples accordingly

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_68498b0d6a68832d99c772ddf0083bc2