### PR TITLE
Add no_ad flag to fadmod files

### DIFF
--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -104,12 +104,13 @@ def _write_fadmod(mod_name: str, routines, routine_map: dict, directory: Path) -
     data = {}
     for r in routines:
         info = routine_map.get(r.name)
-        if info is not None:
-            if info.get("name_fwd_ad") is None and info.get("name_rev_ad") is None:
-                continue
-            info = dict(info)
-            info["module"] = mod_name
-            data[r.name] = info
+        if info is None:
+            continue
+        info = dict(info)
+        info["module"] = mod_name
+        if info.get("name_fwd_ad") is None and info.get("name_rev_ad") is None:
+            info["no_ad"] = True
+        data[r.name] = info
 
     if not data:
         return

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 import unittest
+import json
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -67,6 +68,16 @@ class TestGenerator(unittest.TestCase):
             )
             generated = generator.generate_ad(str(src), warn=False)
             self.assertNotIn("a_ad", generated)
+
+    def test_fadmod_includes_no_ad(self):
+        code_tree.Node.reset()
+        fadmod = Path("directives.fadmod")
+        if fadmod.exists():
+            fadmod.unlink()
+        generator.generate_ad("examples/directives.f90", warn=False)
+        data = json.loads(fadmod.read_text())
+        self.assertIn("skip_me", data)
+        self.assertTrue(data["skip_me"].get("no_ad"))
 
 
 def _make_example_test(src: Path):


### PR DESCRIPTION
## Summary
- store `no_ad` in `.fadmod` records when AD generation is skipped
- test that the flag is written for routines marked `NO_AD`

## Testing
- `python -m pytest -q tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_686b185b69ec832da719b79aa75d0045