### PR TITLE
Move runtime checks to Fortran

### DIFF
--- a/tests/fortran_runtime/run_arrays.f90
+++ b/tests/fortran_runtime/run_arrays.f90
@@ -2,10 +2,12 @@ program run_arrays
   use array
   use array_ad
   implicit none
+  real, parameter :: tol = 1.0e-5
 
   integer, parameter :: I_all = 0
   integer, parameter :: I_elementwise_add = 1
   integer, parameter :: I_dot_product = 2
+  integer, parameter :: I_multidimension = 3
 
   integer :: length, status
   character(:), allocatable :: arg
@@ -23,6 +25,8 @@ program run_arrays
               i_test = I_elementwise_add
            case ("dot_product")
               i_test = I_dot_product
+           case ("multidimension")
+              i_test = I_multidimension
            case default
               print *, 'Invalid test name: ', arg
               error stop 1
@@ -38,6 +42,9 @@ program run_arrays
   if (i_test == I_dot_product .or. i_test == I_all) then
      call test_dot_product
   end if
+  if (i_test == I_multidimension .or. i_test == I_all) then
+     call test_multidimension
+  end if
 
   stop
 contains
@@ -46,6 +53,7 @@ contains
     integer, parameter :: n = 3
     real :: a(n), b(n), c(n)
     real :: a_ad(n), b_ad(n), c_ad(n)
+    real :: exp_c, exp_a, exp_b
 
     a = (/1.0, 2.0, 3.0/)
     b = (/4.0, 5.0, 6.0/)
@@ -56,7 +64,15 @@ contains
     c_ad = 1.0
     call elementwise_add_ad(n, a, a_ad, b, b_ad, c_ad)
 
-    print *, c(1), a_ad(1), b_ad(1)
+    exp_c = a(1) + 2.0 * b(1)
+    exp_a = 1.0
+    exp_b = 2.0
+
+    if (abs(c(1) - exp_c) > tol .or. abs(a_ad(1) - exp_a) > tol .or. &
+        abs(b_ad(1) - exp_b) > tol) then
+       print *, 'test_elementwise_add failed', c(1), a_ad(1), b_ad(1)
+       error stop 1
+    end if
     return
   end subroutine test_elementwise_add
 
@@ -64,6 +80,7 @@ contains
     integer, parameter :: n = 3
     real :: a(n), b(n), res
     real :: a_ad(n), b_ad(n), res_ad
+    real :: exp_res, exp_a, exp_b
 
     a = (/1.0, 2.0, 3.0/)
     b = (/4.0, 5.0, 6.0/)
@@ -74,8 +91,48 @@ contains
     res_ad = 1.0
     call dot_product_ad(n, a, a_ad, b, b_ad, res_ad)
 
-    print *, res, a_ad(1), b_ad(1)
+    exp_res = a(1)*b(1) + a(2)*b(2) + a(3)*b(3)
+    exp_a = b(1)
+    exp_b = a(1)
+
+    if (abs(res - exp_res) > tol .or. abs(a_ad(1) - exp_a) > tol .or. &
+        abs(b_ad(1) - exp_b) > tol) then
+       print *, 'test_dot_product failed', res, a_ad(1), b_ad(1)
+       error stop 1
+    end if
     return
   end subroutine test_dot_product
+
+  subroutine test_multidimension
+    integer, parameter :: n = 2, m = 2
+    real :: a(n,m), b(n,m), d(n,m)
+    real :: a_ad(n,m), b_ad(n,m), d_ad(n,m)
+    real :: c, c_ad
+    real :: exp_d, exp_a, exp_b, exp_c
+
+    a = reshape((/1.0, 2.0, 3.0, 4.0/), (/n, m/))
+    b = reshape((/5.0, 6.0, 7.0, 8.0/), (/n, m/))
+    c = 1.5
+    call multidimension(n, m, a, b, c, d)
+
+    a_ad = 0.0
+    b_ad = 0.0
+    d_ad = 0.0
+    d_ad(1,1) = 1.0
+    c_ad = 0.0
+    call multidimension_ad(n, m, a, a_ad, b, b_ad, c, c_ad, d_ad)
+
+    exp_d = a(1,1) + b(1,1) * c
+    exp_a = 1.0
+    exp_b = c
+    exp_c = b(1,1)
+
+    if (abs(d(1,1) - exp_d) > tol .or. abs(a_ad(1,1) - exp_a) > tol .or. &
+        abs(b_ad(1,1) - exp_b) > tol .or. abs(c_ad - exp_c) > tol) then
+       print *, 'test_multidimension failed', d(1,1), a_ad(1,1), b_ad(1,1), c_ad
+       error stop 1
+    end if
+    return
+  end subroutine test_multidimension
 
 end program run_arrays

