### PR TITLE
Insert forward block before reverse pass

### DIFF
--- a/examples/arrays_ad.f90
+++ b/examples/arrays_ad.f90
@@ -10,9 +10,12 @@ contains
     real, intent(in)  :: b(n)
     real, intent(out) :: b_ad(n)
     real, intent(in)  :: c_ad(n)
+    real :: c(n)
     real :: dc_da(n)
     real :: dc_db(n)
 
+
+    c = a + b
 
     dc_da(:) = 1.0
     dc_db(:) = 1.0
@@ -42,11 +45,18 @@ contains
     real, intent(in)  :: d_ad(n, m)
     integer :: i
     integer :: j
+    real :: d(n, m)
     real :: dd_da_i__j
     real :: dd_db_i__j
     real :: dd_dc
 
     c_ad = 0.0
+
+    DO j = 1, m
+      DO i = 1, n
+        d(i, j) = a(i, j) + b(i, j) * c
+      END DO
+    END DO
 
     DO j = m, 1, -1
       DO i = n, 1, -1
@@ -70,11 +80,17 @@ contains
     real, intent(out) :: b_ad(n)
     real, intent(in)  :: res_ad
     integer :: i
+    real :: res
     real :: res_ad_
     real :: dres_dres
     real :: dres_da_i
     real :: dres_db_i
 
+
+    res = 0.0
+    DO i = 1, n
+      res = res + a(i) * b(i)
+    END DO
 
     res_ad_ = res_ad
 
@@ -98,10 +114,17 @@ contains
     real, intent(in)  :: c_ad(n)
     integer, intent(in)  :: idx(n)
     integer :: i
+    real :: b(n)
+    real :: c(n)
     real :: dc_da_idx_i_
     real :: db_da_idx_i_
 
     a_ad(:) = 0.0
+
+    DO i = 1, n
+      b(i) = a(idx(i)) + 1.0
+      c(idx(i)) = a(idx(i)) ** 2
+    END DO
 
     DO i = n, 1, -1
       dc_da_idx_i_ = 2 * a(idx(i))
@@ -119,11 +142,25 @@ contains
     real, intent(out) :: a_ad(n)
     real, intent(in)  :: b_ad(n)
     integer :: i
+    real :: b(n)
+    integer :: in
+    integer :: ip
     real :: db_da_in
     real :: db_da_i
     real :: db_da_ip
 
     a_ad(:) = 0.0
+
+    DO i = 1, n
+      in = i - 1
+      ip = i + 1
+      IF (i == 1) THEN
+        in = n
+      ELSE IF (i == n) THEN
+        ip = 1
+      END IF
+      b(i) = (a(in) + 2.0 * a(i) + a(ip)) / 4.0
+    END DO
 
     DO i = n, 1, -1
       db_da_in = 1.0 / 4.0

--- a/examples/control_flow_ad.f90
+++ b/examples/control_flow_ad.f90
@@ -9,8 +9,17 @@ contains
     real, intent(inout) :: y
     real, intent(inout) :: y_ad
     real, intent(in)  :: z_ad
+    real :: z
     real :: dz_dx
 
+
+    IF (x > 0.0) THEN
+      z = x
+    ELSE IF (x < 0.0) THEN
+      z = - x
+    ELSE
+      z = 0.0
+    END IF
 
     IF (x > 0.0) THEN
       dz_dx = 1.0
@@ -29,8 +38,18 @@ contains
     real, intent(in)  :: x
     real, intent(out) :: x_ad
     real, intent(in)  :: z_ad
+    real :: z
     real :: dz_dx
 
+
+    SELECT CASE (i)
+    CASE (1)
+      z = x + 1.0
+    CASE (2)
+      z = x - 1.0
+    CASE DEFAULT
+      z = 0.0
+    END SELECT
 
     SELECT CASE (i)
     CASE (1)
@@ -51,11 +70,17 @@ contains
     real, intent(out) :: x_ad
     real, intent(in)  :: sum_ad
     integer :: i
+    real :: sum
     real :: sum_ad_
     real :: dsum_dsum
     real :: dsum_dx
 
     x_ad = 0.0
+
+    sum = 0.0
+    DO i = 1, n
+      sum = sum + i * x
+    END DO
 
     sum_ad_ = sum_ad
 

--- a/examples/intrinsic_func_ad.f90
+++ b/examples/intrinsic_func_ad.f90
@@ -10,6 +10,19 @@ contains
     real, intent(inout) :: y_ad
     real, intent(in)  :: z_ad
     real :: pi
+    real :: z
+    real :: pi
+    real :: a
+    real :: b
+    real :: c
+    real :: d
+    real :: e
+    real :: f
+    real :: g
+    real :: h
+    real :: o
+    real :: p
+    real :: q
     real :: dz_da
     real :: a_ad
     real :: dz_db
@@ -53,6 +66,20 @@ contains
     real :: db_dy
     real :: da_dx
 
