### PR TITLE
skip AD subroutines without gradients

### DIFF
--- a/examples/control_flow_ad.f90
+++ b/examples/control_flow_ad.f90
@@ -116,15 +116,6 @@ contains
     return
   end subroutine do_example_rev_ad
 
-  subroutine do_while_example_fwd_ad(x, x_ad, limit, limit_ad)
-    real, intent(in)  :: x
-    real, intent(in)  :: x_ad
-    real, intent(in)  :: limit
-    real, intent(in)  :: limit_ad
-
-    return
-  end subroutine do_while_example_fwd_ad
-
   subroutine do_while_example_rev_ad(x, x_ad, limit, limit_ad)
     real, intent(in)  :: x
     real, intent(out) :: x_ad


### PR DESCRIPTION
## Summary
- detect `NO_AD` directives and whether a routine has gradient outputs during header preparation
- skip generating AD code when no gradients are produced
- omit the forward AD stub from `control_flow` example

## Testing
- `pytest -q tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_686b125988f0832db690d8cec99a77e1