### PR TITLE
Add new Fortran runtime drivers

### DIFF
--- a/tests/fortran_runtime/Makefile
+++ b/tests/fortran_runtime/Makefile
@@ -7,7 +7,9 @@ vpath %.f90 ../../examples
 vpath %.f90 ../../fortran_modules
 vpath %.f90 .
 
-PROGRAMS = run_simple_math run_arrays run_call_example run_control_flow run_cross_mod            run_data_storage run_intrinsic_func run_real_kind run_save_vars run_store_vars
+PROGRAMS = run_simple_math run_arrays run_call_example run_control_flow run_cross_mod \
+           run_data_storage run_intrinsic_func run_real_kind run_save_vars run_store_vars \
+           run_directive_const_arg run_parameter_var
 
 all: $(PROGRAMS)
 
@@ -33,6 +35,8 @@ $(OUTDIR)/run_real_kind.o: $(OUTDIR)/real_kind.o $(OUTDIR)/real_kind_ad.o
 $(OUTDIR)/run_save_vars.o: $(OUTDIR)/save_vars.o $(OUTDIR)/save_vars_ad.o
 $(OUTDIR)/run_store_vars.o: $(OUTDIR)/store_vars.o $(OUTDIR)/store_vars_ad.o \
   $(OUTDIR)/data_storage.o
+$(OUTDIR)/run_directive_const_arg.o: $(OUTDIR)/directive_const_arg.o $(OUTDIR)/directive_const_arg_ad.o
+$(OUTDIR)/run_parameter_var.o: $(OUTDIR)/parameter_var.o $(OUTDIR)/parameter_var_ad.o
 
 # Additional module dependencies
 $(OUTDIR)/store_vars_ad.o: $(OUTDIR)/store_vars.mod $(OUTDIR)/data_storage.o
@@ -67,7 +71,13 @@ run_save_vars: $(OUTDIR)/run_save_vars.o $(OUTDIR)/save_vars.o $(OUTDIR)/save_va
 	$(FC) $^ -o $@
 
 run_store_vars: $(OUTDIR)/run_store_vars.o $(OUTDIR)/store_vars.o $(OUTDIR)/store_vars_ad.o $(OUTDIR)/data_storage.o
-	$(FC) $^ -o $@
+        $(FC) $^ -o $@
+
+run_directive_const_arg: $(OUTDIR)/run_directive_const_arg.o $(OUTDIR)/directive_const_arg.o $(OUTDIR)/directive_const_arg_ad.o
+        $(FC) $^ -o $@
+
+run_parameter_var: $(OUTDIR)/run_parameter_var.o $(OUTDIR)/parameter_var.o $(OUTDIR)/parameter_var_ad.o
+        $(FC) $^ -o $@
 
 clean:
 	rm -f $(OUTDIR)/*.o $(OUTDIR)/*.mod

--- a/tests/fortran_runtime/run_directive_const_arg.f90
+++ b/tests/fortran_runtime/run_directive_const_arg.f90
@@ -1,0 +1,56 @@
+program run_directive_const_arg
+  use directive_const_arg
+  use directive_const_arg_ad
+  implicit none
+  real, parameter :: tol = 1.0e-5
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_add_const_fwd = 1
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("add_const_fwd")
+              i_test = I_add_const_fwd
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_add_const_fwd .or. i_test == I_all) then
+     call test_add_const_fwd
+  end if
+
+  stop
+contains
+
+  subroutine test_add_const_fwd
+    real :: x, y, y_eps, y_ad, fd, eps
+
+    eps = 1.0e-6
+    x = 2.0
+    call add_const(x, y, 3.0)
+    call add_const(x + eps, y_eps, 3.0)
+    fd = (y_eps - y) / eps
+    call add_const_fwd_ad(x, 1.0, y_ad, 3.0)
+    if (abs(y_ad - fd) > tol) then
+       print *, 'test_add_const_fwd failed', y_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_add_const_fwd
+
+end program run_directive_const_arg

--- a/tests/fortran_runtime/run_parameter_var.f90
+++ b/tests/fortran_runtime/run_parameter_var.f90
@@ -1,0 +1,56 @@
+program run_parameter_var
+  use parameter_var
+  use parameter_var_ad
+  implicit none
+  real, parameter :: tol = 1.0e-5
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_compute_area_fwd = 1
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("compute_area_fwd")
+              i_test = I_compute_area_fwd
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_compute_area_fwd .or. i_test == I_all) then
+     call test_compute_area_fwd
+  end if
+
+  stop
+contains
+
+  subroutine test_compute_area_fwd
+    real :: r, area, area_eps, area_ad, fd, eps
+
+    eps = 1.0e-6
+    r = 2.0
+    call compute_area(r, area)
+    call compute_area(r + eps, area_eps)
+    fd = (area_eps - area) / eps
+    call compute_area_fwd_ad(r, 1.0, area_ad)
+    if (abs(area_ad - fd) > tol) then
+       print *, 'test_compute_area_fwd failed', area_ad, fd
+       error stop 1
+    end if
+    return
+  end subroutine test_compute_area_fwd
+
+end program run_parameter_var


### PR DESCRIPTION
## Summary
- add `run_directive_const_arg.f90` runtime program
- add `run_parameter_var.f90` runtime program
- allow building the new programs in `tests/fortran_runtime/Makefile`

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_686698038ad4832d95c0c796d76b6d4f