--- a/tests/fortran_runtime/run_control_flow.f90
+++ b/tests/fortran_runtime/run_control_flow.f90
@@ -2,6 +2,7 @@ program run_control_flow
   use control_flow
   use control_flow_ad
   implicit none
+  real, parameter :: tol = 1.0e-5
 
   integer, parameter :: I_all = 0
   integer, parameter :: I_if_example = 1
@@ -45,6 +46,7 @@ contains
   subroutine test_if_example
     real :: x, y, z
     real :: x_ad, y_ad, z_ad
+    real :: exp_z, exp_x
 
     x = 1.0
     y = 2.0
@@ -55,7 +57,13 @@ contains
     z_ad = 1.0
     call if_example_ad(x, x_ad, y, y_ad, z_ad)
 
-    print *, z, x_ad
+    exp_z = x
+    exp_x = 1.0
+
+    if (abs(z - exp_z) > tol .or. abs(x_ad - exp_x) > tol) then
+       print *, 'test_if_example failed', z, x_ad
+       error stop 1
+    end if
     return
   end subroutine test_if_example
 
@@ -63,6 +71,7 @@ contains
     integer :: n
     real :: x, sum
     real :: x_ad, sum_ad
+    real :: exp_sum, exp_x
 
     n = 3
     x = 2.0
@@ -72,7 +81,13 @@ contains
     sum_ad = 1.0
     call do_example_ad(n, x, x_ad, sum_ad)
 
-    print *, sum, x_ad
+    exp_sum = x * real(n * (n + 1) / 2)
+    exp_x = real(n * (n + 1) / 2)
+
+    if (abs(sum - exp_sum) > tol .or. abs(x_ad - exp_x) > tol) then
+       print *, 'test_do_example failed', sum, x_ad
+       error stop 1
+    end if
     return
   end subroutine test_do_example
 

--- a/tests/fortran_runtime/run_intrinsic_func.f90
+++ b/tests/fortran_runtime/run_intrinsic_func.f90
@@ -2,6 +2,7 @@ program run_intrinsic_func
   use intrinsic_func
   use intrinsic_func_ad
   implicit none
+  real, parameter :: tol = 1.0e-5
 
   integer, parameter :: I_all = 0
   integer, parameter :: I_casting = 1
@@ -41,6 +42,8 @@ contains
     real :: r, r_ad
     double precision :: d, d_ad
     character(len=1) :: c
+    double precision :: exp_d
+    real :: exp_r
 
     i = 3
     r = 4.5
@@ -51,7 +54,13 @@ contains
     d_ad = 1.0d0
     call casting_intrinsics_ad(i, r, r_ad, d_ad, c)
 
-    print *, d, r_ad
+    exp_d = dble(r) + dble(int(r))
+    exp_r = 1.0
+
+    if (abs(d - exp_d) > tol .or. abs(r_ad - exp_r) > tol) then
+       print *, 'test_casting failed', d, r_ad
+       error stop 1
+    end if
     return
   end subroutine test_casting
 

--- a/tests/fortran_runtime/run_save_vars.f90
+++ b/tests/fortran_runtime/run_save_vars.f90
@@ -2,6 +2,7 @@ program run_save_vars
   use save_vars
   use save_vars_ad
   implicit none
+  real, parameter :: tol = 1.0e-5
 
   integer, parameter :: I_all = 0
   integer, parameter :: I_simple = 1
@@ -39,6 +40,7 @@ contains
   subroutine test_simple
     real :: x, y, z
     real :: x_ad, y_ad, z_ad
+    real :: exp_z, exp_x, exp_y
 
     x = 2.0
     y = 3.0
@@ -49,7 +51,15 @@ contains
     z_ad = 1.0
     call simple_ad(x, x_ad, y, y_ad, z_ad)
 
