### PR TITLE
Fix typos in control flow classes

### DIFF
--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -1243,8 +1243,8 @@ class DoLoop(DoAbst):
     """A ``do`` loop."""
 
     index: OpVar
-    start: Operaion
-    end: Operaion
+    start: Operator
+    end: Operator
     step: Optional[Operator] = None
 
     def __post_init__(self):
@@ -1477,7 +1477,7 @@ class DoWhile(DoAbst):
     cond: OpVar
 
     def __post_init__(self):
-        self.do_index_list = ["__nerver_match__"]
+        self.do_index_list = ["__never_match__"]
 
     def iter_ref_vars(self) -> Iterator[OpVar]:
         yield from self.cond.collect_vars()


### PR DESCRIPTION
## Summary
- correct `DoLoop` field annotations
- fix typo in `DoWhile.__post_init__`
- run unit tests

## Testing
- `python -m unittest tests.test_generator -v`

------
https://chatgpt.com/codex/tasks/task_b_6864dcd76150832dab83fc331c103b1f