### PR TITLE
Fix runtime tests for updated AD routine names

### DIFF
--- a/tests/fortran_runtime/run_arrays.f90
+++ b/tests/fortran_runtime/run_arrays.f90
@@ -62,7 +62,7 @@ contains
     a_ad = 0.0
     b_ad = 0.0
     c_ad = 1.0
-    call elementwise_add_ad(n, a, a_ad, b, b_ad, c_ad)
+    call elementwise_add_rev_ad(n, a, a_ad, b, b_ad, c_ad)
 
     exp_c = a(1) + 2.0 * b(1)
     exp_a = 1.0
@@ -89,7 +89,7 @@ contains
     a_ad = 0.0
     b_ad = 0.0
     res_ad = 1.0
-    call dot_product_ad(n, a, a_ad, b, b_ad, res_ad)
+    call dot_product_rev_ad(n, a, a_ad, b, b_ad, res_ad)
 
     exp_res = a(1)*b(1) + a(2)*b(2) + a(3)*b(3)
     exp_a = b(1)
@@ -120,7 +120,7 @@ contains
     d_ad = 0.0
     d_ad(1,1) = 1.0
     c_ad = 0.0
-    call multidimension_ad(n, m, a, a_ad, b, b_ad, c, c_ad, d_ad)
+    call multidimension_rev_ad(n, m, a, a_ad, b, b_ad, c, c_ad, d_ad)
 
     exp_d = a(1,1) + b(1,1) * c
     exp_a = 1.0

--- a/tests/fortran_runtime/run_call_example.f90
+++ b/tests/fortran_runtime/run_call_example.f90
@@ -66,7 +66,7 @@ contains
 
     x_ad = 1.0
     y_ad = 0.0
-    call call_subroutine_ad(x, x_ad, y, y_ad)
+    call call_subroutine_rev_ad(x, x_ad, y, y_ad)
 
     exp_x = 4.0
     exp_x_ad = 2.0
@@ -90,7 +90,7 @@ contains
 
     x_ad = 1.0
     y_ad = 0.0
-    call call_fucntion_ad(x_ad, y, y_ad)
+    call call_fucntion_rev_ad(x_ad, y, y_ad)
 
     exp_x = y**2
     exp_x_ad = 0.0
@@ -115,7 +115,7 @@ contains
 
     x_ad = 1.0
     y_ad = 0.0
-    call arg_operation_ad(x, x_ad, y, y_ad)
+    call arg_operation_rev_ad(x, x_ad, y, y_ad)
 
     exp_x = 6.0
     exp_x_ad = 2.0
@@ -140,7 +140,7 @@ contains
 
     x_ad = 1.0
     y_ad = 0.0
-    call arg_function_ad(x, x_ad, y, y_ad)
+    call arg_function_rev_ad(x, x_ad, y, y_ad)
 
     exp_x = 6.0
     exp_x_ad = 2.0

--- a/tests/fortran_runtime/run_control_flow.f90
+++ b/tests/fortran_runtime/run_control_flow.f90
@@ -55,7 +55,7 @@ contains
     x_ad = 0.0
     y_ad = 0.0
     z_ad = 1.0
-    call if_example_ad(x, x_ad, y, y_ad, z_ad)
+    call if_example_rev_ad(x, x_ad, y, y_ad, z_ad)
 
     exp_z = x
     exp_x = 1.0
@@ -79,7 +79,7 @@ contains
 
     x_ad = 0.0
     sum_ad = 1.0
-    call do_example_ad(n, x, x_ad, sum_ad)
+    call do_example_rev_ad(n, x, x_ad, sum_ad)
 
     exp_sum = x * real(n * (n + 1) / 2)
     exp_x = real(n * (n + 1) / 2)

--- a/tests/fortran_runtime/run_cross_mod.f90
+++ b/tests/fortran_runtime/run_cross_mod.f90
@@ -18,7 +18,7 @@ contains
     call call_inc(x)
 
     x_ad = 1.0
-    call call_inc_ad(x, x_ad)
+    call call_inc_rev_ad(x, x_ad)
 
     exp_x = 2.0
     exp_x_ad = 1.0

--- a/tests/fortran_runtime/run_intrinsic_func.f90
+++ b/tests/fortran_runtime/run_intrinsic_func.f90
@@ -52,7 +52,7 @@ contains
 
     r_ad = 0.0
     d_ad = 1.0d0
-    call casting_intrinsics_ad(i, r, r_ad, d_ad, c)
+    call casting_intrinsics_rev_ad(i, r, r_ad, d_ad, c)
 
     exp_d = dble(r) + dble(int(r))
     exp_r = 1.0

