### PR TITLE
Add forward mode runtime tests

### DIFF
--- a/tests/fortran_runtime/run_call_example.f90
+++ b/tests/fortran_runtime/run_call_example.f90
@@ -9,6 +9,10 @@ program run_call_example
   integer, parameter :: I_call_fucntion = 2
   integer, parameter :: I_arg_operation = 3
   integer, parameter :: I_arg_function = 4
+  integer, parameter :: I_call_subroutine_fwd = 5
+  integer, parameter :: I_call_fucntion_fwd = 6
+  integer, parameter :: I_arg_operation_fwd = 7
+  integer, parameter :: I_arg_function_fwd = 8
 
   integer :: length, status
   character(:), allocatable :: arg
@@ -30,6 +34,14 @@ program run_call_example
               i_test = I_arg_operation
            case ("arg_function")
               i_test = I_arg_function
+           case ("call_subroutine_fwd")
+              i_test = I_call_subroutine_fwd
+           case ("call_fucntion_fwd")
+              i_test = I_call_fucntion_fwd
+           case ("arg_operation_fwd")
+              i_test = I_arg_operation_fwd
+           case ("arg_function_fwd")
+              i_test = I_arg_function_fwd
            case default
               print *, 'Invalid test name: ', arg
               error stop 1
@@ -50,6 +62,18 @@ program run_call_example
   end if
   if (i_test == I_arg_function .or. i_test == I_all) then
      call test_arg_function
+  end if
+  if (i_test == I_call_subroutine_fwd) then
+     call test_call_subroutine_fwd
+  end if
+  if (i_test == I_call_fucntion_fwd) then
+     call test_call_fucntion_fwd
+  end if
+  if (i_test == I_arg_operation_fwd) then
+     call test_arg_operation_fwd
+  end if
+  if (i_test == I_arg_function_fwd) then
+     call test_arg_function_fwd
   end if
 
   stop
@@ -153,5 +177,94 @@ contains
     end if
     return
   end subroutine test_arg_function
+
+  subroutine test_call_subroutine_fwd
+    real :: x, y, x_ad, fd, eps, x_base, x_eps
+
+    eps = 1.0e-6
+    x = 1.0
+    y = 2.0
+    call call_subroutine(x, y)
+    x_base = x
+    x = 1.0 + eps
+    y = 2.0 + eps
+    call call_subroutine(x, y)
+    x_eps = x
+    fd = (x_eps - x_base) / eps
+    x = 1.0
+    y = 2.0
+    x_ad = 1.0
+    call call_subroutine_fwd_ad(x, x_ad, y, 1.0)
+    if (abs(x_ad - fd) > tol) then
+       print *, 'test_call_subroutine_fwd failed', x_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_call_subroutine_fwd
+
+  subroutine test_call_fucntion_fwd
+    real :: x, y, x_eps, res_fd, x_ad, eps
+
+    eps = 1.0e-6
+    y = 3.0
+    call call_fucntion(x, y)
+    x_eps = 0.0
+    call call_fucntion(x_eps, y + eps)
+    res_fd = (x_eps - x) / eps
+    call call_fucntion_fwd_ad(x_ad, y, 1.0)
+    if (abs(x_ad - res_fd) > tol) then
+       print *, 'test_call_fucntion_fwd failed', x_ad, res_fd
+       error stop 1
+    end if
+    return
+  end subroutine test_call_fucntion_fwd
+
+  subroutine test_arg_operation_fwd
+    real :: x, y, x_base, x_eps, x_ad, fd, eps
+
+    eps = 1.0e-6
+    x = 1.0
+    y = 2.0
+    call arg_operation(x, y)
+    x_base = x
+    x = 1.0 + eps
+    y = 2.0 + eps
+    call arg_operation(x, y)
+    x_eps = x
+    fd = (x_eps - x_base) / eps
+    x = 1.0
+    y = 2.0
+    x_ad = 1.0
+    call arg_operation_fwd_ad(x, x_ad, y, 1.0)
+    if (abs(x_ad - fd) > tol) then
+       print *, 'test_arg_operation_fwd failed', x_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_arg_operation_fwd
+
+  subroutine test_arg_function_fwd
+    real :: x, y, x_base, x_eps, x_ad, fd, eps
+
+    eps = 1.0e-6
+    x = 1.0
+    y = 2.0
+    call arg_function(x, y)
+    x_base = x
+    x = 1.0 + eps
+    y = 2.0 + eps
+    call arg_function(x, y)
+    x_eps = x
+    fd = (x_eps - x_base) / eps
+    x = 1.0
+    y = 2.0
+    x_ad = 1.0
+    call arg_function_fwd_ad(x, x_ad, y, 1.0)
+    if (abs(x_ad - fd) > tol) then
+       print *, 'test_arg_function_fwd failed', x_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_arg_function_fwd
 
 end program run_call_example

