### PR TITLE
Improve loop derivative optimizations

### DIFF
--- a/examples/arrays_ad.f90
+++ b/examples/arrays_ad.f90
@@ -42,8 +42,6 @@ contains
     real :: dres_db
     real :: res_ad_
 
-    a_ad = 0.0
-    b_ad = 0.0
 
     res_ad_ = res_ad
 
@@ -51,8 +49,8 @@ contains
       dres_dres = 1.0
       dres_da = b(i)
       dres_db = a(i)
-      a_ad(i) = res_ad_ * dres_da + a_ad(i)
-      b_ad(i) = res_ad_ * dres_db + b_ad(i)
+      a_ad(i) = res_ad_ * dres_da
+      b_ad(i) = res_ad_ * dres_db
       res_ad_ = res_ad_ * dres_dres
     END DO
 

--- a/examples/intrinsic_func_ad.f90
+++ b/examples/intrinsic_func_ad.f90
@@ -80,7 +80,7 @@ contains
     a_ad = z_ad * dz_da
     dq_dx = 1.0
     dq_dy = -real(int(x / y), kind(x))
-    y_ad = q_ad * dq_dy
+    y_ad = q_ad * dq_dy + y_ad
     x_ad = q_ad * dq_dx
     dp_dx = 2.0 / sqrt(acos(-1.0)) * exp(-(x)**2)
     dp_dy = -2.0 / sqrt(acos(-1.0)) * exp(-(y)**2)


### PR DESCRIPTION
## Summary
- add per variable use count in generator
- optimize array updates in loops when each element is written once
- adjust initialization cleanup regex to handle array element assignments
- update expected Fortran outputs

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_684a2af58570832dbde196ee44d27151