### PR TITLE
Add tests for helper classes

### DIFF
--- a/tests/test_aryindex.py
+++ b/tests/test_aryindex.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fautodiff import operators
+
+
+class TestAryIndex(unittest.TestCase):
+    def test_equality_and_str(self):
+        i = operators.OpVar('i')
+        idx1 = operators.AryIndex([operators.OpInt(1), None, i])
+        idx2 = operators.AryIndex([1, operators.OpRange(), i])
+        self.assertEqual(idx1.list(), ['1', ':', 'i'])
+        self.assertEqual(str(idx1), '1,:,i')
+        self.assertEqual(idx1, idx2)
+        idx3 = operators.AryIndex([1, None, operators.OpVar('j')])
+        self.assertNotEqual(idx1, idx3)
+
+    def test_comparisons(self):
+        i = operators.OpVar('i')
+        idx = operators.AryIndex([i, None])
+        full = operators.AryIndex([None, None])
+        self.assertTrue(idx <= full)
+        self.assertTrue(full >= idx)
+        self.assertFalse(full <= idx)
+
+    def test_collect_vars_and_flags(self):
+        i = operators.OpVar('i')
+        j = operators.OpVar('j')
+        idx = operators.AryIndex([i, None, j])
+        vars = idx.collect_vars()
+        self.assertEqual(vars, [i, j])
+        self.assertTrue(idx.is_partial_access())
+        self.assertTrue(idx.is_depended_on(i))
+        self.assertFalse(idx.is_depended_on(operators.OpVar('k')))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_dowhile.py
+++ b/tests/test_dowhile.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fautodiff import code_tree, operators
+
+
+class TestDoWhile(unittest.TestCase):
+    def test_basic_render_and_required(self):
+        cond = operators.OpVar('cond')
+        body = code_tree.Block([
+            code_tree.Assignment(operators.OpVar('a'), operators.OpVar('b'))
+        ])
+        loop = code_tree.DoWhile(body, cond)
+        expected = (
+            "do while (cond)\n"
+            "  a = b\n"
+            "end do\n"
+        )
+        self.assertEqual(code_tree.render_program(loop), expected)
+        self.assertEqual([str(v) for v in loop.required_vars()], ['b', 'cond'])
+
+    def test_check_initial(self):
+        body = code_tree.Block([
+            code_tree.Assignment(operators.OpVar('a'), operators.OpVar('b'))
+        ])
+        loop = code_tree.DoWhile(body, operators.OpVar('flag'))
+        self.assertEqual(loop.check_initial('a'), -1)
+        self.assertEqual(loop.check_initial('b'), 0)
+
+    def test_prune_for(self):
+        body = code_tree.Block([
+            code_tree.Assignment(operators.OpVar('a'), operators.OpVar('b'))
+        ])
+        loop = code_tree.DoWhile(body, operators.OpVar('flag'))
+        pruned = loop.prune_for([operators.OpVar('a')])
+        self.assertEqual(code_tree.render_program(pruned), code_tree.render_program(loop))
+        pruned2 = loop.prune_for([operators.OpVar('c')])
+        self.assertTrue(pruned2.is_effectively_empty())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_vardict.py
+++ b/tests/test_vardict.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fautodiff.var_dict import Vardict
+
+
+class TestVardict(unittest.TestCase):
+    def test_basic_operations(self):
+        vd = Vardict()
+        vd['a'] = 1
+        vd['b'] = 2
+        self.assertEqual(vd['a'], 1)
+        self.assertEqual(vd['b'], 2)
+        self.assertIn('a', vd)
+        self.assertIn('b', vd)
+        self.assertEqual(len(vd), 2)
+        self.assertEqual(set(vd.keys()), {'a', 'b'})
+        self.assertEqual(set(vd.values()), {1, 2})
+        self.assertEqual(set(vd.items()), {('a', 1), ('b', 2)})
+        collected = [k for k in vd]
+        self.assertEqual(set(collected), {'a', 'b'})
+
+        copy = vd.copy()
+        self.assertEqual(set(copy.items()), set(vd.items()))
+
+        del vd['a']
+        self.assertNotIn('a', vd)
+        with self.assertRaises(KeyError):
+            _ = vd['a']
+
+        vd.remove('b')
+        self.assertEqual(len(vd), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- cover `AryIndex` behaviour
- exercise `DoWhile` loop utilities
- add a suite for `Vardict`

## Testing
- `python tests/test_generator.py` *(fails: AssertionError: Mismatch for save_vars.f90)*

------
https://chatgpt.com/codex/tasks/task_b_685bd4394464832d84389516458d09c6