--- a/tests/fortran_runtime/run_control_flow.f90
+++ b/tests/fortran_runtime/run_control_flow.f90
@@ -7,6 +7,8 @@ program run_control_flow
   integer, parameter :: I_all = 0
   integer, parameter :: I_if_example = 1
   integer, parameter :: I_do_example = 2
+  integer, parameter :: I_if_example_fwd = 3
+  integer, parameter :: I_do_example_fwd = 4
 
   integer :: length, status
   character(:), allocatable :: arg
@@ -24,6 +26,10 @@ program run_control_flow
               i_test = I_if_example
            case ("do_example")
               i_test = I_do_example
+           case ("if_example_fwd")
+              i_test = I_if_example_fwd
+           case ("do_example_fwd")
+              i_test = I_do_example_fwd
            case default
               print *, 'Invalid test name: ', arg
               error stop 1
@@ -38,6 +44,12 @@ program run_control_flow
   end if
   if (i_test == I_do_example .or. i_test == I_all) then
      call test_do_example
+  end if
+  if (i_test == I_if_example_fwd) then
+     call test_if_example_fwd
+  end if
+  if (i_test == I_do_example_fwd) then
+     call test_do_example_fwd
   end if
 
   stop
@@ -90,5 +102,40 @@ contains
     end if
     return
   end subroutine test_do_example
+
+  subroutine test_if_example_fwd
+    real :: x, y, z, z_eps, z_ad, fd, eps
+
+    eps = 1.0e-6
+    x = 1.0
+    y = 2.0
+    call if_example(x, y, z)
+    call if_example(x + eps, y + eps, z_eps)
+    fd = (z_eps - z) / eps
+    call if_example_fwd_ad(x, 1.0, y, 1.0, z_ad)
+    if (abs(z_ad - fd) > tol) then
+       print *, 'test_if_example_fwd failed', z_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_if_example_fwd
+
+  subroutine test_do_example_fwd
+    integer :: n
+    real :: x, sum, sum_eps, sum_ad, fd, eps
+
+    eps = 1.0e-6
+    n = 3
+    x = 2.0
+    call do_example(n, x, sum)
+    call do_example(n, x + eps, sum_eps)
+    fd = (sum_eps - sum) / eps
+    call do_example_fwd_ad(n, x, 1.0, sum_ad)
+    if (abs(sum_ad - fd) > tol) then
+       print *, 'test_do_example_fwd failed', sum_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_do_example_fwd
 
 end program run_control_flow

--- a/tests/fortran_runtime/run_cross_mod.f90
+++ b/tests/fortran_runtime/run_cross_mod.f90
@@ -4,7 +4,36 @@ program run_cross_mod
   implicit none
   real, parameter :: tol = 1.0e-5
 
-  call test_call_inc
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_call_inc_fwd = 1
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("call_inc_fwd")
+              i_test = I_call_inc_fwd
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_all) then
+     call test_call_inc
+  else if (i_test == I_call_inc_fwd) then
+     call test_call_inc_fwd
+  end if
 
   stop
 contains
@@ -29,5 +58,24 @@ contains
     end if
     return
   end subroutine test_call_inc
+
+  subroutine test_call_inc_fwd
+    real :: x, x_eps, x_ad, fd, eps
+
+    eps = 1.0e-6
+    x = 1.0
+    call call_inc(x)
+    x_eps = 1.0 + eps
+    call call_inc(x_eps)
+    fd = (x_eps - x) / eps
+    x = 1.0
+    x_ad = 1.0
+    call call_inc_fwd_ad(x, x_ad)
+    if (abs(x_ad - fd) > tol) then
+       print *, 'test_call_inc_fwd failed', x_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_call_inc_fwd
 
 end program run_cross_mod

--- a/tests/fortran_runtime/run_intrinsic_func.f90
+++ b/tests/fortran_runtime/run_intrinsic_func.f90
@@ -6,6 +6,7 @@ program run_intrinsic_func
 
   integer, parameter :: I_all = 0
   integer, parameter :: I_casting = 1
+  integer, parameter :: I_casting_fwd = 2
 
   integer :: length, status
   character(:), allocatable :: arg
