### PR TITLE
Add fparser version requirement check

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ the ``fparser.two`` API).
 
 ## Installation
 
-The parser relies on the `fparser` package which can be installed via pip:
+The parser relies on the `fparser` package (version **0.2.0 or later**) which can be installed via pip:
 
 ```bash
-pip install fparser
+pip install "fparser>=0.2.0"
 ```
 
 ## Parsing Fortran

--- a/fautodiff/__init__.py
+++ b/fautodiff/__init__.py
@@ -1,5 +1,11 @@
 """Public API for fautodiff."""
 
+from packaging.version import Version, parse
+import fparser
+
+if parse(getattr(fparser, "__version__", "0")) < Version("0.2.0"):
+    raise RuntimeError("fautodiff requires fparser version 0.2.0 or later")
+
 from . import parser
 from .generator import generate_ad
 

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -2,6 +2,12 @@ from pathlib import Path
 import sys
 import re
 
+from packaging.version import Version, parse
+import fparser
+
+if parse(getattr(fparser, "__version__", "0")) < Version("0.2.0"):
+    raise RuntimeError("fautodiff requires fparser version 0.2.0 or later")
+
 from . import parser
 from .parser import Fortran2003, walk
 from fparser.two.Fortran2008 import Block_Nonlabel_Do_Construct


### PR DESCRIPTION
## Summary
- enforce `fparser` >= 0.2.0 during runtime
- document the `fparser` version requirement in the README

## Testing
- `python tests/test_generator.py` *(fails: Mismatch for arrays.f90)*

------
https://chatgpt.com/codex/tasks/task_b_684a3cd07610832db7cfc869406fd604