### PR TITLE
Rename parameter flag

### DIFF
--- a/examples/parameter_var.f90
+++ b/examples/parameter_var.f90
@@ -1,0 +1,10 @@
+module parameter_var
+  implicit none
+contains
+  subroutine compute_area(r, area)
+    real, intent(in) :: r
+    real, intent(out) :: area
+    real, parameter :: pi = 3.14159
+    area = pi * r * r
+  end subroutine compute_area
+end module parameter_var

--- a/examples/parameter_var_ad.f90
+++ b/examples/parameter_var_ad.f90
@@ -1,0 +1,19 @@
+module parameter_var_ad
+  use parameter_var
+  implicit none
+
+contains
+
+  subroutine compute_area_ad(r, r_ad, area_ad)
+    real, intent(in)  :: r
+    real, intent(out) :: r_ad
+    real, intent(inout) :: area_ad
+    real, parameter :: pi = 3.14159
+
+    r_ad = area_ad * (pi * r + pi * r) ! area = pi * r * r
+    area_ad = 0.0 ! area = pi * r * r
+
+    return
+  end subroutine compute_area_ad
+
+end module parameter_var_ad

--- a/fautodiff/var_list.py
+++ b/fautodiff/var_list.py
@@ -102,7 +102,14 @@ class VarList:
                 else:
                     index_new.append(idx)
             if replaced:
-                return OpVar(var.name, index=index_new, is_real=var.is_real)
+                return OpVar(
+                    var.name,
+                    index=index_new,
+                    kind=var.kind,
+                    typename=var.typename,
+                    ad_target=var.ad_target,
+                    is_constant=var.is_constant,
+                )
         return var
 
     def push(self, var: OpVar, not_reorganize: bool = False) -> None:


### PR DESCRIPTION
## Summary
- preserve parameter attributes when parsing declarations
- carry parameter flag and initializer through code generation
- regenerate parameter variable example

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_68647bb1b1f4832d88200ab6eb400c71