### PR TITLE
Add forward mode AD generation

### DIFF
--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -320,7 +320,7 @@ def _generate_rev_ad_subroutine(routine_org, routine_map, warnings):
     _set_call_intents(routine_org.content)
 
     saved_vars = []
-    ad_code = routine_org.content.convert_assignments(
+    ad_code = routine_org.content.generate_ad(
         saved_vars, reverse=True, routine_map=routine_map, warnings=warnings
     )[0]
     #print("subroutine: ", subroutine.name) # for debug
@@ -514,7 +514,7 @@ def _generate_fwd_ad_subroutine(routine_org, routine_map, warnings):
     _set_call_intents(routine_org.content)
 
     saved_vars = []
-    ad_code = routine_org.content.convert_assignments(
+    ad_code = routine_org.content.generate_ad(
         saved_vars, reverse=False, routine_map=routine_map, warnings=warnings
     )[0]
 


### PR DESCRIPTION
## Summary
- add forward AD generation support
- rename convert_assignments->generate_ad
- implement `_generate_ad_forward`

## Testing
- `python -m pytest -q` *(fails: ld returned 1 exit status)*

------
https://chatgpt.com/codex/tasks/task_b_6864fa5bb918832d84d43cd8ac3af611