### PR TITLE
Handle tree-based AD subroutine output

### DIFF
--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -58,6 +58,17 @@ class Assignment(Node):
 
 
 @dataclass
+class Statement(Node):
+    """A generic statement line."""
+
+    text: str
+
+    def render(self, indent: int = 0) -> List[str]:
+        space = " " * indent
+        return [f"{space}{self.text}\n"]
+
+
+@dataclass
 class Declaration(Node):
     """A declaration statement."""
 


### PR DESCRIPTION
## Summary
- add a Statement node to represent generic code lines
- return Block objects from `_generate_ad_subroutine`
- render AD subroutines in `generate_ad()`
- restrict `Declaration` usage to declarations only

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684aaec45360832dad9fe69f4113a3c5