### PR TITLE
Update generator to rely on block nodes

### DIFF
--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -467,9 +467,11 @@ def _generate_ad_subroutine(routine, filename, warnings):
         args = [str(a) for a in (stmt.items[2].items if stmt.items[2] else [])]
         result = None
 
-    spec, exec_part = parser._routine_parts(routine)
+    spec, exec_part_node = parser._routine_parts(routine)
     # Convert execution part to a forward node block for later use
-    fwd_block = parser.exec_part_to_block(exec_part)
+    fwd_block = parser.exec_part_to_block(exec_part_node)
+    # Use the forward block to obtain a fresh execution part for AD generation
+    exec_part = parser.block_to_exec_part(fwd_block)
     decl_map = parser._parse_decls(spec)
     used_vars = set()
     pre_lines = Block([])  # nodes inserted before the main reversed body

--- a/tests/test_parser_nodes.py
+++ b/tests/test_parser_nodes.py
@@ -20,6 +20,15 @@ class TestExecPartToBlock(unittest.TestCase):
         self.assertIsInstance(blk.children[1], Assignment)
         self.assertIsInstance(blk.children[2], Return)
 
+    def test_block_roundtrip(self):
+        ast = parser.parse_file('examples/simple_math.f90')
+        sub = parser.walk(ast, Fortran2003.Subroutine_Subprogram)[0]
+        _, exec_part = parser._routine_parts(sub)
+        blk = parser.exec_part_to_block(exec_part)
+        new_exec = parser.block_to_exec_part(blk)
+        self.assertIsNotNone(new_exec)
+        self.assertEqual(len(new_exec.content), len(exec_part.content))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- convert `Block` objects back to fparser execution parts with new helper `block_to_exec_part`
- generate AD code from the reconstructed execution part so the original exec_part is only used to create `fwd_block`
- test round‑trip conversion of execution parts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ba2ac79e8832d9352fb79ee386135