### PR TITLE
Add examples for REAL kind values

### DIFF
--- a/examples/real_kind.f90
+++ b/examples/real_kind.f90
@@ -1,0 +1,25 @@
+module real_kind
+  implicit none
+  integer, parameter :: RP = kind(1.0d0)
+
+contains
+
+  subroutine scale_8(x)
+    real(kind=8), intent(inout) :: x
+    x = x * 2.0_8
+    return
+  end subroutine scale_8
+
+  subroutine scale_rp(x)
+    real(kind=RP), intent(inout) :: x
+    x = x * 2.0_RP
+    return
+  end subroutine scale_rp
+
+  subroutine scale_dp(x)
+    double precision, intent(inout) :: x
+    x = x * 2.0d0
+    return
+  end subroutine scale_dp
+
+end module real_kind

--- a/examples/real_kind_ad.f90
+++ b/examples/real_kind_ad.f90
@@ -1,0 +1,33 @@
+module real_kind_ad
+  implicit none
+
+contains
+
+  subroutine scale_8_ad(x, x_ad)
+    real(8), intent(inout) :: x
+    real(8), intent(inout) :: x_ad
+
+    x_ad = x_ad * 2.0d0 ! x = x * 2.0_8
+
+    return
+  end subroutine scale_8_ad
+
+  subroutine scale_rp_ad(x, x_ad)
+    real(RP), intent(inout) :: x
+    real(RP), intent(inout) :: x_ad
+
+    x_ad = x_ad * 2.0_RP ! x = x * 2.0_RP
+
+    return
+  end subroutine scale_rp_ad
+
+  subroutine scale_dp_ad(x, x_ad)
+    double precision, intent(inout) :: x
+    double precision, intent(inout) :: x_ad
+
+    x_ad = x_ad * 2.0e0d0 ! x = x * 2.0d0
+
+    return
+  end subroutine scale_dp_ad
+
+end module real_kind_ad

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -95,6 +95,53 @@ class TestParser(unittest.TestCase):
         self.assertIsInstance(stmt.rhs, operators.OpFuncUser)
         self.assertEqual(stmt.rhs.name, "foo")
 
+    def test_parse_real_kind_8(self):
+        src = textwrap.dedent("""\
+        module test
+        contains
+          subroutine foo(x)
+            real(kind=8) :: x
+          end subroutine foo
+        end module test
+        """)
+        module = parser.parse_src(src)[0]
+        routine = module.routines[0]
+        decl = routine.decls.find_by_name("x")
+        self.assertIsNotNone(decl)
+        self.assertEqual(decl.kind, "8")
+
+    def test_parse_real_kind_rp(self):
+        src = textwrap.dedent("""\
+        module test
+        integer, parameter :: RP = kind(1.0d0)
+        contains
+          subroutine foo(x)
+            real(kind=RP) :: x
+          end subroutine foo
+        end module test
+        """)
+        module = parser.parse_src(src)[0]
+        routine = module.routines[0]
+        decl = routine.decls.find_by_name("x")
+        self.assertIsNotNone(decl)
+        self.assertEqual(decl.kind, "RP")
+
+    def test_parse_double_precision(self):
+        src = textwrap.dedent("""\
+        module test
+        contains
+          subroutine foo(x)
+            double precision :: x
+          end subroutine foo
+        end module test
+        """)
+        module = parser.parse_src(src)[0]
+        routine = module.routines[0]
+        decl = routine.decls.find_by_name("x")
+        self.assertIsNotNone(decl)
+        self.assertEqual(decl.typename.lower(), "double precision")
+        self.assertIsNone(decl.kind)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support kind selector for REAL declarations
- test REAL(kind=8) and REAL(kind=RP)
- add new example using REAL(kind=8), REAL(kind=RP) and DOUBLE PRECISION
- update example computations so AD output includes operations
- parse double precision declarations correctly

## Testing
- `python -m pytest tests/test_parser.py::TestParser::test_parse_real_kind_8 tests/test_parser.py::TestParser::test_parse_real_kind_rp tests/test_parser.py::TestParser::test_parse_double_precision -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6863af1be6e8832d93ea6c16ff857b31