### PR TITLE
Fix declaration spacing

### DIFF
--- a/examples/arrays_ad.f90
+++ b/examples/arrays_ad.f90
@@ -13,7 +13,6 @@ contains
     real :: dc_da(n)
     real :: dc_db(n)
 
-
     dc_da(:) = 1.0
     dc_db(:) = 1.0
     b_ad(:) = c_ad * dc_db
@@ -47,7 +46,6 @@ contains
     real :: dd_dc
 
     c_ad = 0.0
-
     DO j = m, 1, -1
       DO i = n, 1, -1
         dd_da_i__j = 1.0
@@ -75,7 +73,6 @@ contains
     real :: dres_da_i
     real :: dres_db_i
 
-
     res_ad_ = res_ad
 
     DO i = n, 1, -1
@@ -102,7 +99,6 @@ contains
     real :: db_da_idx_i_
 
     a_ad(:) = 0.0
-
     DO i = n, 1, -1
       dc_da_idx_i_ = 2 * a(idx(i))
       a_ad(idx(i)) = c_ad(idx(i)) * dc_da_idx_i_ + a_ad(idx(i))
@@ -126,7 +122,6 @@ contains
     real :: db_da_ip
 
     a_ad(:) = 0.0
-
     DO i = n, 1, -1
       in = i - 1
       ip = i + 1

--- a/examples/control_flow_ad.f90
+++ b/examples/control_flow_ad.f90
@@ -11,7 +11,6 @@ contains
     real, intent(in)  :: z_ad
     real :: dz_dx
 
-
     IF (x > 0.0) THEN
       dz_dx = 1.0
       x_ad = z_ad * dz_dx
@@ -30,7 +29,6 @@ contains
     real, intent(out) :: x_ad
     real, intent(in)  :: z_ad
     real :: dz_dx
-
 
     SELECT CASE (i)
     CASE (1)
@@ -56,7 +54,6 @@ contains
     real :: dsum_dx
 
     x_ad = 0.0
-
     sum_ad_ = sum_ad
 
     DO i = n, 1, -1

--- a/examples/intrinsic_func_ad.f90
+++ b/examples/intrinsic_func_ad.f90
@@ -53,7 +53,6 @@ contains
     real :: db_dy
     real :: da_dx
 
-
     pi = ACOS(- 1.0)
 
     dz_da = 1.0
@@ -138,7 +137,6 @@ contains
 
     arr_ad(:) = 0.0
     x_ad = 0.0
-
     dy_da = 1.0
     dy_db = 1.0
     dy_dc = 1.0
@@ -155,7 +153,6 @@ contains
     real, intent(in)  :: mat_out_ad(:, :)
     real :: mat_out_ad_(size(mat_out_ad, 1), size(mat_out_ad, 2))
 
-
     mat_out_ad_ = cshift(mat_out_ad, -1, 2)
     mat_in_ad = transpose(mat_out_ad_)
 
@@ -169,7 +166,6 @@ contains
     real, intent(in)  :: d_ad
     character(len = 1), intent(inout) :: c
     real :: dd_dr
-
 
     dd_dr = 1.0
     r_ad = d_ad * dd_dr

--- a/examples/simple_math_ad.f90
+++ b/examples/simple_math_ad.f90
@@ -17,7 +17,6 @@ contains
     real :: dwork_da
     real :: dwork_db
 
-
     dc_dc = 1.0
     dc_dwork = 1.0
     work_ad = c_ad * dc_dwork
@@ -43,7 +42,6 @@ contains
     real :: c_ad_
     real :: dc_da
 
-
     dc_dc = - 1.0
     dc_db = 1.0
     b_ad = c_ad * dc_db
@@ -66,7 +64,6 @@ contains
     real :: dc_da
     real :: c_ad_
     real :: dc_db
-
 
     dc_dc = 3.0
     dc_da = 1.0
@@ -91,7 +88,6 @@ contains
     real :: c_ad_
     real :: dc_db
 
-
     dc_dc = 1.0 / 2.0
     dc_da = 1.0
     a_ad = c_ad * dc_da
