### PR TITLE
Add NO_AD example with input-only routine

### DIFF
--- a/examples/directives.f90
+++ b/examples/directives.f90
@@ -15,12 +15,21 @@ contains
   end subroutine add_const
 
 !$FAD NO_AD
-  subroutine skip_me(x, y)
-    real, intent(inout) :: x, y
+  subroutine skip_me(x)
+    real, intent(in) :: x
 
-    y = x + y
-
+    ! routine is intentionally empty but must be parsed
   end subroutine skip_me
+
+  subroutine worker(x, z)
+    real, intent(in) :: x
+    real, intent(out) :: z
+    real :: y
+
+    y = x + 1.0
+    call skip_me(y)
+    z = y
+  end subroutine worker
 
 end module directives
 

--- a/examples/directives_ad.f90
+++ b/examples/directives_ad.f90
@@ -27,4 +27,29 @@ contains
     return
   end subroutine add_const_rev_ad
 
+  subroutine worker_fwd_ad(x, x_ad, z_ad)
+    real, intent(in)  :: x
+    real, intent(in)  :: x_ad
+    real, intent(out) :: z_ad
+    real :: y_ad
+
+    y_ad = x_ad ! y = x + 1.0
+    z_ad = y_ad ! z = y
+
+    return
+  end subroutine worker_fwd_ad
+
+  subroutine worker_rev_ad(x, x_ad, z_ad)
+    real, intent(in)  :: x
+    real, intent(out) :: x_ad
+    real, intent(inout) :: z_ad
+    real :: y_ad
+
+    y_ad = z_ad ! z = y
+    z_ad = 0.0 ! z = y
+    x_ad = y_ad ! y = x + 1.0
+
+    return
+  end subroutine worker_rev_ad
+
 end module directives_ad

--- a/tests/fortran_runtime/Makefile
+++ b/tests/fortran_runtime/Makefile
@@ -74,10 +74,11 @@ run_store_vars: $(OUTDIR)/run_store_vars.o $(OUTDIR)/store_vars.o $(OUTDIR)/stor
 	$(FC) $^ -o $@
 
 run_directives: $(OUTDIR)/run_directives.o $(OUTDIR)/directives.o $(OUTDIR)/directives_ad.o
-       $(FC) $^ -o $@
+	$(FC) $^ -o $@
 
 run_parameter_var: $(OUTDIR)/run_parameter_var.o $(OUTDIR)/parameter_var.o $(OUTDIR)/parameter_var_ad.o
 	$(FC) $^ -o $@
+
 
 clean:
 	rm -f $(OUTDIR)/*.o $(OUTDIR)/*.mod

--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -95,11 +95,12 @@ class TestFortranADCode(unittest.TestCase):
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_directives(self):
-        self._run_test('directives', ['add_const'])
+        self._run_test('directives', ['add_const', 'worker'])
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_parameter_var(self):
         self._run_test('parameter_var', ['compute_area'])
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- modify `skip_me` to take only an input argument
- update `worker` and regenerated AD code

## Testing
- `python tests/test_generator.py`
- `python tests/test_fortran_adcode.py -k directives`

------
https://chatgpt.com/codex/tasks/task_b_686b2418e88c832db13b57e50996ad94