### PR TITLE
Rename directive example to directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,18 @@ end subroutine foo
 ```
 
 Arguments listed in ``CONSTANT_ARGS`` do not receive corresponding ``_ad``
-variables in the generated routine. See ``examples/directive_const_arg.f90``
-for a full example.
+variables in the generated routine. See ``examples/directives.f90``
+for a full example that also demonstrates skipping a routine with ``NO_AD``.
+
+Use ``NO_AD`` to indicate that a routine should be parsed but skipped when
+generating AD code:
+
+```fortran
+!$FAD NO_AD
+subroutine skip_me(x)
+  ! ...
+end subroutine skip_me
+```
 
 Run the included tests with:
 

--- a/examples/directives.f90
+++ b/examples/directives.f90
@@ -1,4 +1,4 @@
-module directive_const_arg
+module directives
   implicit none
 
 contains
@@ -14,5 +14,13 @@ contains
     return
   end subroutine add_const
 
-end module directive_const_arg
+!$FAD NO_AD
+  subroutine skip_me(x, y)
+    real, intent(inout) :: x, y
+
+    y = x + y
+
+  end subroutine skip_me
+
+end module directives
 

--- a/examples/directives_ad.f90
+++ b/examples/directives_ad.f90
@@ -1,5 +1,5 @@
-module directive_const_arg_ad
-  use directive_const_arg
+module directives_ad
+  use directives
   implicit none
 
 contains
@@ -27,4 +27,4 @@ contains
     return
   end subroutine add_const_rev_ad
 
-end module directive_const_arg_ad
+end module directives_ad

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -686,6 +686,8 @@ def generate_ad(
         routine_info_fwd = {}
         routine_info_rev = {}
         for r in mod_org.routines:
+            if "NO_AD" in r.directives:
+                continue
             if mode in ("forward", "both"):
                 routine_info = _prepare_fwd_ad_header(r)
                 routine_info_fwd[r.name] = routine_info
@@ -709,6 +711,8 @@ def generate_ad(
         ad_modules_used = set()
 
         for routine in mod_org.routines:
+            if "NO_AD" in routine.directives:
+                continue
             if mode in ("forward", "both"):
                 sub, mods_called = _generate_fwd_ad_subroutine(
                     routine, routine_map, routine_info_fwd[routine.name], warnings

--- a/tests/fortran_runtime/Makefile
+++ b/tests/fortran_runtime/Makefile
@@ -9,7 +9,7 @@ vpath %.f90 .
 
 PROGRAMS = run_simple_math run_arrays run_call_example run_control_flow run_cross_mod \
            run_data_storage run_intrinsic_func run_real_kind run_save_vars run_store_vars \
-           run_directive_const_arg run_parameter_var
+           run_directives run_parameter_var
 
 all: $(PROGRAMS)
 
@@ -35,7 +35,7 @@ $(OUTDIR)/run_real_kind.o: $(OUTDIR)/real_kind.o $(OUTDIR)/real_kind_ad.o
 $(OUTDIR)/run_save_vars.o: $(OUTDIR)/save_vars.o $(OUTDIR)/save_vars_ad.o
 $(OUTDIR)/run_store_vars.o: $(OUTDIR)/store_vars.o $(OUTDIR)/store_vars_ad.o \
   $(OUTDIR)/data_storage.o
-$(OUTDIR)/run_directive_const_arg.o: $(OUTDIR)/directive_const_arg.o $(OUTDIR)/directive_const_arg_ad.o
+$(OUTDIR)/run_directives.o: $(OUTDIR)/directives.o $(OUTDIR)/directives_ad.o
 $(OUTDIR)/run_parameter_var.o: $(OUTDIR)/parameter_var.o $(OUTDIR)/parameter_var_ad.o
 
 # Additional module dependencies
@@ -73,8 +73,8 @@ run_save_vars: $(OUTDIR)/run_save_vars.o $(OUTDIR)/save_vars.o $(OUTDIR)/save_va
 run_store_vars: $(OUTDIR)/run_store_vars.o $(OUTDIR)/store_vars.o $(OUTDIR)/store_vars_ad.o $(OUTDIR)/data_storage.o
 	$(FC) $^ -o $@
 
-run_directive_const_arg: $(OUTDIR)/run_directive_const_arg.o $(OUTDIR)/directive_const_arg.o $(OUTDIR)/directive_const_arg_ad.o
-	$(FC) $^ -o $@
+run_directives: $(OUTDIR)/run_directives.o $(OUTDIR)/directives.o $(OUTDIR)/directives_ad.o
+       $(FC) $^ -o $@
 
 run_parameter_var: $(OUTDIR)/run_parameter_var.o $(OUTDIR)/parameter_var.o $(OUTDIR)/parameter_var_ad.o
 	$(FC) $^ -o $@

--- a/tests/fortran_runtime/run_directives.f90
+++ b/tests/fortran_runtime/run_directives.f90
@@ -1,6 +1,6 @@
-program run_directive_const_arg
-  use directive_const_arg
-  use directive_const_arg_ad
+program run_directives
+  use directives
+  use directives_ad
   implicit none
   real, parameter :: tol = 1.0e-4
 
@@ -67,4 +67,4 @@ contains
     return
   end subroutine test_add_const
 
-end program run_directive_const_arg
+end program run_directives

--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -94,8 +94,8 @@ class TestFortranADCode(unittest.TestCase):
         self._run_test('store_vars', ['do_with_recurrent_scalar'])
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
-    def test_directive_const_arg(self):
-        self._run_test('directive_const_arg', ['add_const'])
+    def test_directives(self):
+        self._run_test('directives', ['add_const'])
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_parameter_var(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -169,7 +169,7 @@ class TestParser(unittest.TestCase):
 
     def test_parse_file_directive_constant_args(self):
         base = Path(__file__).resolve().parents[1]
-        src = base / "examples" / "directive_const_arg.f90"
+        src = base / "examples" / "directives.f90"
         modules = parser.parse_file(str(src))
         routine = modules[0].routines[0]
         self.assertIn("CONSTANT_ARGS", routine.directives)
@@ -178,6 +178,23 @@ class TestParser(unittest.TestCase):
         self.assertTrue(decl.constant)
         var = routine.get_var("z")
         self.assertTrue(var.is_constant)
+
+    def test_parse_directive_no_ad(self):
+        src = textwrap.dedent(
+            """
+            module test
+            contains
+            !$FAD NO_AD
+              subroutine foo(x)
+                real :: x
+                x = x + 1.0
+              end subroutine foo
+            end module test
+            """
+        )
+        module = parser.parse_src(src)[0]
+        routine = module.routines[0]
+        self.assertIn("NO_AD", routine.directives)
 
 
 


### PR DESCRIPTION
## Summary
- rename directive example to `directives.f90`
- update AD module and runtime driver names
- adjust Makefile and tests for the new file
- reference new example in README

## Testing
- `python -m pytest tests/test_parser.py -q`
- `python -m pytest tests/test_generator.py -q`

------
https://chatgpt.com/codex/tasks/task_b_686b0eb66348832dbfd86d5f18832674