### PR TITLE
Add Fortran variable descriptor

### DIFF
--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -150,6 +150,24 @@ class Node:
 
 
 @dataclass
+class Variable:
+    """Representation of a Fortran variable."""
+
+    name: str
+    typename: str
+    kind: Optional[str] = None
+    dimension: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.dimension is not None and self.dimension == "":
+            raise ValueError("dimension must not be empty")
+
+    def is_array(self) -> bool:
+        """Return ``True`` if this variable represents an array."""
+        return self.dimension is not None
+
+
+@dataclass
 class Block(Node):
     """A container for a sequence of nodes."""
 

--- a/tests/test_code_tree.py
+++ b/tests/test_code_tree.py
@@ -198,5 +198,18 @@ class TestNodeMethods(unittest.TestCase):
         self.assertEqual(cond_blk2.remove_initial_self_add("x_da"), 2)
 
 
+class TestVariable(unittest.TestCase):
+    def test_scalar(self):
+        var = code_tree.Variable("x", "real")
+        self.assertEqual(var.name, "x")
+        self.assertEqual(var.typename, "real")
+        self.assertFalse(var.is_array())
+
+    def test_array(self):
+        var = code_tree.Variable("a", "real", dimension="(n)")
+        self.assertTrue(var.is_array())
+        self.assertEqual(var.dimension, "(n)")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `Variable` dataclass in `code_tree` to represent Fortran variables
- include unit tests for the new class

## Testing
- `python tests/test_generator.py`
- `python tests/test_code_tree.py`
- `python tests/test_parser_nodes.py`


------
https://chatgpt.com/codex/tasks/task_b_684bb8de606c832d83b97ca3bf8e62da