### PR TITLE
Add _rev suffix for reverse mode tests

### DIFF
--- a/tests/fortran_runtime/run_arrays.f90
+++ b/tests/fortran_runtime/run_arrays.f90
@@ -5,9 +5,9 @@ program run_arrays
   real, parameter :: tol = 1.0e-5
 
   integer, parameter :: I_all = 0
-  integer, parameter :: I_elementwise_add = 1
-  integer, parameter :: I_dot_product = 2
-  integer, parameter :: I_multidimension = 3
+  integer, parameter :: I_elementwise_add_rev = 1
+  integer, parameter :: I_dot_product_rev = 2
+  integer, parameter :: I_multidimension_rev = 3
   integer, parameter :: I_elementwise_add_fwd = 4
   integer, parameter :: I_dot_product_fwd = 5
   integer, parameter :: I_multidimension_fwd = 6
@@ -24,12 +24,12 @@ program run_arrays
         call get_command_argument(1, arg, status=status)
         if (status == 0) then
            select case(arg)
-           case ("elementwise_add")
-              i_test = I_elementwise_add
-           case ("dot_product")
-              i_test = I_dot_product
-           case ("multidimension")
-              i_test = I_multidimension
+           case ("elementwise_add_rev")
+              i_test = I_elementwise_add_rev
+           case ("dot_product_rev")
+              i_test = I_dot_product_rev
+           case ("multidimension_rev")
+              i_test = I_multidimension_rev
            case ("elementwise_add_fwd")
               i_test = I_elementwise_add_fwd
            case ("dot_product_fwd")
@@ -45,14 +45,14 @@ program run_arrays
      end if
   end if
 
-  if (i_test == I_elementwise_add .or. i_test == I_all) then
-     call test_elementwise_add
+  if (i_test == I_elementwise_add_rev .or. i_test == I_all) then
+     call test_elementwise_add_rev
   end if
-  if (i_test == I_dot_product .or. i_test == I_all) then
-     call test_dot_product
+  if (i_test == I_dot_product_rev .or. i_test == I_all) then
+     call test_dot_product_rev
   end if
-  if (i_test == I_multidimension .or. i_test == I_all) then
-     call test_multidimension
+  if (i_test == I_multidimension_rev .or. i_test == I_all) then
+     call test_multidimension_rev
   end if
   if (i_test == I_elementwise_add_fwd) then
      call test_elementwise_add_fwd
@@ -67,7 +67,7 @@ program run_arrays
   stop
 contains
 
-  subroutine test_elementwise_add
+  subroutine test_elementwise_add_rev
     integer, parameter :: n = 3
     real :: a(n), b(n), c(n)
     real :: a_ad(n), b_ad(n), c_ad(n)
@@ -92,9 +92,9 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_elementwise_add
+  end subroutine test_elementwise_add_rev
 
-  subroutine test_dot_product
+  subroutine test_dot_product_rev
     integer, parameter :: n = 3
     real :: a(n), b(n), res
     real :: a_ad(n), b_ad(n), res_ad
@@ -119,9 +119,9 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_dot_product
+  end subroutine test_dot_product_rev
 
-  subroutine test_multidimension
+  subroutine test_multidimension_rev
     integer, parameter :: n = 2, m = 2
     real :: a(n,m), b(n,m), d(n,m)
     real :: a_ad(n,m), b_ad(n,m), d_ad(n,m)
@@ -151,7 +151,7 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_multidimension
+  end subroutine test_multidimension_rev
 
   subroutine test_elementwise_add_fwd
     integer, parameter :: n = 3

--- a/tests/fortran_runtime/run_call_example.f90
+++ b/tests/fortran_runtime/run_call_example.f90
@@ -5,10 +5,10 @@ program run_call_example
   real, parameter :: tol = 1.0e-5
 
   integer, parameter :: I_all = 0
-  integer, parameter :: I_call_subroutine = 1
-  integer, parameter :: I_call_fucntion = 2
-  integer, parameter :: I_arg_operation = 3
-  integer, parameter :: I_arg_function = 4
+  integer, parameter :: I_call_subroutine_rev = 1
+  integer, parameter :: I_call_fucntion_rev = 2
+  integer, parameter :: I_arg_operation_rev = 3
+  integer, parameter :: I_arg_function_rev = 4
   integer, parameter :: I_call_subroutine_fwd = 5
   integer, parameter :: I_call_fucntion_fwd = 6
   integer, parameter :: I_arg_operation_fwd = 7