@@ -21,6 +22,8 @@ program run_intrinsic_func
            select case(arg)
            case ("casting")
               i_test = I_casting
+           case ("casting_fwd")
+              i_test = I_casting_fwd
            case default
               print *, 'Invalid test name: ', arg
               error stop 1
@@ -32,6 +35,9 @@ program run_intrinsic_func
 
   if (i_test == I_casting .or. i_test == I_all) then
      call test_casting
+  end if
+  if (i_test == I_casting_fwd) then
+     call test_casting_fwd
   end if
 
   stop
@@ -63,5 +69,26 @@ contains
     end if
     return
   end subroutine test_casting
+
+  subroutine test_casting_fwd
+    integer :: i, n
+    real :: r, r_eps, r_ad, fd, eps
+    double precision :: d, d_eps, d_ad
+    character(len=1) :: c
+
+    eps = 1.0e-6
+    i = 3
+    r = 4.5
+    c = 'A'
+    call casting_intrinsics(i, r, d, c, n)
+    call casting_intrinsics(i, r + eps, d_eps, c, n)
+    fd = (d_eps - d) / eps
+    call casting_intrinsics_fwd_ad(i, r, 1.0, d_ad, c)
+    if (abs(d_ad - fd) > tol) then
+       print *, 'test_casting_fwd failed', d_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_casting_fwd
 
 end program run_intrinsic_func

--- a/tests/fortran_runtime/run_real_kind.f90
+++ b/tests/fortran_runtime/run_real_kind.f90
@@ -8,6 +8,9 @@ program run_real_kind
   integer, parameter :: I_scale_8 = 1
   integer, parameter :: I_scale_rp = 2
   integer, parameter :: I_scale_dp = 3
+  integer, parameter :: I_scale_8_fwd = 4
+  integer, parameter :: I_scale_rp_fwd = 5
+  integer, parameter :: I_scale_dp_fwd = 6
 
   integer :: length, status
   character(:), allocatable :: arg
@@ -27,6 +30,12 @@ program run_real_kind
               i_test = I_scale_rp
            case("scale_dp")
               i_test = I_scale_dp
+           case("scale_8_fwd")
+              i_test = I_scale_8_fwd
+           case("scale_rp_fwd")
+              i_test = I_scale_rp_fwd
+           case("scale_dp_fwd")
+              i_test = I_scale_dp_fwd
            case default
               print *, 'Invalid test name: ', arg
               error stop 1
@@ -44,6 +53,15 @@ program run_real_kind
   end if
   if (i_test == I_scale_dp .or. i_test == I_all) then
      call test_scale_dp
+  end if
+  if (i_test == I_scale_8_fwd) then
+     call test_scale_8_fwd
+  end if
+  if (i_test == I_scale_rp_fwd) then
+     call test_scale_rp_fwd
+  end if
+  if (i_test == I_scale_dp_fwd) then
+     call test_scale_dp_fwd
   end if
 
   stop
@@ -108,5 +126,62 @@ contains
     end if
     return
   end subroutine test_scale_dp
+
+  subroutine test_scale_8_fwd
+    real(8) :: x, x_eps, x_ad, fd, eps
+
+    eps = 1.0e-6_8
+    x = 2.0_8
+    call scale_8(x)
+    x_eps = 2.0_8 + eps
+    call scale_8(x_eps)
+    fd = (x_eps - x) / eps
+    x = 2.0_8
+    x_ad = 1.0_8
+    call scale_8_fwd_ad(x, x_ad)
+    if (abs(x_ad - fd) > tol) then
+       print *, 'test_scale_8_fwd failed', x_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_scale_8_fwd
+
+  subroutine test_scale_rp_fwd
+    real(RP) :: x, x_eps, x_ad, fd, eps
+
+    eps = 1.0e-6_RP
+    x = 2.0_RP
+    call scale_rp(x)
+    x_eps = 2.0_RP + eps
+    call scale_rp(x_eps)
+    fd = (x_eps - x) / eps
+    x = 2.0_RP
+    x_ad = 1.0_RP
+    call scale_rp_fwd_ad(x, x_ad)
+    if (abs(x_ad - fd) > tol) then
+       print *, 'test_scale_rp_fwd failed', x_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_scale_rp_fwd
+
+  subroutine test_scale_dp_fwd
+    double precision :: x, x_eps, x_ad, fd, eps
+
+    eps = 1.0d-6
+    x = 2.0d0
+    call scale_dp(x)
+    x_eps = 2.0d0 + eps
+    call scale_dp(x_eps)
+    fd = (x_eps - x) / eps
+    x = 2.0d0
+    x_ad = 1.0d0
+    call scale_dp_fwd_ad(x, x_ad)
+    if (abs(x_ad - fd) > tol) then
+       print *, 'test_scale_dp_fwd failed', x_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_scale_dp_fwd
 
 end program run_real_kind

