### PR TITLE
Support querying call argument types

### DIFF
--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -859,7 +859,11 @@ class SaveAssignment(Node):
             raise RuntimeError(f"Variable has aleady saved: {name}")
         if self.tmpvar is None:
             self.var = self.var.deep_clone()
-            self.tmpvar = OpVar(self._save_var_name(name, id), index=self.var.index, is_real=self.var.is_real)
+            self.tmpvar = OpVar(
+                self._save_var_name(name, self.id),
+                index=self.var.index,
+                is_real=self.var.is_real,
+            )
         if self.load:
             self.lhs = self.var
             self.rhs = self.tmpvar

--- a/fautodiff/operators.py
+++ b/fautodiff/operators.py
@@ -778,6 +778,15 @@ class OpLog(OpBinary):
         a1 = self._paren(self.args[1], eq=eq)
         return f"{a0} {self.op} {a1}"
 
+INTRINSIC_FUNCTIONS = {
+    'abs', 'sqrt', 'exp', 'log', 'log10', 'sin', 'cos', 'tan', 'asin',
+    'acos', 'atan', 'sinh', 'cosh', 'tanh', 'asinh', 'acosh', 'atanh',
+    'erf', 'erfc', 'real', 'dble', 'mod', 'min', 'max', 'sign', 'atan2',
+    'transpose', 'cshift', 'len', 'len_trim', 'adjustl', 'index', 'lbound',
+    'ubound', 'size', 'epsilon', 'huge', 'tiny', 'ichar', 'achar', 'int',
+    'nint'
+}
+
 NONDIFF_INTRINSICS = {
     'len',
     'len_trim',


### PR DESCRIPTION
## Summary
- keep routine mapping when generating AD code
- populate CallStatement intents from routine declarations
- recognize intrinsic functions during parsing
- convert OpFuncUser nodes for known intrinsics in parser
- fix temporary variable naming in `SaveAssignment`
- store list of intrinsic function names in `operators.py`

## Testing
- `python tests/test_generator.py -q`


------
https://chatgpt.com/codex/tasks/task_b_6862376ea51c832db5f64d7d1db15e2e