### PR TITLE
Fix Python 3.9 import error in generator

### DIFF
--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 import sys
 import re


### PR DESCRIPTION
## Summary
- use `from __future__ import annotations` in `generator.py` so that union type
  hints are stored as strings

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_684ad13326bc832dba2bf947ffab4b2e