@@ -26,14 +26,14 @@ program run_call_example
         call get_command_argument(1, arg, status=status)
         if (status == 0) then
            select case(arg)
-           case ("call_subroutine")
-              i_test = I_call_subroutine
-           case ("call_fucntion")
-              i_test = I_call_fucntion
-           case ("arg_operation")
-              i_test = I_arg_operation
-           case ("arg_function")
-              i_test = I_arg_function
+           case ("call_subroutine_rev")
+              i_test = I_call_subroutine_rev
+           case ("call_fucntion_rev")
+              i_test = I_call_fucntion_rev
+           case ("arg_operation_rev")
+              i_test = I_arg_operation_rev
+           case ("arg_function_rev")
+              i_test = I_arg_function_rev
            case ("call_subroutine_fwd")
               i_test = I_call_subroutine_fwd
            case ("call_fucntion_fwd")
@@ -51,17 +51,17 @@ program run_call_example
      end if
   end if
 
-  if (i_test == I_call_subroutine .or. i_test == I_all) then
-     call test_call_subroutine
+  if (i_test == I_call_subroutine_rev .or. i_test == I_all) then
+     call test_call_subroutine_rev
   end if
-  if (i_test == I_call_fucntion .or. i_test == I_all) then
-     call test_call_fucntion
+  if (i_test == I_call_fucntion_rev .or. i_test == I_all) then
+     call test_call_fucntion_rev
   end if
-  if (i_test == I_arg_operation .or. i_test == I_all) then
-     call test_arg_operation
+  if (i_test == I_arg_operation_rev .or. i_test == I_all) then
+     call test_arg_operation_rev
   end if
-  if (i_test == I_arg_function .or. i_test == I_all) then
-     call test_arg_function
+  if (i_test == I_arg_function_rev .or. i_test == I_all) then
+     call test_arg_function_rev
   end if
   if (i_test == I_call_subroutine_fwd) then
      call test_call_subroutine_fwd
@@ -79,7 +79,7 @@ program run_call_example
   stop
 contains
 
-  subroutine test_call_subroutine
+  subroutine test_call_subroutine_rev
     real :: x, y
     real :: x_ad, y_ad
     real :: exp_x, exp_x_ad, exp_y_ad
@@ -102,9 +102,9 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_call_subroutine
+  end subroutine test_call_subroutine_rev
 
-  subroutine test_call_fucntion
+  subroutine test_call_fucntion_rev
     real :: x, y
     real :: x_ad, y_ad
     real :: exp_x, exp_x_ad, exp_y_ad
@@ -126,9 +126,9 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_call_fucntion
+  end subroutine test_call_fucntion_rev
 
-  subroutine test_arg_operation
+  subroutine test_arg_operation_rev
     real :: x, y
     real :: x_ad, y_ad
     real :: exp_x, exp_x_ad, exp_y_ad
@@ -151,9 +151,9 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_arg_operation
+  end subroutine test_arg_operation_rev
 
-  subroutine test_arg_function
+  subroutine test_arg_function_rev
     real :: x, y
     real :: x_ad, y_ad
     real :: exp_x, exp_x_ad, exp_y_ad
@@ -176,7 +176,7 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_arg_function
+  end subroutine test_arg_function_rev
 
   subroutine test_call_subroutine_fwd
     real :: x, y, x_ad, fd, eps, x_base, x_eps

--- a/tests/fortran_runtime/run_control_flow.f90
+++ b/tests/fortran_runtime/run_control_flow.f90
@@ -5,8 +5,8 @@ program run_control_flow
   real, parameter :: tol = 1.0e-5
 
   integer, parameter :: I_all = 0
-  integer, parameter :: I_if_example = 1
-  integer, parameter :: I_do_example = 2
+  integer, parameter :: I_if_example_rev = 1
+  integer, parameter :: I_do_example_rev = 2
   integer, parameter :: I_if_example_fwd = 3
   integer, parameter :: I_do_example_fwd = 4
 