--- a/tests/fortran_runtime/run_save_vars.f90
+++ b/tests/fortran_runtime/run_save_vars.f90
@@ -6,6 +6,7 @@ program run_save_vars
 
   integer, parameter :: I_all = 0
   integer, parameter :: I_simple = 1
+  integer, parameter :: I_simple_fwd = 2
 
   integer :: length, status
   character(:), allocatable :: arg
@@ -21,6 +22,8 @@ program run_save_vars
            select case(arg)
            case ("simple")
               i_test = I_simple
+           case ("simple_fwd")
+              i_test = I_simple_fwd
            case default
               print *, 'Invalid test name: ', arg
               error stop 1
@@ -32,6 +35,9 @@ program run_save_vars
 
   if (i_test == I_simple .or. i_test == I_all) then
      call test_simple
+  end if
+  if (i_test == I_simple_fwd) then
+     call test_simple_fwd
   end if
 
   stop
@@ -62,5 +68,22 @@ contains
     end if
     return
   end subroutine test_simple
+
+  subroutine test_simple_fwd
+    real :: x, y, z, z_eps, z_ad, fd, eps
+
+    eps = 1.0e-6
+    x = 2.0
+    y = 3.0
+    call simple(x, y, z)
+    call simple(x + eps, y + eps, z_eps)
+    fd = (z_eps - z) / eps
+    call simple_fwd_ad(x, 1.0, y, 1.0, z_ad)
+    if (abs(z_ad - fd) > tol) then
+       print *, 'test_simple_fwd failed', z_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_simple_fwd
 
 end program run_save_vars

--- a/tests/fortran_runtime/run_simple_math.f90
+++ b/tests/fortran_runtime/run_simple_math.f90
@@ -10,6 +10,11 @@ program run_simple_math
   integer, parameter :: I_subtract_numbers = 3
   integer, parameter :: I_divide_numbers   = 4
   integer, parameter :: I_power_numbers    = 5
+  integer, parameter :: I_add_numbers_fwd      = 6
+  integer, parameter :: I_multiply_numbers_fwd = 7
+  integer, parameter :: I_subtract_numbers_fwd = 8
+  integer, parameter :: I_divide_numbers_fwd   = 9
+  integer, parameter :: I_power_numbers_fwd    = 10
 
   integer :: length, status
   character(:), allocatable :: arg
@@ -33,6 +38,16 @@ program run_simple_math
               i_test = I_divide_numbers
            case ("power_numbers")
               i_test = I_power_numbers
+           case ("add_numbers_fwd")
+              i_test = I_add_numbers_fwd
+           case ("multiply_numbers_fwd")
+              i_test = I_multiply_numbers_fwd
+           case ("subtract_numbers_fwd")
+              i_test = I_subtract_numbers_fwd
+           case ("divide_numbers_fwd")
+              i_test = I_divide_numbers_fwd
+           case ("power_numbers_fwd")
+              i_test = I_power_numbers_fwd
            case default
               print *, 'Invalid test name: ', arg
               error stop 1
@@ -56,6 +71,21 @@ program run_simple_math
   end if
   if (i_test == I_power_numbers .or. i_test == I_all) then
      call test_power_numbers
+  end if
+  if (i_test == I_add_numbers_fwd) then
+     call test_add_numbers_fwd
+  end if
+  if (i_test == I_multiply_numbers_fwd) then
+     call test_multiply_numbers_fwd
+  end if
+  if (i_test == I_subtract_numbers_fwd) then
+     call test_subtract_numbers_fwd
+  end if
+  if (i_test == I_divide_numbers_fwd) then
+     call test_divide_numbers_fwd
+  end if
+  if (i_test == I_power_numbers_fwd) then
+     call test_power_numbers_fwd
   end if
 
   stop
@@ -196,5 +226,90 @@ contains
     end if
     return
   end subroutine test_power_numbers
