### PR TITLE
Add Fortran runtime tests for all example modules

### DIFF
--- a/tests/fortran_runtime/run_arrays.f90
+++ b/tests/fortran_runtime/run_arrays.f90
@@ -1,0 +1,81 @@
+program run_arrays
+  use array
+  use array_ad
+  implicit none
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_elementwise_add = 1
+  integer, parameter :: I_dot_product = 2
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("elementwise_add")
+              i_test = I_elementwise_add
+           case ("dot_product")
+              i_test = I_dot_product
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_elementwise_add .or. i_test == I_all) then
+     call test_elementwise_add
+  end if
+  if (i_test == I_dot_product .or. i_test == I_all) then
+     call test_dot_product
+  end if
+
+  stop
+contains
+
+  subroutine test_elementwise_add
+    integer, parameter :: n = 3
+    real :: a(n), b(n), c(n)
+    real :: a_ad(n), b_ad(n), c_ad(n)
+
+    a = (/1.0, 2.0, 3.0/)
+    b = (/4.0, 5.0, 6.0/)
+    call elementwise_add(n, a, b, c)
+
+    a_ad = 0.0
+    b_ad = 0.0
+    c_ad = 1.0
+    call elementwise_add_ad(n, a, a_ad, b, b_ad, c_ad)
+
+    print *, c(1), a_ad(1), b_ad(1)
+    return
+  end subroutine test_elementwise_add
+
+  subroutine test_dot_product
+    integer, parameter :: n = 3
+    real :: a(n), b(n), res
+    real :: a_ad(n), b_ad(n), res_ad
+
+    a = (/1.0, 2.0, 3.0/)
+    b = (/4.0, 5.0, 6.0/)
+    res = dot_product(n, a, b)
+
+    a_ad = 0.0
+    b_ad = 0.0
+    res_ad = 1.0
+    call dot_product_ad(n, a, a_ad, b, b_ad, res_ad)
+
+    print *, res, a_ad(1), b_ad(1)
+    return
+  end subroutine test_dot_product
+
+end program run_arrays

--- a/tests/fortran_runtime/run_control_flow.f90
+++ b/tests/fortran_runtime/run_control_flow.f90
@@ -1,0 +1,79 @@
+program run_control_flow
+  use control_flow
+  use control_flow_ad
+  implicit none
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_if_example = 1
+  integer, parameter :: I_do_example = 2
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("if_example")
+              i_test = I_if_example
+           case ("do_example")
+              i_test = I_do_example
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_if_example .or. i_test == I_all) then
+     call test_if_example
+  end if
+  if (i_test == I_do_example .or. i_test == I_all) then
+     call test_do_example
+  end if
+
+  stop
+contains
+
+  subroutine test_if_example
+    real :: x, y, z
+    real :: x_ad, y_ad, z_ad
+
+    x = 1.0
+    y = 2.0
+    call if_example(x, y, z)
+
+    x_ad = 0.0
+    y_ad = 0.0
+    z_ad = 1.0
+    call if_example_ad(x, x_ad, y, y_ad, z_ad)
+
+    print *, z, x_ad
+    return
+  end subroutine test_if_example
+
+  subroutine test_do_example
+    integer :: n
+    real :: x, sum
+    real :: x_ad, sum_ad
+
+    n = 3
+    x = 2.0
+    call do_example(n, x, sum)
+
+    x_ad = 0.0
+    sum_ad = 1.0
+    call do_example_ad(n, x, x_ad, sum_ad)
+
+    print *, sum, x_ad
+    return
+  end subroutine test_do_example
+
+end program run_control_flow

--- a/tests/fortran_runtime/run_intrinsic_func.f90
+++ b/tests/fortran_runtime/run_intrinsic_func.f90
@@ -1,0 +1,58 @@
+program run_intrinsic_func
+  use intrinsic_func
+  use intrinsic_func_ad
+  implicit none
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_casting = 1
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("casting")
+              i_test = I_casting
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_casting .or. i_test == I_all) then
+     call test_casting
+  end if
+
+  stop
+contains
+
+  subroutine test_casting
+    integer :: i, n
+    real :: r, r_ad
+    double precision :: d, d_ad
+    character(len=1) :: c
+
+    i = 3
+    r = 4.5
+    c = 'A'
+    call casting_intrinsics(i, r, d, c, n)
+
+    r_ad = 0.0
+    d_ad = 1.0d0
+    call casting_intrinsics_ad(i, r, r_ad, d_ad, c)
+
+    print *, d, r_ad
+    return
+  end subroutine test_casting
+
+end program run_intrinsic_func

