### PR TITLE
Add directive const arg example

### DIFF
--- a/examples/directive_const_arg.f90
+++ b/examples/directive_const_arg.f90
@@ -1,0 +1,13 @@
+module directive_const_arg
+  implicit none
+contains
+!$FAD CONSTANT_ARGS: k
+  subroutine add_const(i, j, k)
+    real, intent(in) :: i
+    real, intent(out) :: j
+    real, intent(in) :: k
+
+    j = i + k
+  end subroutine add_const
+end module directive_const_arg
+

--- a/examples/directive_const_arg_ad.f90
+++ b/examples/directive_const_arg_ad.f90
@@ -1,0 +1,19 @@
+module directive_const_arg_ad
+  use directive_const_arg
+  implicit none
+
+contains
+
+  subroutine add_const_ad(i, i_ad, j_ad, k)
+    real, intent(in)  :: i
+    real, intent(out) :: i_ad
+    real, intent(inout) :: j_ad
+    real, intent(in)  :: k
+
+    i_ad = j_ad ! j = i + k
+    j_ad = 0.0 ! j = i + k
+
+    return
+  end subroutine add_const_ad
+
+end module directive_const_arg_ad

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -167,6 +167,18 @@ class TestParser(unittest.TestCase):
         var = routine.get_var("x")
         self.assertTrue(var.is_constant)
 
+    def test_parse_file_directive_constant_args(self):
+        base = Path(__file__).resolve().parents[1]
+        src = base / "examples" / "directive_const_arg.f90"
+        modules = parser.parse_file(str(src))
+        routine = modules[0].routines[0]
+        self.assertIn("CONSTANT_ARGS", routine.directives)
+        self.assertEqual(routine.directives["CONSTANT_ARGS"], ["k"])
+        decl = routine.decls.find_by_name("k")
+        self.assertTrue(decl.constant)
+        var = routine.get_var("k")
+        self.assertTrue(var.is_constant)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- showcase CONSTANT_ARGS directive in new example
- add expected autodiff output
- extend parser tests to check directive handling with parse_file

## Testing
- `python tests/test_generator.py`
- `python tests/test_parser.py`


------
https://chatgpt.com/codex/tasks/task_b_6864d69053b8832dbf067ef99216495a