### PR TITLE
Add reverse checks to Fortran runtime tests

### DIFF
--- a/tests/fortran_runtime/run_directive_const_arg.f90
+++ b/tests/fortran_runtime/run_directive_const_arg.f90
@@ -41,6 +41,7 @@ contains
     real :: x, y, z
     real :: x_ad, y_ad
     real :: y_eps, fd, eps
+    real :: inner1, inner2
 
     eps = 1.0e-3
     x = 2.0
@@ -52,6 +53,14 @@ contains
     call add_const_fwd_ad(x, x_ad, y_ad, z)
     if (abs(y_ad - fd) > tol) then
        print *, 'test_add_const_fwd failed', y_ad, fd
+       error stop 1
+    end if
+
+    inner1 = y_ad**2
+    call add_const_rev_ad(x, x_ad, y_ad, z)
+    inner2 = x_ad
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_add_const_rev failed', inner1, inner2
        error stop 1
     end if
 

--- a/tests/fortran_runtime/run_parameter_var.f90
+++ b/tests/fortran_runtime/run_parameter_var.f90
@@ -42,6 +42,7 @@ contains
     real :: r, area
     real :: r_ad, area_ad
     real :: area_eps, fd, eps
+    real :: inner1, inner2
 
     eps = 1.0e-3
     r = 2.0
@@ -52,6 +53,14 @@ contains
     call compute_area_fwd_ad(r, r_ad, area_ad)
     if (abs((area_ad - fd) / fd) > tol) then
        print *, 'test_compute_area_fwd failed', area_ad, fd
+       error stop 1
+    end if
+
+    inner1 = area_ad**2
+    call compute_area_rev_ad(r, r_ad, area_ad)
+    inner2 = r_ad
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_compute_area_rev failed', inner1, inner2
        error stop 1
     end if
 


### PR DESCRIPTION
## Summary
- extend `run_directive_const_arg.f90` with a reverse check for `add_const`
- add reverse-mode validation in `run_parameter_var.f90`

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_6869efa45c18832d8643c7905a44b6d5