### PR TITLE
Add accumulate flag to Assignment

### DIFF
--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -917,7 +917,7 @@ def _generate_ad_subroutine(routine, filename, warnings):
         t, _ = decl_map.get(arg, ("real", None))
         _, dims = _split_type(t)
         suf = "(:)" if dims else ""
-        init_lines.append(Assignment(f"{arg}_ad{suf}", 0.0))
+        init_lines.append(Assignment(f"{arg}_ad{suf}", "0.0"))
     # only intent(out) argument gradients need initialization
 
     for il in init_lines:

--- a/tests/test_code_tree.py
+++ b/tests/test_code_tree.py
@@ -131,6 +131,22 @@ class TestNodeMethods(unittest.TestCase):
             "a = 1\n" "b = a\n",
         )
 
+    def test_assignment_accumulate(self):
+        # detection without flag
+        a = code_tree.Assignment("x_da", "x_da + y")
+        self.assertEqual(a.required_vars(["x_da"]), ["y"])
+
+        # explicit accumulate
+        b = code_tree.Assignment("x_da", "y", accumulate=True)
+        self.assertEqual(
+            code_tree.render_program(code_tree.Block([b])),
+            "x_da = y + x_da\n",
+        )
+        self.assertEqual(b.required_vars(["x_da"]), ["y"])
+
+        with self.assertRaises(ValueError):
+            code_tree.Assignment("x_da", "x_da + y", accumulate=True)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- refine `Assignment` with new `accumulate` flag replacing `self_add`
- adjust `required_vars` logic for the flag or self-add detection
- append lhs at render time when accumulating
- update tests for new behaviour

## Testing
- `python tests/test_generator.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b6892f87c832dafdc376a1d189527