### PR TITLE
Add fadmod info files and cross-module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ differentiate.  Use ``--no-warn`` to silence these messages:
 python -m fautodiff.generator --no-warn examples/simple_math.f90
 ```
 
+Each module's routine signatures are also written to a `<module>.fadmod` file
+when AD code is generated.  These JSON files can be loaded when differentiating
+another file that uses the module.  Add search directories with ``-I`` (repeat
+as needed) and disable writing with ``--no-fadmod``:
+
+```bash
+python -m fautodiff.generator -I examples examples/cross_mod_b.f90
+```
+
 Run the included tests with:
 
 ```bash

--- a/examples/cross_mod_a.f90
+++ b/examples/cross_mod_a.f90
@@ -1,0 +1,8 @@
+module cross_mod_a
+  implicit none
+contains
+  subroutine incval(a)
+    real, intent(inout) :: a
+    a = a + 1.0
+  end subroutine incval
+end module cross_mod_a

--- a/examples/cross_mod_a_ad.f90
+++ b/examples/cross_mod_a_ad.f90
@@ -1,0 +1,13 @@
+module cross_mod_a_ad
+  implicit none
+
+contains
+
+  subroutine incval_ad(a, a_ad)
+    real, intent(inout) :: a
+    real, intent(inout) :: a_ad
+
+    return
+  end subroutine incval_ad
+
+end module cross_mod_a_ad

--- a/examples/cross_mod_b.f90
+++ b/examples/cross_mod_b.f90
@@ -1,0 +1,9 @@
+module cross_mod_b
+  use cross_mod_a
+  implicit none
+contains
+  subroutine call_inc(b)
+    real, intent(inout) :: b
+    call incval(b)
+  end subroutine call_inc
+end module cross_mod_b

--- a/examples/cross_mod_b_ad.f90
+++ b/examples/cross_mod_b_ad.f90
@@ -1,0 +1,15 @@
+module cross_mod_b_ad
+  implicit none
+
+contains
+
+  subroutine call_inc_ad(b, b_ad)
+    real, intent(inout) :: b
+    real, intent(inout) :: b_ad
+
+    call incval_ad(b, b_ad) ! call incval(b)
+
+    return
+  end subroutine call_inc_ad
+
+end module cross_mod_b_ad

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -20,6 +20,29 @@ class TestGenerator(unittest.TestCase):
         idx_imp = next(i for i, l in enumerate(lines) if "implicit none" in l)
         self.assertLess(idx_use, idx_imp)
 
+    def test_cross_mod_a_writes_fadmod(self):
+        code_tree.Node.reset()
+        src = Path("examples/cross_mod_a.f90")
+        fadmod = src.with_name("cross_mod_a.fadmod")
+        if fadmod.exists():
+            fadmod.unlink()
+        generated = generator.generate_ad(str(src), warn=False)
+        expected = src.with_name("cross_mod_a_ad.f90").read_text()
+        self.assertEqual(generated, expected)
+        self.assertTrue(fadmod.exists())
+
+    def test_cross_mod_b_loads_fadmod(self):
+        code_tree.Node.reset()
+        # ensure fadmod exists
+        generator.generate_ad("examples/cross_mod_a.f90", warn=False)
+        generated = generator.generate_ad(
+            "examples/cross_mod_b.f90",
+            warn=False,
+            search_dirs=["examples"],
+        )
+        expected = Path("examples/cross_mod_b_ad.f90").read_text()
+        self.assertEqual(generated, expected)
+
 
 def _make_example_test(src: Path):
     def test(self):
@@ -33,7 +56,7 @@ def _make_example_test(src: Path):
 
 examples_dir = Path("examples")
 for _src in sorted(examples_dir.glob("*.f90")):
-    if _src.name.endswith("_ad.f90"):
+    if _src.name.endswith("_ad.f90") or _src.stem in {"cross_mod_a", "cross_mod_b"}:
         continue
     test_name = f"test_{_src.stem}"
     setattr(TestGenerator, test_name, _make_example_test(_src))


### PR DESCRIPTION
## Summary
- add ability to write routine information to `.fadmod` files
- load needed `.fadmod` files from search directories
- extend CLI with `-I` (repeatable) and `--no-fadmod`
- add cross-module examples and update README
- test generator with cross-module scenario
- document that `-I` can be repeated

## Testing
- `python tests/test_generator.py`
- `python tests/test_fortran_runtime.py`


------
https://chatgpt.com/codex/tasks/task_b_6863b4c7afc8832db2bad3a1d84ce97e