### PR TITLE
Support AD calls for CallStatement nodes

### DIFF
--- a/examples/arrays_ad.f90
+++ b/examples/arrays_ad.f90
@@ -23,6 +23,11 @@ contains
     integer, intent(in)  :: n
     real, intent(inout) :: a(n)
     real, intent(inout) :: a_ad(n)
+    integer :: i
+
+    do i = n, 1, - 1
+      a_ad(i) = a_ad(i) * 2.0 ! a(i) = a(i) * 2.0
+    end do
 
     return
   end subroutine scale_array_ad

--- a/examples/call_example.f90
+++ b/examples/call_example.f90
@@ -1,0 +1,11 @@
+module call_example
+contains
+  subroutine foo(a)
+    real, intent(inout) :: a
+    a = a * 2.0
+  end subroutine foo
+  subroutine bar(x)
+    real, intent(inout) :: x
+    call foo(x)
+  end subroutine bar
+end module call_example

--- a/examples/call_example.f90
+++ b/examples/call_example.f90
@@ -1,11 +1,22 @@
 module call_example
+  implicit none
+
 contains
+
   subroutine foo(a)
     real, intent(inout) :: a
+
     a = a * 2.0
+
+    return
   end subroutine foo
+
   subroutine bar(x)
     real, intent(inout) :: x
+
     call foo(x)
+
+    return
   end subroutine bar
+
 end module call_example

--- a/examples/call_example_ad.f90
+++ b/examples/call_example_ad.f90
@@ -1,0 +1,24 @@
+module call_example_ad
+  implicit none
+
+contains
+
+  subroutine foo_ad(a, a_ad)
+    real, intent(inout) :: a
+    real, intent(inout) :: a_ad
+
+    return
+  end subroutine foo_ad
+
+  subroutine bar_ad(x, x_ad)
+    real, intent(inout) :: x
+    real, intent(inout) :: x_ad
+
+    call foo(x)
+
+    call foo_ad(x, x_ad)
+
+    return
+  end subroutine bar_ad
+
+end module call_example_ad

--- a/examples/call_example_ad.f90
+++ b/examples/call_example_ad.f90
@@ -7,6 +7,8 @@ contains
     real, intent(inout) :: a
     real, intent(inout) :: a_ad
 
+    a_ad = a_ad * 2.0 ! a = a * 2.0
+
     return
   end subroutine foo_ad
 

--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -196,6 +196,14 @@ class Node:
     def set_parent(self, node: "Node") -> "Node":
         self.parent = node
 
+    def get_routine(self) -> Optional["Routine"]:
+        node: Optional[Node] = self
+        while node is not None:
+            if isinstance(node, Routine):
+                return node
+            node = node.parent
+        return None
+
     def find_by_id(self, node_id: int) -> Optional["Node"]:
         """Return the node with ``node_id`` from this subtree or ``None``."""
         if self.__id == node_id:
@@ -604,6 +612,7 @@ class Routine(Node):
     content: Block = field(default_factory=Block)
     ad_init: Optional[Block] = None
     ad_content: Optional[Block] = None
+    ad_arg_info: Optional[tuple] = None
     kind: ClassVar[str] = "subroutine"
 
     def _all_blocks(self):


### PR DESCRIPTION
## Summary
- handle `CallStatement` when generating AD subroutines
- ensure gradient arguments are added and gradient variables declared
- extend variable analysis for `CallStatement`
- add a new example demonstrating AD on a routine calling another routine

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68624595f378832d912db110e628747c