### PR TITLE
Add AD module dependencies in generated code

### DIFF
--- a/examples/cross_mod_b_ad.f90
+++ b/examples/cross_mod_b_ad.f90
@@ -1,6 +1,7 @@
 module cross_mod_b_ad
   use cross_mod_b
   use cross_mod_a
+  use cross_mod_a_ad
   implicit none
 
 contains

--- a/tests/test_fortran_runtime.py
+++ b/tests/test_fortran_runtime.py
@@ -198,7 +198,9 @@ class TestFortranRuntime(unittest.TestCase):
             tmp_b = tmp / 'cross_mod_b.f90'
             tmp_a.write_text(src_a.read_text())
             tmp_b.write_text(src_b.read_text())
-            ad_code_a = generator.generate_ad(str(tmp_a), warn=False)
+            ad_code_a = generator.generate_ad(
+                str(tmp_a), warn=False, fadmod_dir=str(tmp)
+            )
             ad_path_a = tmp / 'cross_mod_a_ad.f90'
             ad_path_a.write_text(ad_code_a)
             ad_code_b = generator.generate_ad(str(tmp_b), warn=False, search_dirs=[str(tmp)])


### PR DESCRIPTION
## Summary
- include the defining module name when writing `.fadmod` files
- detect AD routine calls and add corresponding `*_ad` modules to `use` statements
- update generated example for cross-module call
- adjust runtime test to store `.fadmod` alongside temporary sources

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68647c198fb4832d937f2d5f1f2590ef