### PR TITLE
Update skip directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ end subroutine foo
 
 Arguments listed in ``CONSTANT_ARGS`` do not receive corresponding ``_ad``
 variables in the generated routine. See ``examples/directives.f90``
-for a full example that also demonstrates skipping a routine with ``NO_AD``.
+for a full example that also demonstrates skipping a routine with ``SKIP``.
 
-Use ``NO_AD`` to indicate that a routine should be parsed but skipped when
+Use ``SKIP`` to indicate that a routine should be parsed but skipped when
 generating AD code:
 
 ```fortran
-!$FAD NO_AD
+!$FAD SKIP
 subroutine skip_me(x)
   ! ...
 end subroutine skip_me

--- a/examples/directives.f90
+++ b/examples/directives.f90
@@ -14,7 +14,7 @@ contains
     return
   end subroutine add_const
 
-!$FAD NO_AD
+!$FAD SKIP
   subroutine skip_me(x)
     real, intent(in) :: x
 

--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -719,7 +719,7 @@ class CallStatement(Node):
         arg_info = routine_map[name]
 
         name_key = "name_rev_ad" if reverse else "name_fwd_ad"
-        if arg_info.get("no_ad") or arg_info.get(name_key) is None:
+        if arg_info.get("skip") or arg_info.get(name_key) is None:
             return [self]
 
         def _push_arg(i, arg):

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -109,7 +109,7 @@ def _write_fadmod(mod_name: str, routines, routine_map: dict, directory: Path) -
         info = dict(info)
         info["module"] = mod_name
         if info.get("name_fwd_ad") is None and info.get("name_rev_ad") is None:
-            info["no_ad"] = True
+            info["skip"] = True
         data[r.name] = info
 
     if not data:
@@ -180,8 +180,8 @@ def _prepare_fwd_ad_header(routine_org):
     subroutine.ad_init = Block([])
     subroutine.ad_content = Block([])
 
-    no_ad = bool(routine_org.directives.get("NO_AD")) or len(out_grad_args) == 0
-    if no_ad:
+    skip = bool(routine_org.directives.get("SKIP")) or len(out_grad_args) == 0
+    if skip:
         arg_info["name_fwd_ad"] = None
 
     return {
@@ -191,7 +191,7 @@ def _prepare_fwd_ad_header(routine_org):
         "out_grad_args": out_grad_args,
         "has_grad_input": has_grad_input,
         "arg_info": arg_info,
-        "no_ad": no_ad,
+        "skip": skip,
     }
 
 
@@ -273,8 +273,8 @@ def _prepare_rev_ad_header(routine_org):
     subroutine.ad_init = Block([])
     subroutine.ad_content = Block([])
 
-    no_ad = bool(routine_org.directives.get("NO_AD")) or len(out_grad_args) == 0
-    if no_ad:
+    skip = bool(routine_org.directives.get("SKIP")) or len(out_grad_args) == 0
+    if skip:
         arg_info["name_rev_ad"] = None
 
     return {
@@ -284,7 +284,7 @@ def _prepare_rev_ad_header(routine_org):
         "out_grad_args": out_grad_args,
         "has_grad_input": has_grad_input,
         "arg_info": arg_info,
-        "no_ad": no_ad,
+        "skip": skip,
     }
 
 
@@ -310,7 +310,7 @@ def _collect_called_ad_modules(blocks, routine_map, reverse):
 
 
 def _generate_fwd_ad_subroutine(routine_org, routine_map, routine_info, warnings):
-    if routine_info.get("no_ad"):
+    if routine_info.get("skip"):
         return None, set()
 
     subroutine = routine_info["subroutine"]
@@ -478,7 +478,7 @@ def _generate_fwd_ad_subroutine(routine_org, routine_map, routine_info, warnings
 
 
 def _generate_rev_ad_subroutine(routine_org, routine_map, routine_info, warnings):
-    if routine_info.get("no_ad"):
+    if routine_info.get("skip"):
         return None, False, set()
 
     subroutine = routine_info["subroutine"]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -69,7 +69,7 @@ class TestGenerator(unittest.TestCase):
             generated = generator.generate_ad(str(src), warn=False)
             self.assertNotIn("a_ad", generated)
 
-    def test_fadmod_includes_no_ad(self):
+    def test_fadmod_includes_skip(self):
         code_tree.Node.reset()
         fadmod = Path("directives.fadmod")
         if fadmod.exists():
@@ -77,9 +77,9 @@ class TestGenerator(unittest.TestCase):
         generator.generate_ad("examples/directives.f90", warn=False)
         data = json.loads(fadmod.read_text())
         self.assertIn("skip_me", data)
-        self.assertTrue(data["skip_me"].get("no_ad"))
+        self.assertTrue(data["skip_me"].get("skip"))
 
-    def test_no_ad_call_skips_derivatives(self):
+    def test_skip_call_skips_derivatives(self):
         code_tree.Node.reset()
         from tempfile import TemporaryDirectory
         import textwrap
@@ -88,7 +88,7 @@ class TestGenerator(unittest.TestCase):
             """
             module test
             contains
-            !$FAD NO_AD
+            !$FAD SKIP
               subroutine foo(x, y)
                 real, intent(in) :: x
                 real, intent(out) :: y
@@ -117,7 +117,7 @@ class TestGenerator(unittest.TestCase):
         self.assertIn("bar_rev_ad", generated)
         self.assertIn("call foo(x, y)", generated)
         self.assertIn("foo", fadmod)
-        self.assertTrue(fadmod["foo"].get("no_ad"))
+        self.assertTrue(fadmod["foo"].get("skip"))
 
 
 def _make_example_test(src: Path):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -179,12 +179,12 @@ class TestParser(unittest.TestCase):
         var = routine.get_var("z")
         self.assertTrue(var.is_constant)
 
-    def test_parse_directive_no_ad(self):
+    def test_parse_directive_skip(self):
         src = textwrap.dedent(
             """
             module test
             contains
-            !$FAD NO_AD
+            !$FAD SKIP
               subroutine foo(x)
                 real :: x
                 x = x + 1.0
@@ -194,7 +194,7 @@ class TestParser(unittest.TestCase):
         )
         module = parser.parse_src(src)[0]
         routine = module.routines[0]
-        self.assertIn("NO_AD", routine.directives)
+        self.assertIn("SKIP", routine.directives)
 
 
 


### PR DESCRIPTION
## Summary
- rename `NO_AD` directive to `SKIP`
- rename generated fadmod flag to `skip`
- update examples and README to use new directive
- adjust generator and code tree to respect `SKIP`
- update unit tests for the new directive

## Testing
- `python tests/test_generator.py`
- `python tests/test_fortran_runtime.py`
- `python tests/test_parser.py`


------
https://chatgpt.com/codex/tasks/task_b_686b2f73f71c832d9a6b154e05109aa3