### PR TITLE
Refactor store_vars reverse AD test

### DIFF
--- a/tests/fortran_runtime/run_store_vars.f90
+++ b/tests/fortran_runtime/run_store_vars.f90
@@ -42,7 +42,7 @@ contains
     real :: x(n), z(n)
     real :: x_ad(n), z_ad(n)
     real :: z_eps(n), fd(n), eps
-    real :: exp_z, exp_x1, exp_x2, exp_x3
+    real :: inner1, inner2
 
     eps = 1.0e-3
     x = (/2.0, 3.0, 4.0/)
@@ -59,19 +59,12 @@ contains
        error stop 1
     end if
 
-    x = (/2.0, 3.0, 4.0/)
-    call do_with_recurrent_scalar(n, x, z)
+    inner1 = sum(z_ad(:)**2)
     x_ad = 0.0
-    z_ad = 0.0
-    z_ad(n) = 1.0
     call do_with_recurrent_scalar_rev_ad(n, x, x_ad, z_ad)
-    exp_z = x(1) * x(2) * x(3)
-    exp_x1 = x(2) * x(3)
-    exp_x2 = x(1) * x(3)
-    exp_x3 = x(1) * x(2)
-    if (abs(z(n) - exp_z) > tol .or. abs(x_ad(1) - exp_x1) > tol .or. &
-        abs(x_ad(2) - exp_x2) > tol .or. abs(x_ad(3) - exp_x3) > tol) then
-       print *, 'test_do_with_recurrent_scalar_rev failed', z(n), x_ad
+    inner2 = sum(x_ad(:))
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_do_with_recurrent_scalar_rev failed', inner1, inner2
        error stop 1
     end if
 


### PR DESCRIPTION
## Summary
- tweak `run_store_vars.f90` reverse AD check to use inner product test
- remove obsolete explicit value checks

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_686a3298ca08832d9f06dc26f314c41b