+
+  subroutine test_add_numbers_fwd
+    real :: a, b, c, c_eps, c_ad, fd, eps
+
+    eps = 1.0e-6
+    a = 2.0
+    b = 3.0
+    c = add_numbers(a, b)
+    c_eps = add_numbers(a + eps, b + eps)
+    fd = (c_eps - c) / eps
+    call add_numbers_fwd_ad(a, 1.0, b, 1.0, c_ad)
+    if (abs(c_ad - fd) > tol) then
+       print *, 'test_add_numbers_fwd failed', c_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_add_numbers_fwd
+
+  subroutine test_multiply_numbers_fwd
+    real :: a, b, c, c_eps, c_ad, fd, eps
+
+    eps = 1.0e-6
+    a = 2.0
+    b = 3.0
+    call multiply_numbers(a, b, c)
+    call multiply_numbers(a + eps, b + eps, c_eps)
+    fd = (c_eps - c) / eps
+    call multiply_numbers_fwd_ad(a, 1.0, b, 1.0, c_ad)
+    if (abs(c_ad - fd) > tol) then
+       print *, 'test_multiply_numbers_fwd failed', c_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_multiply_numbers_fwd
+
+  subroutine test_subtract_numbers_fwd
+    real :: a, b, c, c_eps, c_ad, fd, eps
+
+    eps = 1.0e-6
+    a = 2.0
+    b = 3.0
+    c = subtract_numbers(a, b)
+    c_eps = subtract_numbers(a + eps, b + eps)
+    fd = (c_eps - c) / eps
+    call subtract_numbers_fwd_ad(a, 1.0, b, 1.0, c_ad)
+    if (abs(c_ad - fd) > tol) then
+       print *, 'test_subtract_numbers_fwd failed', c_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_subtract_numbers_fwd
+
+  subroutine test_divide_numbers_fwd
+    real :: a, b, c, c_eps, c_ad, fd, eps
+
+    eps = 1.0e-6
+    a = 2.0
+    b = 3.0
+    call divide_numbers(a, b, c)
+    call divide_numbers(a + eps, b + eps, c_eps)
+    fd = (c_eps - c) / eps
+    call divide_numbers_fwd_ad(a, 1.0, b, 1.0, c_ad)
+    if (abs(c_ad - fd) > tol) then
+       print *, 'test_divide_numbers_fwd failed', c_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_divide_numbers_fwd
+
+  subroutine test_power_numbers_fwd
+    real :: a, b, c, c_eps, c_ad, fd, eps
+
+    eps = 1.0e-6
+    a = 2.0
+    b = 3.0
+    c = power_numbers(a, b)
+    c_eps = power_numbers(a + eps, b + eps)
+    fd = (c_eps - c) / eps
+    call power_numbers_fwd_ad(a, 1.0, b, 1.0, c_ad)
+    if (abs(c_ad - fd) > tol) then
+       print *, 'test_power_numbers_fwd failed', c_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_power_numbers_fwd
 
 end program run_simple_math

--- a/tests/fortran_runtime/run_store_vars.f90
+++ b/tests/fortran_runtime/run_store_vars.f90
@@ -4,7 +4,36 @@ program run_store_vars
   implicit none
   real, parameter :: tol = 1.0e-5
 
-  call test_do_with_recurrent_scalar
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_do_with_recurrent_scalar_fwd = 1
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("do_with_recurrent_scalar_fwd")
+              i_test = I_do_with_recurrent_scalar_fwd
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_all) then
+     call test_do_with_recurrent_scalar
+  else if (i_test == I_do_with_recurrent_scalar_fwd) then
+     call test_do_with_recurrent_scalar_fwd
+  end if
 
   stop
 contains
@@ -35,5 +64,23 @@ contains
     end if
     return
   end subroutine test_do_with_recurrent_scalar
+
+  subroutine test_do_with_recurrent_scalar_fwd
+    integer, parameter :: n = 3
+    real :: x(n), z(n), z_eps(n)
+    real :: z_ad(n), fd, eps
+
+    eps = 1.0e-6
+    x = (/2.0, 3.0, 4.0/)
+    call do_with_recurrent_scalar(n, x, z)
+    call do_with_recurrent_scalar(n, x + eps, z_eps)
+    fd = (z_eps(n) - z(n)) / eps
+    call do_with_recurrent_scalar_fwd_ad(n, x, 1.0, z_ad)
+    if (abs(z_ad(n) - fd) > tol) then
+       print *, 'test_do_with_recurrent_scalar_fwd failed', z_ad(n), fd
+       error stop 1
+    end if
+    return
+  end subroutine test_do_with_recurrent_scalar_fwd
 
 end program run_store_vars


### PR DESCRIPTION
## Summary
- extend runtime test programs with forward-mode derivatives
- support new command line arguments for forward-mode tests
- compare forward-mode results against finite differences

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_686695420bd4832d849a8ef0acc56b66