@@ -22,10 +22,10 @@ program run_control_flow
         call get_command_argument(1, arg, status=status)
         if (status == 0) then
            select case(arg)
-           case ("if_example")
-              i_test = I_if_example
-           case ("do_example")
-              i_test = I_do_example
+           case ("if_example_rev")
+              i_test = I_if_example_rev
+           case ("do_example_rev")
+              i_test = I_do_example_rev
            case ("if_example_fwd")
               i_test = I_if_example_fwd
            case ("do_example_fwd")
@@ -39,11 +39,11 @@ program run_control_flow
      end if
   end if
 
-  if (i_test == I_if_example .or. i_test == I_all) then
-     call test_if_example
+  if (i_test == I_if_example_rev .or. i_test == I_all) then
+     call test_if_example_rev
   end if
-  if (i_test == I_do_example .or. i_test == I_all) then
-     call test_do_example
+  if (i_test == I_do_example_rev .or. i_test == I_all) then
+     call test_do_example_rev
   end if
   if (i_test == I_if_example_fwd) then
      call test_if_example_fwd
@@ -55,7 +55,7 @@ program run_control_flow
   stop
 contains
 
-  subroutine test_if_example
+  subroutine test_if_example_rev
     real :: x, y, z
     real :: x_ad, y_ad, z_ad
     real :: exp_z, exp_x
@@ -77,9 +77,9 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_if_example
+  end subroutine test_if_example_rev
 
-  subroutine test_do_example
+  subroutine test_do_example_rev
     integer :: n
     real :: x, sum
     real :: x_ad, sum_ad
@@ -101,7 +101,7 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_do_example
+  end subroutine test_do_example_rev
 
   subroutine test_if_example_fwd
     real :: x, y, z, z_eps, z_ad, fd, eps

--- a/tests/fortran_runtime/run_cross_mod.f90
+++ b/tests/fortran_runtime/run_cross_mod.f90
@@ -30,7 +30,7 @@ program run_cross_mod
   end if
 
   if (i_test == I_all) then
-     call test_call_inc
+     call test_call_inc_rev
   else if (i_test == I_call_inc_fwd) then
      call test_call_inc_fwd
   end if
@@ -38,7 +38,7 @@ program run_cross_mod
   stop
 contains
 
-  subroutine test_call_inc
+  subroutine test_call_inc_rev
     real :: x
     real :: x_ad
     real :: exp_x, exp_x_ad
@@ -57,7 +57,7 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_call_inc
+  end subroutine test_call_inc_rev
 
   subroutine test_call_inc_fwd
     real :: x, x_eps, x_ad, fd, eps

--- a/tests/fortran_runtime/run_intrinsic_func.f90
+++ b/tests/fortran_runtime/run_intrinsic_func.f90
@@ -5,7 +5,7 @@ program run_intrinsic_func
   real, parameter :: tol = 1.0e-5
 
   integer, parameter :: I_all = 0
-  integer, parameter :: I_casting = 1
+  integer, parameter :: I_casting_rev = 1
   integer, parameter :: I_casting_fwd = 2
 
   integer :: length, status
@@ -20,8 +20,8 @@ program run_intrinsic_func
         call get_command_argument(1, arg, status=status)
         if (status == 0) then
            select case(arg)
-           case ("casting")
-              i_test = I_casting
+           case ("casting_rev")
+              i_test = I_casting_rev
            case ("casting_fwd")
               i_test = I_casting_fwd
            case default
@@ -33,8 +33,8 @@ program run_intrinsic_func
      end if
   end if
 
-  if (i_test == I_casting .or. i_test == I_all) then
-     call test_casting
+  if (i_test == I_casting_rev .or. i_test == I_all) then
+     call test_casting_rev
   end if
   if (i_test == I_casting_fwd) then
      call test_casting_fwd
@@ -43,7 +43,7 @@ program run_intrinsic_func
   stop
 contains
 
-  subroutine test_casting
+  subroutine test_casting_rev
     integer :: i, n
     real :: r, r_ad
     double precision :: d, d_ad
@@ -68,7 +68,7 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_casting
+  end subroutine test_casting_rev
 
   subroutine test_casting_fwd
     integer :: i, n

