### PR TITLE
Refactor parser generator separation

### DIFF
--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -1,9 +1,20 @@
-"""Utility functions for parsing Fortran using ``fparser.two``."""
+"""Fortran parsing utilities based on ``fparser``.
+
+This module centralizes all direct interaction with :mod:`fparser` so that the
+rest of the package does not rely on the underlying parser implementation.
+"""
+
+from packaging.version import Version, parse
+import fparser
 
 from fparser.common.readfortran import FortranFileReader
 from fparser.two.parser import ParserFactory
 from fparser.two import Fortran2003
+from fparser.two.Fortran2008 import Block_Nonlabel_Do_Construct
 from fparser.two.utils import walk
+
+if parse(getattr(fparser, "__version__", "0")) < Version("0.2.0"):
+    raise RuntimeError("fautodiff requires fparser version 0.2.0 or later")
 
 
 def _stmt_name(stmt):
@@ -24,7 +35,15 @@ def _stmt_name(stmt):
 # Re-export commonly used classes and utilities so other modules do not need
 # to import ``fparser2`` directly.
 
-__all__ = ["parse_file", "find_subroutines", "Fortran2003", "walk"]
+__all__ = [
+    "parse_file",
+    "find_subroutines",
+    "Fortran2003",
+    "walk",
+    "Block_Nonlabel_Do_Construct",
+    "_parse_decls",
+    "_routine_parts",
+]
 
 
 def parse_file(path):
@@ -41,3 +60,57 @@ def find_subroutines(ast):
         stmt = node.children[0]  # Subroutine_Stmt
         names.append(_stmt_name(stmt))
     return names
+
+
+def _parse_decls(spec):
+    """Return mapping of variable names to ``(type, intent)``."""
+    decl_map = {}
+    if spec is None:
+        return decl_map
+    for decl in spec.content:
+        if not isinstance(decl, Fortran2003.Type_Declaration_Stmt):
+            continue
+        base_type = decl.items[0].tofortran().lower()
+        text = decl.tofortran().upper()
+        if "INTENT(INOUT)" in text:
+            intent = "inout"
+        elif "INTENT(OUT)" in text:
+            intent = "out"
+        elif "INTENT(IN)" in text:
+            intent = "in"
+        else:
+            intent = None
+
+        dim_attr = None
+        attrs = decl.items[1]
+        if attrs is not None:
+            for attr in attrs.items:
+                if hasattr(attr, "items") and str(attr.items[0]).upper() == "DIMENSION":
+                    dim_attr = attr.items[1].tofortran()
+                    break
+
+        for entity in decl.items[2].items:
+            name = str(entity.items[0])
+            arrspec = entity.items[1]
+            type_str = base_type
+            dims = None
+            if arrspec is not None:
+                dims = arrspec.tofortran()
+            elif dim_attr is not None:
+                dims = dim_attr
+            if dims is not None:
+                type_str = f"{type_str}, dimension({dims})"
+            decl_map[name] = (type_str, intent)
+    return decl_map
+
+
+def _routine_parts(routine):
+    """Return the specification and execution parts of a routine node."""
+    spec = None
+    exec_part = None
+    for part in routine.content:
+        if isinstance(part, Fortran2003.Specification_Part):
+            spec = part
+        elif isinstance(part, Fortran2003.Execution_Part):
+            exec_part = part
+    return spec, exec_part

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -10,7 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from fautodiff import generator
 from fautodiff import parser
-from fautodiff.generator import _collect_names, _parse_decls, _routine_parts
+from fautodiff.generator import _collect_names
 
 
 def _validate_no_undefined(code):
@@ -19,8 +19,8 @@ def _validate_no_undefined(code):
     ast = p(reader)
     errors = []
     for sub in parser.walk(ast, Fortran2003.Subroutine_Subprogram):
-        spec, exec_part = _routine_parts(sub)
-        decl_map = _parse_decls(spec)
+        spec, exec_part = parser._routine_parts(sub)
+        decl_map = parser._parse_decls(spec)
         declared = set(decl_map.keys())
         intents = {n: i for n, (_, i) in decl_map.items()}
         assigned = set()
@@ -51,8 +51,8 @@ def _check_inits(code):
     ast = p(reader)
     violations = []
     for sub in parser.walk(ast, Fortran2003.Subroutine_Subprogram):
-        spec, exec_part = _routine_parts(sub)
-        decl_map = _parse_decls(spec)
+        spec, exec_part = parser._routine_parts(sub)
+        decl_map = parser._parse_decls(spec)
         intents = {n: i for n, (_, i) in decl_map.items()}
         inits = set()
         for stmt in getattr(exec_part, "content", []):


### PR DESCRIPTION
## Summary
- move declaration parsing utilities into parser module
- centralize fparser imports in parser
- update generator to use parser helpers
- adjust tests to import functions from parser

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_684a55dbaadc832d99b767107d2e6ead