--- a/tests/fortran_runtime/run_save_vars.f90
+++ b/tests/fortran_runtime/run_save_vars.f90
@@ -1,0 +1,56 @@
+program run_save_vars
+  use save_vars
+  use save_vars_ad
+  implicit none
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_simple = 1
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("simple")
+              i_test = I_simple
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_simple .or. i_test == I_all) then
+     call test_simple
+  end if
+
+  stop
+contains
+
+  subroutine test_simple
+    real :: x, y, z
+    real :: x_ad, y_ad, z_ad
+
+    x = 2.0
+    y = 3.0
+    call simple(x, y, z)
+
+    x_ad = 0.0
+    y_ad = 0.0
+    z_ad = 1.0
+    call simple_ad(x, x_ad, y, y_ad, z_ad)
+
+    print *, z, x_ad, y_ad
+    return
+  end subroutine test_simple
+
+end program run_save_vars

--- a/tests/test_fortran_runtime.py
+++ b/tests/test_fortran_runtime.py
@@ -113,6 +113,84 @@ class TestFortranRuntime(unittest.TestCase):
             self.assertAlmostEqual(values[1], 2360520.0, places=5)
             self.assertAlmostEqual(values[2], 911601.625, places=5)
 
+    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
+    def test_arrays_elementwise_add(self):
+        base = Path(__file__).resolve().parents[1]
+        src = base / 'examples' / 'arrays.f90'
+        code_tree.Node.reset()
+        ad_code = generator.generate_ad(str(src), warn=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            ad_path = tmp / 'arrays_ad.f90'
+            ad_path.write_text(ad_code)
+            driver = Path(__file__).resolve().parent / 'fortran_runtime' / 'run_arrays.f90'
+            exe = tmp / 'run_arrays.out'
+            cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
+            subprocess.check_call(cmd)
+            run = subprocess.run([str(exe), 'elementwise_add'], stdout=subprocess.PIPE, text=True, check=True)
+            values = [float(v) for v in run.stdout.strip().split()]
+            self.assertAlmostEqual(values[0], 9.0, places=5)
+            self.assertAlmostEqual(values[1], 1.0, places=5)
+            self.assertAlmostEqual(values[2], 2.0, places=5)
+
+    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
+    def test_control_flow_if_example(self):
+        base = Path(__file__).resolve().parents[1]
+        src = base / 'examples' / 'control_flow.f90'
+        code_tree.Node.reset()
+        ad_code = generator.generate_ad(str(src), warn=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            ad_path = tmp / 'control_flow_ad.f90'
+            ad_path.write_text(ad_code)
+            driver = Path(__file__).resolve().parent / 'fortran_runtime' / 'run_control_flow.f90'
+            exe = tmp / 'run_cf.out'
+            cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
+            subprocess.check_call(cmd)
+            run = subprocess.run([str(exe), 'if_example'], stdout=subprocess.PIPE, text=True, check=True)
+            values = [float(v) for v in run.stdout.strip().split()]
+            self.assertAlmostEqual(values[0], 1.0, places=5)
+            self.assertAlmostEqual(values[1], 1.0, places=5)
+
+    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
+    def test_intrinsic_casting(self):
+        base = Path(__file__).resolve().parents[1]
+        src = base / 'examples' / 'intrinsic_func.f90'
+        code_tree.Node.reset()
+        ad_code = generator.generate_ad(str(src), warn=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            ad_path = tmp / 'intrinsic_func_ad.f90'
+            ad_path.write_text(ad_code)
+            driver = Path(__file__).resolve().parent / 'fortran_runtime' / 'run_intrinsic_func.f90'
+            exe = tmp / 'run_intrinsic.out'
+            cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
+            subprocess.check_call(cmd)
+            run = subprocess.run([str(exe), 'casting'], stdout=subprocess.PIPE, text=True, check=True)
+            values = [float(v) for v in run.stdout.strip().split()]
+            self.assertAlmostEqual(values[0], 8.5, places=5)
+            self.assertAlmostEqual(values[1], 1.0, places=5)
+
+    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
+    def test_save_vars_simple(self):
+        base = Path(__file__).resolve().parents[1]
+        src = base / 'examples' / 'save_vars.f90'
+        code_tree.Node.reset()
+        ad_code = generator.generate_ad(str(src), warn=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            ad_path = tmp / 'save_vars_ad.f90'
+            ad_path.write_text(ad_code)
+            driver = Path(__file__).resolve().parent / 'fortran_runtime' / 'run_save_vars.f90'
+            exe = tmp / 'run_save_vars.out'
+            cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
+            subprocess.check_call(cmd)
+            run = subprocess.run([str(exe), 'simple'], stdout=subprocess.PIPE, text=True, check=True)
+            values = [float(v) for v in run.stdout.strip().split()]
+            self.assertAlmostEqual(values[0], 32.0, places=5)
+            self.assertAlmostEqual(values[1], 34.0, places=5)
+            self.assertAlmostEqual(values[2], 1.0, places=5)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add driver programs for arrays, control_flow, intrinsic_func and save_vars examples
- extend `test_fortran_runtime.py` to run these drivers

## Testing
- `python tests/test_generator.py`
- `python tests/test_fortran_runtime.py`

------
https://chatgpt.com/codex/tasks/task_b_685ff72e17d0832dae51e6ff4da0ab74