@@ -114,7 +110,6 @@ contains
     real :: dc_da
     real :: dc_db
     real :: c_ad_
-
 
     dc_dc = 1.0
     dc_da = b * a**(b - 1.0) + b * (4.0 * a + 2.0)**(b - 1.0) * 4.0 + (b * 5.0 + 3.0) * a**(b * 5.0 + 2.0)

--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -77,48 +77,54 @@ class Assignment(Node):
 
 @dataclass
 class Subroutine(Node):
-    """A ``subroutine`` with its body."""
+    """A ``subroutine`` with declaration and execution blocks."""
 
     name: str
     args: str = ""
+    decls: Block = field(default_factory=Block)
     body: Block = field(default_factory=Block)
 
     def render(self, indent: int = 0) -> List[str]:
         space = "  " * indent
         args = f"({self.args})" if self.args else "()"
         lines = [f"{space}subroutine {self.name}{args}\n"]
+        lines.extend(self.decls.render(indent + 1))
+        lines.append("\n")
         lines.extend(self.body.render(indent + 1))
         lines.append(f"{space}end subroutine {self.name}\n")
         return lines
 
     def is_effectively_empty(self) -> bool:
-        return self.body.is_effectively_empty()
+        return self.decls.is_effectively_empty() and self.body.is_effectively_empty()
 
     def has_assignment_to(self, var: str) -> bool:
-        return self.body.has_assignment_to(var)
+        return self.decls.has_assignment_to(var) or self.body.has_assignment_to(var)
 
 
 @dataclass
 class Function(Node):
-    """A ``function`` with its body."""
+    """A ``function`` with declaration and execution blocks."""
 
     name: str
     args: str = ""
+    decls: Block = field(default_factory=Block)
     body: Block = field(default_factory=Block)
 
     def render(self, indent: int = 0) -> List[str]:
         space = "  " * indent
         args = f"({self.args})" if self.args else "()"
         lines = [f"{space}function {self.name}{args}\n"]
+        lines.extend(self.decls.render(indent + 1))
+        lines.append("\n")
         lines.extend(self.body.render(indent + 1))
         lines.append(f"{space}end function {self.name}\n")
         return lines
 
     def is_effectively_empty(self) -> bool:
-        return self.body.is_effectively_empty()
+        return self.decls.is_effectively_empty() and self.body.is_effectively_empty()
 
     def has_assignment_to(self, var: str) -> bool:
-        return self.body.has_assignment_to(var)
+        return self.decls.has_assignment_to(var) or self.body.has_assignment_to(var)
 
 
 @dataclass

--- a/fautodiff/intrinsic_rules.py
+++ b/fautodiff/intrinsic_rules.py
@@ -67,7 +67,7 @@ NONDIFF_INTRINSICS = {
 }
 
 
-def _handle_transpose(lhs, items, grad_var, defined, decls, decl_set):
+def _handle_transpose(lhs, items, grad_var, defined, decl_names, decl_set):
     """Propagate gradient through ``transpose``."""
     arg = items[0].tofortran()
     lhs_grad = grad_var.get(lhs, f"{lhs}_ad")
@@ -80,7 +80,7 @@ def _handle_transpose(lhs, items, grad_var, defined, decls, decl_set):
     return block, {lhs, arg}
 
 
-def _handle_cshift(lhs, items, grad_var, defined, decls, decl_set):
+def _handle_cshift(lhs, items, grad_var, defined, decl_names, decl_set):
     """Propagate gradient through ``cshift``."""
     arr = items[0].tofortran()
     shift = items[1].tofortran()
@@ -93,7 +93,7 @@ def _handle_cshift(lhs, items, grad_var, defined, decls, decl_set):
         block.append(f"{new_grad} = {update}\n")
         grad_var[lhs] = new_grad
         if new_grad not in decl_set:
-            decls.append(new_grad)
+            decl_names.append(new_grad)
             decl_set.add(new_grad)
     else:
         if arr in defined:


### PR DESCRIPTION
## Summary
- avoid extra EmptyLine nodes after initializing gradients
- regenerate expected AD examples
- keep one blank line between declaration and body blocks

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_684adfa3a438832db27189091a29e3be