+
+    pi = ACOS(- 1.0)
+    a = SQRT(ABS(x))
+    b = EXP(x) + LOG(y) + LOG10(ABS(x) + 1.0)
+    c = SIN(x) + COS(y) + TAN(x)
+    d = ASIN(x / pi) + ACOS(y / (pi + 1.0)) + ATAN(x)
+    e = asinh(x) + acosh(y) + atanh(x)
+    f = ATAN2(x, y) + COSH(x) + SINH(y) + TANH(x)
+    g = SIGN(x, y)
+    h = MAX(x, y)
+    o = MIN(x, y)
+    p = erf(x) + erfc(y)
+    q = MOD(x, y)
+    z = a + b + c + d + e + f + g + h + o + p + q
 
     pi = ACOS(- 1.0)
 
@@ -129,6 +156,15 @@ contains
     real, intent(in)  :: x
     real, intent(out) :: x_ad
     real, intent(in)  :: y_ad
+    integer :: idx
+    integer :: lb
+    integer :: ub
+    real :: y
+    integer :: n
+    integer :: len_trimmed
+    real :: a
+    real :: b
+    real :: c
     real :: dy_da
     real :: a_ad
     real :: dy_db
@@ -138,6 +174,11 @@ contains
 
     arr_ad(:) = 0.0
     x_ad = 0.0
+
+    a = EPSILON(x)
+    b = HUGE(x)
+    c = TINY(x)
+    y = a + b + c
 
     dy_da = 1.0
     dy_db = 1.0
@@ -153,8 +194,12 @@ contains
     real, intent(in)  :: mat_in(:, :)
     real, intent(out) :: mat_in_ad(:, :)
     real, intent(in)  :: mat_out_ad(:, :)
+    real :: mat_out(:, :)
     real :: mat_out_ad_(size(mat_out_ad, 1), size(mat_out_ad, 2))
 
+
+    mat_out = TRANSPOSE(mat_in)
+    mat_out = CSHIFT(mat_out, 1, 2)
 
     mat_out_ad_ = cshift(mat_out_ad, -1, 2)
     mat_in_ad = transpose(mat_out_ad_)
@@ -168,8 +213,15 @@ contains
     real, intent(out) :: r_ad
     real, intent(in)  :: d_ad
     character(len = 1), intent(inout) :: c
+    double precision :: d
+    integer :: n
+    integer :: i2
+    real :: r2
     real :: dd_dr
 
+
+    i2 = INT(r)
+    d = DBLE(r) + DBLE(i2)
 
     dd_dr = 1.0
     r_ad = d_ad * dd_dr

--- a/examples/simple_math_ad.f90
+++ b/examples/simple_math_ad.f90
@@ -9,6 +9,8 @@ contains
     real, intent(in)  :: b
     real, intent(out) :: b_ad
     real, intent(in)  :: c_ad
+    real :: c
+    real :: work
     real :: dc_dc
     real :: dc_dwork
     real :: work_ad
@@ -17,6 +19,10 @@ contains
     real :: dwork_da
     real :: dwork_db
 
+
+    work = a + b
+    c = a + 1.0
+    c = c + 2.0 + work
 
     dc_dc = 1.0
     dc_dwork = 1.0
@@ -38,11 +44,15 @@ contains
     real, intent(in)  :: b
     real, intent(out) :: b_ad
     real, intent(in)  :: c_ad
+    real :: c
     real :: dc_dc
     real :: dc_db
     real :: c_ad_
     real :: dc_da
 
+
+    c = a - b
+    c = - c + b
 
     dc_dc = - 1.0
     dc_db = 1.0
@@ -62,11 +72,15 @@ contains
     real, intent(in)  :: b
     real, intent(out) :: b_ad
     real, intent(in)  :: c_ad
+    real :: c
     real :: dc_dc
     real :: dc_da
     real :: c_ad_
     real :: dc_db
 
+
+    c = a * b + a
+    c = c * 3.0 + a
 
     dc_dc = 3.0
     dc_da = 1.0
@@ -86,11 +100,15 @@ contains
     real, intent(in)  :: b
     real, intent(out) :: b_ad
     real, intent(in)  :: c_ad
+    real :: c
     real :: dc_dc
     real :: dc_da
     real :: c_ad_
     real :: dc_db
 
+
+    c = a / (b + 1.5)
+    c = c / 2.0 + a
 
     dc_dc = 1.0 / 2.0
     dc_da = 1.0
@@ -110,11 +128,15 @@ contains
     real, intent(in)  :: b
     real, intent(out) :: b_ad
     real, intent(in)  :: c_ad
+    real :: c
     real :: dc_dc
     real :: dc_da
     real :: dc_db
     real :: c_ad_
 
+
+    c = a ** 3 + b ** 5.5
+    c = c + a ** b + (4.0 * a + 2.0) ** b + a ** (b * 5.0 + 3.0)
 
     dc_dc = 1.0
     dc_da = b * a**(b - 1.0) + b * (4.0 * a + 2.0)**(b - 1.0) * 4.0 + (b * 5.0 + 3.0) * a**(b * 5.0 + 2.0)


### PR DESCRIPTION
## Summary
- emit local variable declarations for forward computations
- insert forward pass before the backward derivative section
- regenerate AD examples to match updated generator

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_684a7b6928d0832dbf135949035ad6a6