### PR TITLE
Align runtime control flow tests with AD procedure

### DIFF
--- a/tests/fortran_runtime/run_control_flow.f90
+++ b/tests/fortran_runtime/run_control_flow.f90
@@ -59,7 +59,7 @@ contains
     real :: x, y, z
     real :: x_ad, y_ad, z_ad
     real :: y_eps, z_eps, fd, eps
-    real :: exp_z, exp_x
+    real :: inner1, inner2
 
     eps = 1.0e-3
     x = 1.0
@@ -76,17 +76,14 @@ contains
        error stop 1
     end if
 
-    x = 1.0
-    y = 2.0
+    inner1 = z_ad**2
     call if_example(x, y, z)
     x_ad = 0.0
     y_ad = 0.0
-    z_ad = 1.0
     call if_example_rev_ad(x, x_ad, y, y_ad, z_ad)
-    exp_z = x
-    exp_x = 1.0
-    if (abs(z - exp_z) > tol .or. abs(x_ad - exp_x) > tol) then
-       print *, 'test_if_example failed', z, x_ad
+    inner2 = x_ad + y_ad
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_if_example_rev failed', inner1, inner2
        error stop 1
     end if
 
@@ -98,7 +95,7 @@ contains
     real :: x, sum
     real :: x_ad, sum_ad
     real :: sum_eps, fd, eps
-    real :: exp_sum, exp_x
+    real :: inner1, inner2
 
     eps = 1.0e-3
     n = 3
@@ -113,17 +110,15 @@ contains
        error stop 1
     end if
 
+    inner1 = sum_ad**2
     n = 3
     x = 2.0
     call do_example(n, x, sum)
     x_ad = 0.0
-    sum_ad = 1.0
     call do_example_rev_ad(n, x, x_ad, sum_ad)
-    exp_sum = x * real(n * (n + 1) / 2)
-    exp_x = real(n * (n + 1) / 2)
-
-    if (abs(sum - exp_sum) > tol .or. abs(x_ad - exp_x) > tol) then
-       print *, 'test_do_example failed', sum, x_ad
+    inner2 = x_ad
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_do_example_rev failed', inner1, inner2
        error stop 1
     end if
 


### PR DESCRIPTION
## Summary
- update control flow runtime tests for `if_example` and `do_example`
- compute inner products using forward AD seeds and verify using reverse AD

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_686a32ec3aa8832d81a2f8790fe4ea73