### PR TITLE
Add node helpers

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -133,5 +133,20 @@ class TestRenderProgram(unittest.TestCase):
         )
         self.assertEqual(code_tree.render_program(prog), expected)
 
+
+class TestNodeMethods(unittest.TestCase):
+    def test_block_empty(self):
+        blk = code_tree.Block([code_tree.EmptyLine()])
+        self.assertTrue(blk.is_effectively_empty())
+
+    def test_has_assignment_to(self):
+        blk = code_tree.Block([
+            code_tree.Assignment("a", "1"),
+            code_tree.EmptyLine(),
+        ])
+        self.assertTrue(blk.has_assignment_to("a"))
+        self.assertFalse(blk.has_assignment_to("b"))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add `is_effectively_empty` and `has_assignment_to` helpers to `code_tree` nodes
- test the new helpers

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_684add8249d4832d8ab4f768eb087a95