-    print *, z, x_ad, y_ad
+    exp_z = 2.0*x**3 + 2.0*x**2 + 2.0*x + (1.0 + y)
+    exp_x = 6.0*x**2 + 4.0*x + 2.0
+    exp_y = 1.0
+
+    if (abs(z - exp_z) > tol .or. abs(x_ad - exp_x) > tol .or. &
+        abs(y_ad - exp_y) > tol) then
+       print *, 'test_simple failed', z, x_ad, y_ad
+       error stop 1
+    end if
     return
   end subroutine test_simple
 

--- a/tests/fortran_runtime/run_simple_math.f90
+++ b/tests/fortran_runtime/run_simple_math.f90
@@ -2,6 +2,7 @@ program run_simple_math
   use simple_math
   use simple_math_ad
   implicit none
+  real, parameter :: tol = 1.0e-5
 
   integer, parameter :: I_all              = 0
   integer, parameter :: I_add_numbers      = 1
@@ -64,6 +65,7 @@ contains
   subroutine test_add_numbers
     real :: a, b, c
     real :: a_ad, b_ad, c_ad
+    real :: exp_c, exp_a, exp_b
 
     a = 2.0
     b = 3.0
@@ -74,14 +76,22 @@ contains
     c_ad = 1.0
     call add_numbers_ad(a, a_ad, b, b_ad, c_ad)
 
-    print *, c, a_ad, b_ad
+    exp_c = 2.0 * a + b + 3.0
+    exp_a = 2.0
+    exp_b = 1.0
 
+    if (abs(c - exp_c) > tol .or. abs(a_ad - exp_a) > tol .or. &
+        abs(b_ad - exp_b) > tol) then
+       print *, 'test_add_numbers failed', c, a_ad, b_ad
+       error stop 1
+    end if
     return
   end subroutine test_add_numbers
 
   subroutine test_multiply_numbers
     real :: a, b, c
     real :: a_ad, b_ad, c_ad
+    real :: exp_c, exp_a, exp_b
 
     a = 2.0
     b = 3.0
@@ -92,14 +102,22 @@ contains
     c_ad = 1.0
     call multiply_numbers_ad(a, a_ad, b, b_ad, c_ad)
 
-    print *, c, a_ad, b_ad
+    exp_c = a * (3.0 * b + 4.0)
+    exp_a = 3.0 * b + 4.0
+    exp_b = 3.0 * a
 
+    if (abs(c - exp_c) > tol .or. abs(a_ad - exp_a) > tol .or. &
+        abs(b_ad - exp_b) > tol) then
+       print *, 'test_multiply_numbers failed', c, a_ad, b_ad
+       error stop 1
+    end if
     return
   end subroutine test_multiply_numbers
 
   subroutine test_subtract_numbers
     real :: a, b, c
     real :: a_ad, b_ad, c_ad
+    real :: exp_c, exp_a, exp_b
 
     a = 2.0
     b = 3.0
@@ -110,14 +128,22 @@ contains
     c_ad = 1.0
     call subtract_numbers_ad(a, a_ad, b, b_ad, c_ad)
 
-    print *, c, a_ad, b_ad
+    exp_c = -a + 2.0*b
+    exp_a = -1.0
+    exp_b = 2.0
 
+    if (abs(c - exp_c) > tol .or. abs(a_ad - exp_a) > tol .or. &
+        abs(b_ad - exp_b) > tol) then
+       print *, 'test_subtract_numbers failed', c, a_ad, b_ad
+       error stop 1
+    end if
     return
   end subroutine test_subtract_numbers
 
   subroutine test_divide_numbers
     real :: a, b, c
     real :: a_ad, b_ad, c_ad
+    real :: exp_c, exp_a, exp_b, t
 
     a = 2.0
     b = 3.0
@@ -128,14 +154,23 @@ contains
     c_ad = 1.0
     call divide_numbers_ad(a, a_ad, b, b_ad, c_ad)
 
-    print *, c, a_ad, b_ad
+    t = b + 1.5
+    exp_c = a / (2.0 * t) + a
+    exp_a = 1.0 / (2.0 * t) + 1.0
+    exp_b = -a / (2.0 * t * t)
 