--- a/tests/fortran_runtime/run_real_kind.f90
+++ b/tests/fortran_runtime/run_real_kind.f90
@@ -57,7 +57,7 @@ contains
     call scale_8(x)
 
     x_ad = 1.0_8
-    call scale_8_ad(x, x_ad)
+    call scale_8_rev_ad(x, x_ad)
 
     exp_x = 4.0_8
     exp_x_ad = 2.0_8
@@ -77,7 +77,7 @@ contains
     call scale_rp(x)
 
     x_ad = 1.0_RP
-    call scale_rp_ad(x, x_ad)
+    call scale_rp_rev_ad(x, x_ad)
 
     exp_x = 4.0_RP
     exp_x_ad = 2.0_RP
@@ -97,7 +97,7 @@ contains
     call scale_dp(x)
 
     x_ad = 1.0d0
-    call scale_dp_ad(x, x_ad)
+    call scale_dp_rev_ad(x, x_ad)
 
     exp_x = 4.0d0
     exp_x_ad = 2.0d0

--- a/tests/fortran_runtime/run_save_vars.f90
+++ b/tests/fortran_runtime/run_save_vars.f90
@@ -49,7 +49,7 @@ contains
     x_ad = 0.0
     y_ad = 0.0
     z_ad = 1.0
-    call simple_ad(x, x_ad, y, y_ad, z_ad)
+    call simple_rev_ad(x, x_ad, y, y_ad, z_ad)
 
     exp_z = 2.0*x**3 + 2.0*x**2 + 2.0*x + (1.0 + y)
     exp_x = 6.0*x**2 + 4.0*x + 2.0

--- a/tests/fortran_runtime/run_simple_math.f90
+++ b/tests/fortran_runtime/run_simple_math.f90
@@ -74,7 +74,7 @@ contains
     a_ad = 0.0
     b_ad = 0.0
     c_ad = 1.0
-    call add_numbers_ad(a, a_ad, b, b_ad, c_ad)
+    call add_numbers_rev_ad(a, a_ad, b, b_ad, c_ad)
 
     exp_c = 2.0 * a + b + 3.0
     exp_a = 2.0
@@ -100,7 +100,7 @@ contains
     a_ad = 0.0
     b_ad = 0.0
     c_ad = 1.0
-    call multiply_numbers_ad(a, a_ad, b, b_ad, c_ad)
+    call multiply_numbers_rev_ad(a, a_ad, b, b_ad, c_ad)
 
     exp_c = a * (3.0 * b + 4.0)
     exp_a = 3.0 * b + 4.0
@@ -126,7 +126,7 @@ contains
     a_ad = 0.0
     b_ad = 0.0
     c_ad = 1.0
-    call subtract_numbers_ad(a, a_ad, b, b_ad, c_ad)
+    call subtract_numbers_rev_ad(a, a_ad, b, b_ad, c_ad)
 
     exp_c = -a + 2.0*b
     exp_a = -1.0
@@ -152,7 +152,7 @@ contains
     a_ad = 0.0
     b_ad = 0.0
     c_ad = 1.0
-    call divide_numbers_ad(a, a_ad, b, b_ad, c_ad)
+    call divide_numbers_rev_ad(a, a_ad, b, b_ad, c_ad)
 
     t = b + 1.5
     exp_c = a / (2.0 * t) + a
@@ -179,7 +179,7 @@ contains
     a_ad = 0.0
     b_ad = 0.0
     c_ad = 1.0
-    call power_numbers_ad(a, a_ad, b, b_ad, c_ad)
+    call power_numbers_rev_ad(a, a_ad, b, b_ad, c_ad)
 
     exp_c = a**3 + b**5.5
     exp_c = exp_c + a**b + (4.0 * a + 2.0)**b + a**(b * 5.0 + 3.0)

--- a/tests/fortran_runtime/run_store_vars.f90
+++ b/tests/fortran_runtime/run_store_vars.f90
@@ -21,7 +21,7 @@ contains
     x_ad = 0.0
     z_ad = 0.0
     z_ad(n) = 1.0
-    call do_with_recurrent_scalar_ad(n, x, x_ad, z_ad)
+    call do_with_recurrent_scalar_rev_ad(n, x, x_ad, z_ad)
 
     exp_z = x(1) * x(2) * x(3)
     exp_x1 = x(2) * x(3)


### PR DESCRIPTION
## Summary
- update Fortran runtime drivers to use new `_rev_ad` subroutine names

## Testing
- `python tests/test_generator.py`
- `python tests/test_fortran_runtime.py`

------
https://chatgpt.com/codex/tasks/task_b_6864fe5db0a8832d918957fd963acc20