### PR TITLE
Fix DoWhile iter_ref_vars

### DIFF
--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -1480,7 +1480,7 @@ class DoWhile(DoAbst):
         self.do_index_list = ["__nerver_match__"]
 
     def iter_ref_vars(self) -> Iterator[OpVar]:
-        iter(self.cond.collect_vars())
+        yield from self.cond.collect_vars()
 
     def build_do_index_list(self, index_list: List[str]) -> None:
         for child in self.iter_children():

--- a/tests/test_code_tree.py
+++ b/tests/test_code_tree.py
@@ -984,6 +984,13 @@ class TestDoWhile(unittest.TestCase):
         self.assertEqual(render_program(loop), code)
         self.assertEqual({str(v) for v in loop.required_vars()}, {"b", "cond"})
 
+    def test_iter_ref_vars(self):
+        body = Block([
+            Assignment(OpVar('a'), OpVar('b'))
+        ])
+        loop = DoWhile(body, OpVar('cond'))
+        self.assertEqual({str(v) for v in loop.iter_ref_vars()}, {"cond"})
+
     def test_check_initial(self):
         code = textwrap.dedent("""\
         do while (flag)


### PR DESCRIPTION
## Summary
- ensure DoWhile.iter_ref_vars yields variables from the loop condition
- test that DoWhile.iter_ref_vars returns the condition variable

## Testing
- `python tests/test_code_tree.py`
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_6864dcac2424832dac150c6eed81bab0