### PR TITLE
Add fadmod directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,14 @@ python -m fautodiff.generator --no-warn examples/simple_math.f90
 Each module's routine signatures are also written to a `<module>.fadmod` file
 when AD code is generated.  These JSON files can be loaded when differentiating
 another file that uses the module.  Add search directories with ``-I`` (repeat
-as needed) and disable writing with ``--no-fadmod``:
+as needed), choose the output directory with ``-M DIR`` (defaults to the current
+directory), and disable writing with ``--no-fadmod``:
 
 ```bash
+# write ``cross_mod_a.fadmod`` under ``examples``
+python -m fautodiff.generator -M examples examples/cross_mod_a.f90
+
+# load that file when differentiating another module
 python -m fautodiff.generator -I examples examples/cross_mod_b.f90
 ```
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -23,7 +23,7 @@ class TestGenerator(unittest.TestCase):
     def test_cross_mod_a_writes_fadmod(self):
         code_tree.Node.reset()
         src = Path("examples/cross_mod_a.f90")
-        fadmod = src.with_name("cross_mod_a.fadmod")
+        fadmod = Path("cross_mod_a.fadmod")
         if fadmod.exists():
             fadmod.unlink()
         generated = generator.generate_ad(str(src), warn=False)
@@ -33,12 +33,12 @@ class TestGenerator(unittest.TestCase):
 
     def test_cross_mod_b_loads_fadmod(self):
         code_tree.Node.reset()
-        # ensure fadmod exists
+        # ensure fadmod exists in current directory
         generator.generate_ad("examples/cross_mod_a.f90", warn=False)
         generated = generator.generate_ad(
             "examples/cross_mod_b.f90",
             warn=False,
-            search_dirs=["examples"],
+            search_dirs=["."],
         )
         expected = Path("examples/cross_mod_b_ad.f90").read_text()
         self.assertEqual(generated, expected)


### PR DESCRIPTION
## Summary
- support specifying fadmod output directory with `fadmod_dir`
- expose `-M` CLI option for the directory
- document the new flag
- adjust tests for default fadmod location

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_6863e88a5ba8832d963842a388063c12