### PR TITLE
Handle routines without AD in CallStatement

### DIFF
--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -718,6 +718,10 @@ class CallStatement(Node):
             raise RuntimeError(f"Not found in routime_map: {name}")
         arg_info = routine_map[name]
 
+        name_key = "name_rev_ad" if reverse else "name_fwd_ad"
+        if arg_info.get("no_ad") or arg_info.get(name_key) is None:
+            return [self]
+
         def _push_arg(i, arg):
             if not isinstance(arg, OpLeaf) and arg_info["type"][i] == "real":
                 name = self._save_var_name(f"{self.name}_arg{i}", self.get_id(), no_suffix=True)


### PR DESCRIPTION
## Summary
- skip derivative calls when a routine is marked `no_ad` or lacks an AD name
- add regression test ensuring such routines are ignored during generation

## Testing
- `pytest -q tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_686b1a1cb5b0832da9705067f9ce3511