### PR TITLE
Prefix runtime module names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,10 @@ This file provides guidelines for contributors about the repository and develop 
   the reversed execution of the routine.
 - Do not introduce additional control flow or modify the numerical logic other
   than inserting the derivative computations.
+
+## 9. Fortran Modules in `fortran_modules`
+- Module names must start with the prefix ``fautodiff_``.
+- Public subroutines provided by these modules must also start with the module
+  name followed by an underscore.  For example, ``data_storage`` becomes
+  ``fautodiff_data_storage`` and its public routine ``push`` is renamed to
+  ``fautodiff_data_storage_push``.

--- a/examples/store_vars_ad.f90
+++ b/examples/store_vars_ad.f90
@@ -1,5 +1,5 @@
 module store_vars_ad
-  use data_storage
+  use fautodiff_data_storage
   implicit none
 
 contains
@@ -16,14 +16,14 @@ contains
 
     work = 1.0
     do i = 1, n
-      call push(work)
+      call fautodiff_data_storage_push(work)
       work = x(i) * work
     end do
 
     work_ad = 0.0
 
     do i = n, 1, - 1
-      call pop(work)
+      call fautodiff_data_storage_pop(work)
       work_save_14_ad = work
       work_ad = z_ad(i) + work_ad ! z(i) = work
       z_ad(i) = 0.0 ! z(i) = work

--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -826,7 +826,8 @@ class PushPop(SaveAssignment):
     def render(self, indent: int = 0) -> List[str]:
         space = "  " * indent
         op = "pop" if self.load else "push"
-        return [f"{space}call {op}({self.var})\n"]
+        op_name = f"fautodiff_data_storage_{op}"
+        return [f"{space}call {op_name}({self.var})\n"]
 
     def to_load(self) -> "PushPop":
         return PushPop(self.var, id=self.id, tmpvar=self.tmpvar, load=True)

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -375,7 +375,7 @@ def generate_ad(in_file, out_file=None, warn=True):
 
         mod = Module(f"{name}_ad")
         if pushpop_used:
-            mod.body.append(Statement("use data_storage"))
+            mod.body.append(Statement("use fautodiff_data_storage"))
         #mod.body.append(Statement(f"use {name}"))
         mod.body.append(Statement("implicit none"))
         for sub in routines:

--- a/fortran_modules/data_storage.f90
+++ b/fortran_modules/data_storage.f90
@@ -1,19 +1,19 @@
-module data_storage
+module fautodiff_data_storage
   implicit none
   private
 
-  public push
-  public pop
+  public fautodiff_data_storage_push
+  public fautodiff_data_storage_pop
 
-  interface push
+  interface fautodiff_data_storage_push
      module procedure push_ary_r4
      module procedure push_scalar_r4
-  end interface push
+  end interface fautodiff_data_storage_push
 
-  interface pop
+  interface fautodiff_data_storage_pop
      module procedure pop_ary_r4
      module procedure pop_scalar_r4
-  end interface pop
+  end interface fautodiff_data_storage_pop
 
 
   type :: ptr_r4_t
@@ -124,4 +124,4 @@ contains
     return
   end subroutine pop_scalar_r4
 
-end module data_storage
+end module fautodiff_data_storage

--- a/tests/fortran_runtime/run_data_storage.f90
+++ b/tests/fortran_runtime/run_data_storage.f90
@@ -1,5 +1,5 @@
 program run_data_storage
-  use data_storage
+  use fautodiff_data_storage
   implicit none
 
   real :: arr(3)
@@ -9,15 +9,15 @@ program run_data_storage
 
   arr = (/10.0, 20.0, 30.0/)
 
-  call push(1.0)
-  call push(2.0)
-  call push(3.0)
-  call push(arr)
+  call fautodiff_data_storage_push(1.0)
+  call fautodiff_data_storage_push(2.0)
+  call fautodiff_data_storage_push(3.0)
+  call fautodiff_data_storage_push(arr)
 
-  call pop(out)
-  call pop(x3)
-  call pop(x2)
-  call pop(x1)
+  call fautodiff_data_storage_pop(out)
+  call fautodiff_data_storage_pop(x3)
+  call fautodiff_data_storage_pop(x2)
+  call fautodiff_data_storage_pop(x1)
 
   ok = .true.
   ok = ok .and. abs(x1 - 1.0) < 1.0e-6

--- a/tests/test_code_tree.py
+++ b/tests/test_code_tree.py
@@ -554,13 +554,13 @@ class TestPushPop(unittest.TestCase):
     def test_push(self):
         var = OpVar("a")
         node = PushPop(var, 100)
-        self.assertEqual(render_program(Block([node])), "call push(a)\n")
+        self.assertEqual(render_program(Block([node])), "call fautodiff_data_storage_push(a)\n")
         self.assertEqual([str(v) for v in node.iter_ref_vars()], ["a"])
 
     def test_pop(self):
         var = OpVar("a")
         node = PushPop(var, 100).to_load()
-        self.assertEqual(render_program(Block([node])), "call pop(a)\n")
+        self.assertEqual(render_program(Block([node])), "call fautodiff_data_storage_pop(a)\n")
         self.assertEqual([str(v) for v in node.iter_assign_vars()], ["a"])
 
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -15,8 +15,8 @@ class TestGenerator(unittest.TestCase):
         code_tree.Node.reset()
         generated = generator.generate_ad("examples/store_vars.f90", warn=False)
         lines = generated.splitlines()
-        self.assertIn("use data_storage", lines[1])
-        idx_use = next(i for i, l in enumerate(lines) if "use data_storage" in l)
+        self.assertIn("use fautodiff_data_storage", lines[1])
+        idx_use = next(i for i, l in enumerate(lines) if "use fautodiff_data_storage" in l)
         idx_imp = next(i for i, l in enumerate(lines) if "implicit none" in l)
         self.assertLess(idx_use, idx_imp)
 


### PR DESCRIPTION
## Summary
- rename `data_storage` module to `fautodiff_data_storage`
- prefix public routines with module name
- adjust generator and code tree to use new names
- update examples and runtime tests
- document naming rule in `AGENTS.md`

## Testing
- `python tests/test_generator.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_6861482c69e8832d88e0b523baf9c1dd