### PR TITLE
Store rhs variables on Assignment creation

### DIFF
--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -254,9 +254,11 @@ class Assignment(Node):
     lhs: str
     rhs: str
     accumulate: bool = False
+    rhs_names: List[str] = field(init=False, repr=False)
 
     def __post_init__(self):
         super().__post_init__()
+        self.rhs_names = _extract_names(self.rhs)
         if self.accumulate and self._detect_self_add():
             raise ValueError("rhs must not reference lhs when accumulate=True")
 
@@ -290,7 +292,7 @@ class Assignment(Node):
         lhs_base = self.lhs.split("(")[0].strip()
         needed = [n for n in (names or []) if n != lhs_base]
         ignore_self = self.accumulate or self._detect_self_add()
-        for n in _extract_names(self.rhs):
+        for n in self.rhs_names:
             if ignore_self and n == lhs_base:
                 continue
             if n not in needed:

--- a/tests/test_code_tree.py
+++ b/tests/test_code_tree.py
@@ -147,6 +147,15 @@ class TestNodeMethods(unittest.TestCase):
         with self.assertRaises(ValueError):
             code_tree.Assignment("x_da", "x_da + y", accumulate=True)
 
+    def test_assignment_rhs_names(self):
+        assign = code_tree.Assignment("a", "b + c")
+        self.assertEqual(assign.rhs_names, ["b", "c"])
+
+    def test_required_vars_uses_cached_names(self):
+        assign = code_tree.Assignment("a", "b + c")
+        assign.rhs = "d"
+        self.assertEqual(assign.required_vars(), ["b", "c"])
+
     def test_remove_initial_self_add(self):
         blk = code_tree.Block([
             code_tree.Assignment("x_da", "x_da + y"),


### PR DESCRIPTION
## Summary
- store names from the RHS expression when creating an `Assignment`
- reference cached names in `Assignment.required_vars`
- test that cached names are used even after modifying `rhs`

## Testing
- `python tests/test_generator.py`
- `python tests/test_code_tree.py`


------
https://chatgpt.com/codex/tasks/task_b_684bb840a3ac832d9350a1db70144e31