### PR TITLE
Implement render_program and tests

### DIFF
--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -113,3 +113,10 @@ class Return(Node):
         return [f"{space}return\n"]
 
 
+def render_program(node: Node) -> str:
+    """Return formatted Fortran code for the entire ``node`` tree."""
+
+    lines = node.render()
+    return "".join(lines)
+
+

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from fautodiff import generator
 from fautodiff import parser
+from fautodiff import code_tree
 from fautodiff.generator import _collect_names
 
 
@@ -82,6 +83,31 @@ class TestGenerator(unittest.TestCase):
             self.assertEqual(errors, [], msg=f"Undefined variables in {src.name}: {errors}")
             violations = _check_inits(generated)
             self.assertEqual(violations, [], msg=f"Unexpected init in {src.name}: {violations}")
+
+
+class TestRenderProgram(unittest.TestCase):
+    def test_simple_assignment(self):
+        prog = code_tree.Block([code_tree.Assignment("a", "1")])
+        self.assertEqual(code_tree.render_program(prog), "a = 1\n")
+
+    def test_if_else_block(self):
+        prog = code_tree.Block(
+            [
+                code_tree.IfBlock(
+                    "a > 0",
+                    code_tree.Block([code_tree.Assignment("b", "1")]),
+                    else_body=code_tree.Block([code_tree.Assignment("b", "2")]),
+                )
+            ]
+        )
+        expected = (
+            "if (a > 0) then\n"
+            "  b = 1\n"
+            "else\n"
+            "  b = 2\n"
+            "end if\n"
+        )
+        self.assertEqual(code_tree.render_program(prog), expected)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add helper `render_program` for rendering full AST trees
- test `render_program` with simple assignment and if/else blocks

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_684aa387fa78832d86f8152ef8d122a0