+    if (abs(c - exp_c) > tol .or. abs(a_ad - exp_a) > tol .or. &
+        abs(b_ad - exp_b) > tol) then
+       print *, 'test_divide_numbers failed', c, a_ad, b_ad
+       error stop 1
+    end if
     return
   end subroutine test_divide_numbers
 
   subroutine test_power_numbers
     real :: a, b, c
     real :: a_ad, b_ad, c_ad
+    real :: exp_c, exp_a, exp_b
 
     a = 2.0
     b = 3.0
@@ -146,8 +181,19 @@ contains
     c_ad = 1.0
     call power_numbers_ad(a, a_ad, b, b_ad, c_ad)
 
-    print *, c, a_ad, b_ad
+    exp_c = a**3 + b**5.5
+    exp_c = exp_c + a**b + (4.0 * a + 2.0)**b + a**(b * 5.0 + 3.0)
 
+    exp_a = 3.0 * a**2 + b * a**(b - 1.0) + b * 4.0 * (4.0 * a + 2.0)**(b - 1.0) + &
+             (5.0 * b + 3.0) * a**(5.0 * b + 2.0)
+    exp_b = 5.5 * b**4.5 + log(a) * a**b + log(4.0 * a + 2.0) * (4.0 * a + 2.0)**b + &
+             5.0 * log(a) * a**(5.0 * b + 3.0)
+
+    if (abs(c - exp_c) > tol .or. abs(a_ad - exp_a) > tol .or. &
+        abs(b_ad - exp_b) > tol) then
+       print *, 'test_power_numbers failed', c, a_ad, b_ad
+       error stop 1
+    end if
     return
   end subroutine test_power_numbers
 

--- a/tests/test_fortran_runtime.py
+++ b/tests/test_fortran_runtime.py
@@ -27,11 +27,7 @@ class TestFortranRuntime(unittest.TestCase):
             exe = tmp / 'run_add.out'
             cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
             subprocess.check_call(cmd)
