### PR TITLE
Add runtime tests for more Fortran examples

### DIFF
--- a/tests/fortran_runtime/run_call_example.f90
+++ b/tests/fortran_runtime/run_call_example.f90
@@ -1,0 +1,157 @@
+program run_call_example
+  use call_example
+  use call_example_ad
+  implicit none
+  real, parameter :: tol = 1.0e-5
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_call_subroutine = 1
+  integer, parameter :: I_call_fucntion = 2
+  integer, parameter :: I_arg_operation = 3
+  integer, parameter :: I_arg_function = 4
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("call_subroutine")
+              i_test = I_call_subroutine
+           case ("call_fucntion")
+              i_test = I_call_fucntion
+           case ("arg_operation")
+              i_test = I_arg_operation
+           case ("arg_function")
+              i_test = I_arg_function
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_call_subroutine .or. i_test == I_all) then
+     call test_call_subroutine
+  end if
+  if (i_test == I_call_fucntion .or. i_test == I_all) then
+     call test_call_fucntion
+  end if
+  if (i_test == I_arg_operation .or. i_test == I_all) then
+     call test_arg_operation
+  end if
+  if (i_test == I_arg_function .or. i_test == I_all) then
+     call test_arg_function
+  end if
+
+  stop
+contains
+
+  subroutine test_call_subroutine
+    real :: x, y
+    real :: x_ad, y_ad
+    real :: exp_x, exp_x_ad, exp_y_ad
+
+    x = 1.0
+    y = 2.0
+    call call_subroutine(x, y)
+
+    x_ad = 1.0
+    y_ad = 0.0
+    call call_subroutine_ad(x, x_ad, y, y_ad)
+
+    exp_x = 4.0
+    exp_x_ad = 2.0
+    exp_y_ad = 1.0
+
+    if (abs(x - exp_x) > tol .or. abs(x_ad - exp_x_ad) > tol .or. &
+        abs(y_ad - exp_y_ad) > tol) then
+       print *, 'test_call_subroutine failed', x, x_ad, y_ad
+       error stop 1
+    end if
+    return
+  end subroutine test_call_subroutine
+
+  subroutine test_call_fucntion
+    real :: x, y
+    real :: x_ad, y_ad
+    real :: exp_x, exp_x_ad, exp_y_ad
+
+    y = 3.0
+    call call_fucntion(x, y)
+
+    x_ad = 1.0
+    y_ad = 0.0
+    call call_fucntion_ad(x_ad, y, y_ad)
+
+    exp_x = y**2
+    exp_x_ad = 0.0
+    exp_y_ad = 2.0 * y
+
+    if (abs(x - exp_x) > tol .or. abs(x_ad - exp_x_ad) > tol .or. &
+        abs(y_ad - exp_y_ad) > tol) then
+       print *, 'test_call_fucntion failed', x, x_ad, y_ad
+       error stop 1
+    end if
+    return
+  end subroutine test_call_fucntion
+
+  subroutine test_arg_operation
+    real :: x, y
+    real :: x_ad, y_ad
+    real :: exp_x, exp_x_ad, exp_y_ad
+
+    x = 1.0
+    y = 2.0
+    call arg_operation(x, y)
+
+    x_ad = 1.0
+    y_ad = 0.0
+    call arg_operation_ad(x, x_ad, y, y_ad)
+
+    exp_x = 6.0
+    exp_x_ad = 2.0
+    exp_y_ad = 2.0
+
+    if (abs(x - exp_x) > tol .or. abs(x_ad - exp_x_ad) > tol .or. &
+        abs(y_ad - exp_y_ad) > tol) then
+       print *, 'test_arg_operation failed', x, x_ad, y_ad
+       error stop 1
+    end if
+    return
+  end subroutine test_arg_operation
+
+  subroutine test_arg_function
+    real :: x, y
+    real :: x_ad, y_ad
+    real :: exp_x, exp_x_ad, exp_y_ad
+
+    x = 1.0
+    y = 2.0
+    call arg_function(x, y)
+
+    x_ad = 1.0
+    y_ad = 0.0
+    call arg_function_ad(x, x_ad, y, y_ad)
+
+    exp_x = 6.0
+    exp_x_ad = 2.0
+    exp_y_ad = 4.0
+
+    if (abs(x - exp_x) > tol .or. abs(x_ad - exp_x_ad) > tol .or. &
+        abs(y_ad - exp_y_ad) > tol) then
+       print *, 'test_arg_function failed', x, x_ad, y_ad
+       error stop 1
+    end if
+    return
+  end subroutine test_arg_function
+
+end program run_call_example

--- a/tests/fortran_runtime/run_cross_mod.f90
+++ b/tests/fortran_runtime/run_cross_mod.f90
@@ -1,0 +1,33 @@
+program run_cross_mod
+  use cross_mod_b
+  use cross_mod_b_ad
+  implicit none
+  real, parameter :: tol = 1.0e-5
+
+  call test_call_inc
+
+  stop
+contains
+
+  subroutine test_call_inc
+    real :: x
+    real :: x_ad
+    real :: exp_x, exp_x_ad
+
+    x = 1.0
+    call call_inc(x)
+
+    x_ad = 1.0
+    call call_inc_ad(x, x_ad)
+
+    exp_x = 2.0
+    exp_x_ad = 1.0
+
+    if (abs(x - exp_x) > tol .or. abs(x_ad - exp_x_ad) > tol) then
+       print *, 'test_call_inc failed', x, x_ad
+       error stop 1
+    end if
+    return
+  end subroutine test_call_inc
+
+end program run_cross_mod

