### PR TITLE
Update reverse AD checks in runtime tests

### DIFF
--- a/tests/fortran_runtime/run_cross_mod.f90
+++ b/tests/fortran_runtime/run_cross_mod.f90
@@ -47,7 +47,7 @@ contains
     real :: x
     real :: x_ad
     real :: x_eps, fd, eps
-    real :: exp_x, exp_x_ad
+    real :: inner1, inner2
 
     eps = 1.0e-3
     x = 1.0
@@ -63,14 +63,12 @@ contains
        error stop 1
     end if
 
+    inner1 = x_ad**2
     x = 1.0
-    call call_inc(x)
-    x_ad = 1.0
     call call_inc_rev_ad(x, x_ad)
-    exp_x = 2.0
-    exp_x_ad = 1.0
-    if (abs(x - exp_x) > tol .or. abs(x_ad - exp_x_ad) > tol) then
-       print *, 'test_call_inc failed', x, x_ad
+    inner2 = x_ad
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_call_inc_rev failed', inner1, inner2
        error stop 1
     end if
 


### PR DESCRIPTION
## Summary
- update the runtime check for `call_inc` to mirror other tests
- compare inner product results instead of analytic values

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_686a33059284832d810af25edcea91f6