### PR TITLE
Handle push/pop in AD generation

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -11,6 +11,15 @@ from fautodiff import code_tree
 class TestGenerator(unittest.TestCase):
     """Tests auto-diff generation for each example file."""
 
+    def test_store_vars_use_data_storage(self):
+        code_tree.Node.reset()
+        generated = generator.generate_ad("examples/store_vars.f90", warn=False)
+        lines = generated.splitlines()
+        self.assertIn("use data_storage", lines[1])
+        idx_use = next(i for i, l in enumerate(lines) if "use data_storage" in l)
+        idx_imp = next(i for i, l in enumerate(lines) if "implicit none" in l)
+        self.assertLess(idx_use, idx_imp)
+
 
 def _make_example_test(src: Path):
     def test(self):


### PR DESCRIPTION
## Summary
- detect PushPop nodes inside routines
- return a flag from `_generate_ad_subroutine`
- insert `use data_storage` in generated module when needed
- test that store_vars uses the data storage module

## Testing
- `pytest tests/test_generator.py::TestGenerator::test_store_vars_use_data_storage -q`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68613eb2345c832d9568495d0ed31f23