### PR TITLE
Fix CLI tool import path and Python version

### DIFF
--- a/bin/fautodiff
+++ b/bin/fautodiff
@@ -1,4 +1,14 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""Entry point for the ``fautodiff`` command line tool."""
+
+import os
+import sys
+
+# Ensure the package can be imported when running from the source tree
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
 from fautodiff.cli import main
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure `bin/fautodiff` is executed with python3
- make running the script from the repository work by adding the project root to `sys.path`

## Testing
- `python3 tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_686b392cf44c832dac5fea769c70e000