--- a/tests/fortran_runtime/run_real_kind.f90
+++ b/tests/fortran_runtime/run_real_kind.f90
@@ -5,9 +5,9 @@ program run_real_kind
   real, parameter :: tol = 1.0e-5
 
   integer, parameter :: I_all = 0
-  integer, parameter :: I_scale_8 = 1
-  integer, parameter :: I_scale_rp = 2
-  integer, parameter :: I_scale_dp = 3
+  integer, parameter :: I_scale_8_rev = 1
+  integer, parameter :: I_scale_rp_rev = 2
+  integer, parameter :: I_scale_dp_rev = 3
   integer, parameter :: I_scale_8_fwd = 4
   integer, parameter :: I_scale_rp_fwd = 5
   integer, parameter :: I_scale_dp_fwd = 6
@@ -24,12 +24,12 @@ program run_real_kind
         call get_command_argument(1, arg, status=status)
         if (status == 0) then
            select case(arg)
-           case("scale_8")
-              i_test = I_scale_8
-           case("scale_rp")
-              i_test = I_scale_rp
-           case("scale_dp")
-              i_test = I_scale_dp
+           case("scale_8_rev")
+              i_test = I_scale_8_rev
+           case("scale_rp_rev")
+              i_test = I_scale_rp_rev
+           case("scale_dp_rev")
+              i_test = I_scale_dp_rev
            case("scale_8_fwd")
               i_test = I_scale_8_fwd
            case("scale_rp_fwd")
@@ -45,14 +45,14 @@ program run_real_kind
      end if
   end if
 
-  if (i_test == I_scale_8 .or. i_test == I_all) then
-     call test_scale_8
+  if (i_test == I_scale_8_rev .or. i_test == I_all) then
+     call test_scale_8_rev
   end if
-  if (i_test == I_scale_rp .or. i_test == I_all) then
-     call test_scale_rp
+  if (i_test == I_scale_rp_rev .or. i_test == I_all) then
+     call test_scale_rp_rev
   end if
-  if (i_test == I_scale_dp .or. i_test == I_all) then
-     call test_scale_dp
+  if (i_test == I_scale_dp_rev .or. i_test == I_all) then
+     call test_scale_dp_rev
   end if
   if (i_test == I_scale_8_fwd) then
      call test_scale_8_fwd
@@ -67,7 +67,7 @@ program run_real_kind
   stop
 contains
 
-  subroutine test_scale_8
+  subroutine test_scale_8_rev
     real(8) :: x, x_ad
     real(8) :: exp_x, exp_x_ad
 
@@ -85,9 +85,9 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_scale_8
+  end subroutine test_scale_8_rev
 
-  subroutine test_scale_rp
+  subroutine test_scale_rp_rev
     real(RP) :: x, x_ad
     real(RP) :: exp_x, exp_x_ad
 
@@ -105,9 +105,9 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_scale_rp
+  end subroutine test_scale_rp_rev
 
-  subroutine test_scale_dp
+  subroutine test_scale_dp_rev
     double precision :: x, x_ad
     double precision :: exp_x, exp_x_ad
 
@@ -125,7 +125,7 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_scale_dp
+  end subroutine test_scale_dp_rev
 
   subroutine test_scale_8_fwd
     real(8) :: x, x_eps, x_ad, fd, eps

--- a/tests/fortran_runtime/run_save_vars.f90
+++ b/tests/fortran_runtime/run_save_vars.f90
@@ -5,7 +5,7 @@ program run_save_vars
   real, parameter :: tol = 1.0e-5
 
   integer, parameter :: I_all = 0
-  integer, parameter :: I_simple = 1
+  integer, parameter :: I_simple_rev = 1
   integer, parameter :: I_simple_fwd = 2
 
   integer :: length, status
@@ -20,8 +20,8 @@ program run_save_vars
         call get_command_argument(1, arg, status=status)
         if (status == 0) then
            select case(arg)
-           case ("simple")
-              i_test = I_simple
+           case ("simple_rev")
+              i_test = I_simple_rev
            case ("simple_fwd")
               i_test = I_simple_fwd
            case default
@@ -33,8 +33,8 @@ program run_save_vars
      end if
   end if
 