-            run = subprocess.run([str(exe), "add_numbers"], stdout=subprocess.PIPE, text=True, check=True)
-            values = [float(v) for v in run.stdout.strip().split()]
-            self.assertAlmostEqual(values[0], 10.0, places=5)
-            self.assertAlmostEqual(values[1], 2.0, places=5)
-            self.assertAlmostEqual(values[2], 1.0, places=5)
+            subprocess.run([str(exe), "add_numbers"], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_multiply_numbers(self):
@@ -47,11 +43,7 @@ class TestFortranRuntime(unittest.TestCase):
             exe = tmp / 'run_multiply.out'
             cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
             subprocess.check_call(cmd)
-            run = subprocess.run([str(exe), "multiply_numbers"], stdout=subprocess.PIPE, text=True, check=True)
-            values = [float(v) for v in run.stdout.strip().split()]
-            self.assertAlmostEqual(values[0], 26.0, places=5)
-            self.assertAlmostEqual(values[1], 13.0, places=5)
-            self.assertAlmostEqual(values[2], 6.0, places=5)
+            subprocess.run([str(exe), "multiply_numbers"], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_subtract_numbers(self):
@@ -67,11 +59,7 @@ class TestFortranRuntime(unittest.TestCase):
             exe = tmp / 'run_subtract.out'
             cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
             subprocess.check_call(cmd)
-            run = subprocess.run([str(exe), "subtract_numbers"], stdout=subprocess.PIPE, text=True, check=True)
-            values = [float(v) for v in run.stdout.strip().split()]
-            self.assertAlmostEqual(values[0], 4.0, places=5)
-            self.assertAlmostEqual(values[1], -1.0, places=5)
-            self.assertAlmostEqual(values[2], 2.0, places=5)
+            subprocess.run([str(exe), "subtract_numbers"], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_divide_numbers(self):
@@ -87,11 +75,7 @@ class TestFortranRuntime(unittest.TestCase):
             exe = tmp / 'run_divide.out'
             cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
             subprocess.check_call(cmd)
-            run = subprocess.run([str(exe), "divide_numbers"], stdout=subprocess.PIPE, text=True, check=True)
-            values = [float(v) for v in run.stdout.strip().split()]
-            self.assertAlmostEqual(values[0], 2.2222222222222223, places=5)
-            self.assertAlmostEqual(values[1], 1.1111111111111112, places=5)
-            self.assertAlmostEqual(values[2], -0.04938271604938271, places=5)
+            subprocess.run([str(exe), "divide_numbers"], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_power_numbers(self):
@@ -107,11 +91,7 @@ class TestFortranRuntime(unittest.TestCase):
             exe = tmp / 'run_power.out'
             cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
             subprocess.check_call(cmd)
-            run = subprocess.run([str(exe), "power_numbers"], stdout=subprocess.PIPE, text=True, check=True)
-            values = [float(v) for v in run.stdout.strip().split()]
-            self.assertAlmostEqual(values[0], 263580.875, places=5)
-            self.assertAlmostEqual(values[1], 2360520.0, places=5)
-            self.assertAlmostEqual(values[2], 911601.625, places=5)
+            subprocess.run([str(exe), "power_numbers"], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_arrays_elementwise_add(self):
@@ -127,11 +107,23 @@ class TestFortranRuntime(unittest.TestCase):
             exe = tmp / 'run_arrays.out'
             cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
             subprocess.check_call(cmd)
-            run = subprocess.run([str(exe), 'elementwise_add'], stdout=subprocess.PIPE, text=True, check=True)
-            values = [float(v) for v in run.stdout.strip().split()]
-            self.assertAlmostEqual(values[0], 9.0, places=5)
-            self.assertAlmostEqual(values[1], 1.0, places=5)
-            self.assertAlmostEqual(values[2], 2.0, places=5)
+            subprocess.run([str(exe), 'elementwise_add'], check=True)
+
+    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
+    def test_arrays_multidimension_fd(self):
+        base = Path(__file__).resolve().parents[1]
+        src = base / 'examples' / 'arrays.f90'
+        code_tree.Node.reset()
+        ad_code = generator.generate_ad(str(src), warn=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            ad_path = tmp / 'arrays_ad.f90'
+            ad_path.write_text(ad_code)
+            driver = Path(__file__).resolve().parent / 'fortran_runtime' / 'run_arrays.f90'
+            exe = tmp / 'run_arrays.out'
+            cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
+            subprocess.check_call(cmd)
+            subprocess.run([str(exe), 'multidimension'], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_control_flow_if_example(self):
@@ -147,10 +139,7 @@ class TestFortranRuntime(unittest.TestCase):
             exe = tmp / 'run_cf.out'
             cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
             subprocess.check_call(cmd)
-            run = subprocess.run([str(exe), 'if_example'], stdout=subprocess.PIPE, text=True, check=True)
-            values = [float(v) for v in run.stdout.strip().split()]
-            self.assertAlmostEqual(values[0], 1.0, places=5)
-            self.assertAlmostEqual(values[1], 1.0, places=5)
+            subprocess.run([str(exe), 'if_example'], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_intrinsic_casting(self):
@@ -166,10 +155,7 @@ class TestFortranRuntime(unittest.TestCase):
             exe = tmp / 'run_intrinsic.out'
             cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
             subprocess.check_call(cmd)
-            run = subprocess.run([str(exe), 'casting'], stdout=subprocess.PIPE, text=True, check=True)
-            values = [float(v) for v in run.stdout.strip().split()]
-            self.assertAlmostEqual(values[0], 8.5, places=5)
-            self.assertAlmostEqual(values[1], 1.0, places=5)
+            subprocess.run([str(exe), 'casting'], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_save_vars_simple(self):
@@ -185,11 +171,7 @@ class TestFortranRuntime(unittest.TestCase):
             exe = tmp / 'run_save_vars.out'
             cmd = [self.compiler, str(src), str(ad_path), str(driver), '-o', str(exe)]
             subprocess.check_call(cmd)
-            run = subprocess.run([str(exe), 'simple'], stdout=subprocess.PIPE, text=True, check=True)
-            values = [float(v) for v in run.stdout.strip().split()]
-            self.assertAlmostEqual(values[0], 32.0, places=5)
-            self.assertAlmostEqual(values[1], 34.0, places=5)
-            self.assertAlmostEqual(values[2], 1.0, places=5)
+            subprocess.run([str(exe), 'simple'], check=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- check Fortran autodiff results inside the runtime drivers
- verify multidimension gradients analytically
- simplify Python tests to rely on exit status

## Testing
- `python tests/test_generator.py`
- `python tests/test_fortran_runtime.py`


------
https://chatgpt.com/codex/tasks/task_b_686009ba3e54832d92bbd94914574dff