### PR TITLE
Run reverse check in multidimension array test

### DIFF
--- a/tests/fortran_runtime/run_arrays.f90
+++ b/tests/fortran_runtime/run_arrays.f90
@@ -160,7 +160,6 @@ contains
        print *, fd(:,:)
        error stop 1
     end if
-    return
 
     inner1 = sum(d_ad(:,:)**2)
     call multidimension_rev_ad(n, m, a, a_ad, b, b_ad, c, c_ad, d_ad)


### PR DESCRIPTION
## Summary
- make `test_multidimension` actually run the reverse-mode validation

## Testing
- `python tests/test_generator.py`
- `make -C tests/fortran_runtime run_arrays`


------
https://chatgpt.com/codex/tasks/task_b_6869ed4d859c832d9513cb1e22a1ac21