-  if (i_test == I_simple .or. i_test == I_all) then
-     call test_simple
+  if (i_test == I_simple_rev .or. i_test == I_all) then
+     call test_simple_rev
   end if
   if (i_test == I_simple_fwd) then
      call test_simple_fwd
@@ -43,7 +43,7 @@ program run_save_vars
   stop
 contains
 
-  subroutine test_simple
+  subroutine test_simple_rev
     real :: x, y, z
     real :: x_ad, y_ad, z_ad
     real :: exp_z, exp_x, exp_y
@@ -67,7 +67,7 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_simple
+  end subroutine test_simple_rev
 
   subroutine test_simple_fwd
     real :: x, y, z, z_eps, z_ad, fd, eps

--- a/tests/fortran_runtime/run_simple_math.f90
+++ b/tests/fortran_runtime/run_simple_math.f90
@@ -5,11 +5,11 @@ program run_simple_math
   real, parameter :: tol = 1.0e-5
 
   integer, parameter :: I_all              = 0
-  integer, parameter :: I_add_numbers      = 1
-  integer, parameter :: I_multiply_numbers = 2
-  integer, parameter :: I_subtract_numbers = 3
-  integer, parameter :: I_divide_numbers   = 4
-  integer, parameter :: I_power_numbers    = 5
+  integer, parameter :: I_add_numbers_rev      = 1
+  integer, parameter :: I_multiply_numbers_rev = 2
+  integer, parameter :: I_subtract_numbers_rev = 3
+  integer, parameter :: I_divide_numbers_rev   = 4
+  integer, parameter :: I_power_numbers_rev    = 5
   integer, parameter :: I_add_numbers_fwd      = 6
   integer, parameter :: I_multiply_numbers_fwd = 7
   integer, parameter :: I_subtract_numbers_fwd = 8
@@ -28,16 +28,16 @@ program run_simple_math
         call get_command_argument(1, arg, status=status)
         if (status == 0) then
            select case(arg)
-           case ("add_numbers")
-              i_test = I_add_numbers
-           case ("multiply_numbers")
-              i_test = I_multiply_numbers
-           case ("subtract_numbers")
-              i_test = I_subtract_numbers
-           case ("divide_numbers")
-              i_test = I_divide_numbers
-           case ("power_numbers")
-              i_test = I_power_numbers
+           case ("add_numbers_rev")
+              i_test = I_add_numbers_rev
+           case ("multiply_numbers_rev")
+              i_test = I_multiply_numbers_rev
+           case ("subtract_numbers_rev")
+              i_test = I_subtract_numbers_rev
+           case ("divide_numbers_rev")
+              i_test = I_divide_numbers_rev
+           case ("power_numbers_rev")
+              i_test = I_power_numbers_rev
            case ("add_numbers_fwd")
               i_test = I_add_numbers_fwd
            case ("multiply_numbers_fwd")
@@ -57,20 +57,20 @@ program run_simple_math
      end if
   end if
            
-  if (i_test == I_add_numbers .or. i_test == I_all) then
-     call test_add_numbers
+  if (i_test == I_add_numbers_rev .or. i_test == I_all) then
+     call test_add_numbers_rev
   end if
-  if (i_test == I_multiply_numbers .or. i_test == I_all) then
-     call test_multiply_numbers
+  if (i_test == I_multiply_numbers_rev .or. i_test == I_all) then
+     call test_multiply_numbers_rev
   end if
-  if (i_test == I_subtract_numbers .or. i_test == I_all) then
-     call test_subtract_numbers
+  if (i_test == I_subtract_numbers_rev .or. i_test == I_all) then
+     call test_subtract_numbers_rev
   end if
-  if (i_test == I_divide_numbers .or. i_test == I_all) then
-     call test_divide_numbers
+  if (i_test == I_divide_numbers_rev .or. i_test == I_all) then
+     call test_divide_numbers_rev
   end if
-  if (i_test == I_power_numbers .or. i_test == I_all) then
-     call test_power_numbers
+  if (i_test == I_power_numbers_rev .or. i_test == I_all) then
+     call test_power_numbers_rev
   end if
   if (i_test == I_add_numbers_fwd) then
      call test_add_numbers_fwd