--- a/tests/fortran_runtime/run_real_kind.f90
+++ b/tests/fortran_runtime/run_real_kind.f90
@@ -1,0 +1,112 @@
+program run_real_kind
+  use real_kind
+  use real_kind_ad
+  implicit none
+  real, parameter :: tol = 1.0e-5
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_scale_8 = 1
+  integer, parameter :: I_scale_rp = 2
+  integer, parameter :: I_scale_dp = 3
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case("scale_8")
+              i_test = I_scale_8
+           case("scale_rp")
+              i_test = I_scale_rp
+           case("scale_dp")
+              i_test = I_scale_dp
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_scale_8 .or. i_test == I_all) then
+     call test_scale_8
+  end if
+  if (i_test == I_scale_rp .or. i_test == I_all) then
+     call test_scale_rp
+  end if
+  if (i_test == I_scale_dp .or. i_test == I_all) then
+     call test_scale_dp
+  end if
+
+  stop
+contains
+
+  subroutine test_scale_8
+    real(8) :: x, x_ad
+    real(8) :: exp_x, exp_x_ad
+
+    x = 2.0_8
+    call scale_8(x)
+
+    x_ad = 1.0_8
+    call scale_8_ad(x, x_ad)
+
+    exp_x = 4.0_8
+    exp_x_ad = 2.0_8
+
+    if (abs(x - exp_x) > tol .or. abs(x_ad - exp_x_ad) > tol) then
+       print *, 'test_scale_8 failed', x, x_ad
+       error stop 1
+    end if
+    return
+  end subroutine test_scale_8
+
+  subroutine test_scale_rp
+    real(RP) :: x, x_ad
+    real(RP) :: exp_x, exp_x_ad
+
+    x = 2.0_RP
+    call scale_rp(x)
+
+    x_ad = 1.0_RP
+    call scale_rp_ad(x, x_ad)
+
+    exp_x = 4.0_RP
+    exp_x_ad = 2.0_RP
+
+    if (abs(x - exp_x) > tol .or. abs(x_ad - exp_x_ad) > tol) then
+       print *, 'test_scale_rp failed', x, x_ad
+       error stop 1
+    end if
+    return
+  end subroutine test_scale_rp
+
+  subroutine test_scale_dp
+    double precision :: x, x_ad
+    double precision :: exp_x, exp_x_ad
+
+    x = 2.0d0
+    call scale_dp(x)
+
+    x_ad = 1.0d0
+    call scale_dp_ad(x, x_ad)
+
+    exp_x = 4.0d0
+    exp_x_ad = 2.0d0
+
+    if (abs(x - exp_x) > tol .or. abs(x_ad - exp_x_ad) > tol) then
+       print *, 'test_scale_dp failed', x, x_ad
+       error stop 1
+    end if
+    return
+  end subroutine test_scale_dp
+
+end program run_real_kind

--- a/tests/fortran_runtime/run_store_vars.f90
+++ b/tests/fortran_runtime/run_store_vars.f90
@@ -1,0 +1,39 @@
+program run_store_vars
+  use store_vars
+  use store_vars_ad
+  implicit none
+  real, parameter :: tol = 1.0e-5
+
+  call test_do_with_recurrent_scalar
+
+  stop
+contains
+
+  subroutine test_do_with_recurrent_scalar
+    integer, parameter :: n = 3
+    real :: x(n), z(n)
+    real :: x_ad(n), z_ad(n)
+    real :: exp_z, exp_x1, exp_x2, exp_x3
+
+    x = (/2.0, 3.0, 4.0/)
+    call do_with_recurrent_scalar(n, x, z)
+
+    x_ad = 0.0
+    z_ad = 0.0
+    z_ad(n) = 1.0
+    call do_with_recurrent_scalar_ad(n, x, x_ad, z_ad)
+
+    exp_z = x(1) * x(2) * x(3)
+    exp_x1 = x(2) * x(3)
+    exp_x2 = x(1) * x(3)
+    exp_x3 = x(1) * x(2)
+
+    if (abs(z(n) - exp_z) > tol .or. abs(x_ad(1) - exp_x1) > tol .or. &
+        abs(x_ad(2) - exp_x2) > tol .or. abs(x_ad(3) - exp_x3) > tol) then
+       print *, 'test_do_with_recurrent_scalar failed', z(n), x_ad
+       error stop 1
+    end if
+    return
+  end subroutine test_do_with_recurrent_scalar
+
+end program run_store_vars


### PR DESCRIPTION
## Summary
- add runtime drivers for call_example, cross module, real_kind and store_vars
- extend `test_fortran_runtime.py` to compile and run all examples

## Testing
- `python tests/test_generator.py`
- `python tests/test_fortran_runtime.py`


------
https://chatgpt.com/codex/tasks/task_b_6863b8c51898832db6ac1584a7ef214f