### PR TITLE
Add runtime tests for all simple_math subroutines

### DIFF
--- a/tests/fortran_runtime/run_simple_math.f90
+++ b/tests/fortran_runtime/run_simple_math.f90
@@ -6,6 +6,9 @@ program run_simple_math
   integer, parameter :: I_all              = 0
   integer, parameter :: I_add_numbers      = 1
   integer, parameter :: I_multiply_numbers = 2
+  integer, parameter :: I_subtract_numbers = 3
+  integer, parameter :: I_divide_numbers   = 4
+  integer, parameter :: I_power_numbers    = 5
 
   integer :: length, status
   character(:), allocatable :: arg
@@ -23,6 +26,12 @@ program run_simple_math
               i_test = I_add_numbers
            case ("multiply_numbers")
               i_test = I_multiply_numbers
+           case ("subtract_numbers")
+              i_test = I_subtract_numbers
+           case ("divide_numbers")
+              i_test = I_divide_numbers
+           case ("power_numbers")
+              i_test = I_power_numbers
            case default
               print *, 'Invalid test name: ', arg
               error stop 1
@@ -37,6 +46,15 @@ program run_simple_math
   end if
   if (i_test == I_multiply_numbers .or. i_test == I_all) then
      call test_multiply_numbers
+  end if
+  if (i_test == I_subtract_numbers .or. i_test == I_all) then
+     call test_subtract_numbers
+  end if
+  if (i_test == I_divide_numbers .or. i_test == I_all) then
+     call test_divide_numbers
+  end if
+  if (i_test == I_power_numbers .or. i_test == I_all) then
+     call test_power_numbers
   end if
 
   stop
@@ -78,5 +96,59 @@ contains
 
     return
   end subroutine test_multiply_numbers
+
+  subroutine test_subtract_numbers
+    real :: a, b, c
+    real :: a_ad, b_ad, c_ad
+
+    a = 2.0
+    b = 3.0
+    c = subtract_numbers(a, b)
+
+    a_ad = 0.0
+    b_ad = 0.0
+    c_ad = 1.0
+    call subtract_numbers_ad(a, a_ad, b, b_ad, c_ad)
+
+    print *, c, a_ad, b_ad
+
+    return
+  end subroutine test_subtract_numbers
+
+  subroutine test_divide_numbers
+    real :: a, b, c
+    real :: a_ad, b_ad, c_ad
+
+    a = 2.0
+    b = 3.0
+    call divide_numbers(a, b, c)
+
+    a_ad = 0.0
+    b_ad = 0.0
+    c_ad = 1.0
+    call divide_numbers_ad(a, a_ad, b, b_ad, c_ad)
+
+    print *, c, a_ad, b_ad
+
+    return
+  end subroutine test_divide_numbers
+
+  subroutine test_power_numbers
+    real :: a, b, c
+    real :: a_ad, b_ad, c_ad
+
+    a = 2.0
+    b = 3.0
+    c = power_numbers(a, b)
+
+    a_ad = 0.0
+    b_ad = 0.0
+    c_ad = 1.0
+    call power_numbers_ad(a, a_ad, b, b_ad, c_ad)
+
+    print *, c, a_ad, b_ad
+
+    return
+  end subroutine test_power_numbers
 
 end program run_simple_math

--- a/tests/test_fortran_runtime.py
+++ b/tests/test_fortran_runtime.py
@@ -53,6 +53,66 @@ class TestFortranRuntime(unittest.TestCase):
             self.assertAlmostEqual(values[1], 13.0, places=5)
             self.assertAlmostEqual(values[2], 6.0, places=5)
 
+    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
+    def test_subtract_numbers(self):
+        base = Path(__file__).resolve().parents[1]
+        src = base / 'examples' / 'simple_math.f90'
+        code_tree.Node.reset()
+        ad_code = generator.generate_ad(str(src), warn=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            ad_path = tmp / 'simple_math_ad.f90'
+            ad_path.write_text(ad_code)
+            driver = Path(__file__).resolve().parent / 'fortran_runtime' / 'run_simple_math.f90'
+            exe = tmp / 'run_subtract.out'
+            cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
+            subprocess.check_call(cmd)
+            run = subprocess.run([str(exe), "subtract_numbers"], stdout=subprocess.PIPE, text=True, check=True)
+            values = [float(v) for v in run.stdout.strip().split()]
+            self.assertAlmostEqual(values[0], 4.0, places=5)
+            self.assertAlmostEqual(values[1], -1.0, places=5)
+            self.assertAlmostEqual(values[2], 2.0, places=5)
+
+    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
+    def test_divide_numbers(self):
+        base = Path(__file__).resolve().parents[1]
+        src = base / 'examples' / 'simple_math.f90'
+        code_tree.Node.reset()
+        ad_code = generator.generate_ad(str(src), warn=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            ad_path = tmp / 'simple_math_ad.f90'
+            ad_path.write_text(ad_code)
+            driver = Path(__file__).resolve().parent / 'fortran_runtime' / 'run_simple_math.f90'
+            exe = tmp / 'run_divide.out'
+            cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
+            subprocess.check_call(cmd)
+            run = subprocess.run([str(exe), "divide_numbers"], stdout=subprocess.PIPE, text=True, check=True)
+            values = [float(v) for v in run.stdout.strip().split()]
+            self.assertAlmostEqual(values[0], 2.2222222222222223, places=5)
+            self.assertAlmostEqual(values[1], 1.1111111111111112, places=5)
+            self.assertAlmostEqual(values[2], -0.04938271604938271, places=5)
+
+    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
+    def test_power_numbers(self):
+        base = Path(__file__).resolve().parents[1]
+        src = base / 'examples' / 'simple_math.f90'
+        code_tree.Node.reset()
+        ad_code = generator.generate_ad(str(src), warn=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            ad_path = tmp / 'simple_math_ad.f90'
+            ad_path.write_text(ad_code)
+            driver = Path(__file__).resolve().parent / 'fortran_runtime' / 'run_simple_math.f90'
+            exe = tmp / 'run_power.out'
+            cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
+            subprocess.check_call(cmd)
+            run = subprocess.run([str(exe), "power_numbers"], stdout=subprocess.PIPE, text=True, check=True)
+            values = [float(v) for v in run.stdout.strip().split()]
+            self.assertAlmostEqual(values[0], 263580.875, places=5)
+            self.assertAlmostEqual(values[1], 2360520.0, places=5)
+            self.assertAlmostEqual(values[2], 911601.625, places=5)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- extend the Fortran runtime driver to cover all subroutines in `simple_math.f90`
- add corresponding unit tests invoking the new runtime checks

## Testing
- `python tests/test_generator.py`
- `python tests/test_fortran_runtime.py`

------
https://chatgpt.com/codex/tasks/task_b_685ff3b4d398832db2286bf949134d2e