@@ -92,7 +92,7 @@ program run_simple_math
 
 contains
 
-  subroutine test_add_numbers
+  subroutine test_add_numbers_rev
     real :: a, b, c
     real :: a_ad, b_ad, c_ad
     real :: exp_c, exp_a, exp_b
@@ -116,9 +116,9 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_add_numbers
+  end subroutine test_add_numbers_rev
 
-  subroutine test_multiply_numbers
+  subroutine test_multiply_numbers_rev
     real :: a, b, c
     real :: a_ad, b_ad, c_ad
     real :: exp_c, exp_a, exp_b
@@ -142,9 +142,9 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_multiply_numbers
+  end subroutine test_multiply_numbers_rev
 
-  subroutine test_subtract_numbers
+  subroutine test_subtract_numbers_rev
     real :: a, b, c
     real :: a_ad, b_ad, c_ad
     real :: exp_c, exp_a, exp_b
@@ -168,9 +168,9 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_subtract_numbers
+  end subroutine test_subtract_numbers_rev
 
-  subroutine test_divide_numbers
+  subroutine test_divide_numbers_rev
     real :: a, b, c
     real :: a_ad, b_ad, c_ad
     real :: exp_c, exp_a, exp_b, t
@@ -195,9 +195,9 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_divide_numbers
+  end subroutine test_divide_numbers_rev
 
-  subroutine test_power_numbers
+  subroutine test_power_numbers_rev
     real :: a, b, c
     real :: a_ad, b_ad, c_ad
     real :: exp_c, exp_a, exp_b
@@ -225,7 +225,7 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_power_numbers
+  end subroutine test_power_numbers_rev
 
   subroutine test_add_numbers_fwd
     real :: a, b, c, c_eps, c_ad, fd, eps

--- a/tests/fortran_runtime/run_store_vars.f90
+++ b/tests/fortran_runtime/run_store_vars.f90
@@ -30,7 +30,7 @@ program run_store_vars
   end if
 
   if (i_test == I_all) then
-     call test_do_with_recurrent_scalar
+     call test_do_with_recurrent_scalar_rev
   else if (i_test == I_do_with_recurrent_scalar_fwd) then
      call test_do_with_recurrent_scalar_fwd
   end if
@@ -38,7 +38,7 @@ program run_store_vars
   stop
 contains
 
-  subroutine test_do_with_recurrent_scalar
+  subroutine test_do_with_recurrent_scalar_rev
     integer, parameter :: n = 3
     real :: x(n), z(n)
     real :: x_ad(n), z_ad(n)
@@ -63,7 +63,7 @@ contains
        error stop 1
     end if
     return
-  end subroutine test_do_with_recurrent_scalar
+  end subroutine test_do_with_recurrent_scalar_rev
 
   subroutine test_do_with_recurrent_scalar_fwd
     integer, parameter :: n = 3

--- a/tests/test_fortran_runtime.py
+++ b/tests/test_fortran_runtime.py
@@ -45,7 +45,7 @@ class TestFortranRuntime(unittest.TestCase):
             ad_path = tmp / 'simple_math_ad.f90'
             ad_path.write_text(ad_code)
             exe = self._build(tmp, 'run_simple_math')
-            subprocess.run([str(exe), "add_numbers"], check=True)
+            subprocess.run([str(exe), "add_numbers_rev"], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_multiply_numbers(self):
@@ -58,7 +58,7 @@ class TestFortranRuntime(unittest.TestCase):
             ad_path = tmp / 'simple_math_ad.f90'
             ad_path.write_text(ad_code)
             exe = self._build(tmp, 'run_simple_math')
-            subprocess.run([str(exe), "multiply_numbers"], check=True)
+            subprocess.run([str(exe), "multiply_numbers_rev"], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_subtract_numbers(self):
@@ -71,7 +71,7 @@ class TestFortranRuntime(unittest.TestCase):
             ad_path = tmp / 'simple_math_ad.f90'
             ad_path.write_text(ad_code)
             exe = self._build(tmp, 'run_simple_math')
-            subprocess.run([str(exe), "subtract_numbers"], check=True)
+            subprocess.run([str(exe), "subtract_numbers_rev"], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_divide_numbers(self):
@@ -84,7 +84,7 @@ class TestFortranRuntime(unittest.TestCase):
             ad_path = tmp / 'simple_math_ad.f90'
             ad_path.write_text(ad_code)
             exe = self._build(tmp, 'run_simple_math')
-            subprocess.run([str(exe), "divide_numbers"], check=True)
+            subprocess.run([str(exe), "divide_numbers_rev"], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_power_numbers(self):
@@ -97,7 +97,7 @@ class TestFortranRuntime(unittest.TestCase):
             ad_path = tmp / 'simple_math_ad.f90'
             ad_path.write_text(ad_code)
             exe = self._build(tmp, 'run_simple_math')
-            subprocess.run([str(exe), "power_numbers"], check=True)
+            subprocess.run([str(exe), "power_numbers_rev"], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_arrays_elementwise_add(self):
@@ -110,7 +110,7 @@ class TestFortranRuntime(unittest.TestCase):
             ad_path = tmp / 'arrays_ad.f90'
             ad_path.write_text(ad_code)
             exe = self._build(tmp, 'run_arrays')
-            subprocess.run([str(exe), 'elementwise_add'], check=True)
+            subprocess.run([str(exe), 'elementwise_add_rev'], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_arrays_multidimension_fd(self):
@@ -123,7 +123,7 @@ class TestFortranRuntime(unittest.TestCase):
             ad_path = tmp / 'arrays_ad.f90'
             ad_path.write_text(ad_code)
             exe = self._build(tmp, 'run_arrays')
-            subprocess.run([str(exe), 'multidimension'], check=True)
+            subprocess.run([str(exe), 'multidimension_rev'], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_control_flow_if_example(self):
@@ -136,7 +136,7 @@ class TestFortranRuntime(unittest.TestCase):
             ad_path = tmp / 'control_flow_ad.f90'
             ad_path.write_text(ad_code)
             exe = self._build(tmp, 'run_control_flow')
-            subprocess.run([str(exe), 'if_example'], check=True)
+            subprocess.run([str(exe), 'if_example_rev'], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_intrinsic_casting(self):
@@ -149,7 +149,7 @@ class TestFortranRuntime(unittest.TestCase):
             ad_path = tmp / 'intrinsic_func_ad.f90'
             ad_path.write_text(ad_code)
             exe = self._build(tmp, 'run_intrinsic_func')
-            subprocess.run([str(exe), 'casting'], check=True)
+            subprocess.run([str(exe), 'casting_rev'], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_save_vars_simple(self):
@@ -162,7 +162,7 @@ class TestFortranRuntime(unittest.TestCase):
             ad_path = tmp / 'save_vars_ad.f90'
             ad_path.write_text(ad_code)
             exe = self._build(tmp, 'run_save_vars')
-            subprocess.run([str(exe), 'simple'], check=True)
+            subprocess.run([str(exe), 'simple_rev'], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_data_storage_push_pop(self):
@@ -211,7 +211,7 @@ class TestFortranRuntime(unittest.TestCase):
             ad_path = tmp / 'call_example_ad.f90'
             ad_path.write_text(ad_code)
             exe = self._build(tmp, 'run_call_example')
-            for tname in ['call_subroutine', 'call_fucntion', 'arg_operation', 'arg_function']:
+            for tname in ['call_subroutine_rev', 'call_fucntion_rev', 'arg_operation_rev', 'arg_function_rev']:
                 subprocess.run([str(exe), tname], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
@@ -225,7 +225,7 @@ class TestFortranRuntime(unittest.TestCase):
             ad_path = tmp / 'real_kind_ad.f90'
             ad_path.write_text(ad_code)
             exe = self._build(tmp, 'run_real_kind')
-            for tname in ['scale_8', 'scale_rp', 'scale_dp']:
+            for tname in ['scale_8_rev', 'scale_rp_rev', 'scale_dp_rev']:
                 subprocess.run([str(exe), tname], check=True)
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')


### PR DESCRIPTION
## Summary
- rename reverse mode subroutines in Fortran runtime drivers to include `_rev`
- update command line arguments to use the new names
- adjust Python tests to call the new arguments

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_68669961a81c832db13b1b812e59532d