### PR TITLE
Handle keyword arguments in call statements

### DIFF
--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -635,6 +635,7 @@ class CallStatement(Node):
 
     name: str
     args: List[Operator] = field(default_factory=list)
+    keywords: Optional[List[Optional[str]]] = None
     intents: Optional[List[str]] = None
     result: Optional[OpVar] = None
     info: Optional[dict] = field(repr=False, default=None)
@@ -651,6 +652,10 @@ class CallStatement(Node):
                 self.args[i] = OpInt(arg)
             elif not isinstance(arg, Operator):
                 raise ValueError(f"arg must be Operator: {type(arg)}")
+        if self.keywords is None:
+            self.keywords = [None] * len(self.args)
+        if len(self.keywords) != len(self.args):
+            raise ValueError("keywords length must match args length")
         if self.intents is not None:
             if not isinstance(self.intents, list):
                 raise ValueError(f"intents must be a list: {type(self.intents)}")
@@ -678,7 +683,13 @@ class CallStatement(Node):
 
     def render(self, indent: int = 0) -> List[str]:
         space = "  " * indent
-        args = ", ".join([str(a) for a in self.args])
+        arg_strs = []
+        for key, arg in zip(self.keywords, self.args):
+            if key is None:
+                arg_strs.append(str(arg))
+            else:
+                arg_strs.append(f"{key}={arg}")
+        args = ", ".join(arg_strs)
         ad_comment = ""
         if self.ad_info is not None:
             ad_comment = f" ! {self.ad_info}"

--- a/tests/test_code_tree.py
+++ b/tests/test_code_tree.py
@@ -577,6 +577,10 @@ class TestCallStatement(unittest.TestCase):
         self.assertEqual({str(v) for v in node.iter_ref_vars()}, {"a"})
         self.assertEqual({str(v) for v in node.iter_assign_vars()}, {"b"})
 
+    def test_keyword_render(self):
+        node = CallStatement("foo", [OpInt(1), OpInt(2)], keywords=["a", "b"]) 
+        self.assertEqual(render_program(Block([node])), "call foo(a=1, b=2)\n")
+
 
 class TestLoopAnalysis(unittest.TestCase):
     def test_simple_loop(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,6 +6,7 @@ import textwrap
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from fautodiff import parser, code_tree, operators
+from fautodiff.code_tree import Block, render_program
 
 
 class TestParser(unittest.TestCase):
@@ -43,6 +44,22 @@ class TestParser(unittest.TestCase):
         stmt = routine.content.first()
         self.assertIsInstance(stmt, code_tree.CallStatement)
         self.assertEqual(stmt.name, "foo")
+
+    def test_parse_call_stmt_keyword_args(self):
+        src = textwrap.dedent("""\
+        module test
+        contains
+          subroutine wrapper()
+            call foo(a=1, b=2)
+          end subroutine wrapper
+        end module test
+        """)
+        module = parser.parse_src(src)[0]
+        routine = module.routines[0]
+        stmt = routine.content.first()
+        self.assertIsInstance(stmt, code_tree.CallStatement)
+        self.assertEqual(stmt.keywords, ["a", "b"])
+        self.assertEqual(render_program(Block([stmt])), "call foo(a=1, b=2)\n")
 
     def test_parse_call_stmt_in_function(self):
         src = textwrap.dedent("""\


### PR DESCRIPTION
## Summary
- support keyword arguments when parsing `Call_Stmt`
- keep argument names in `CallStatement`
- render keywords when printing calls
- test keyword parsing and rendering

## Testing
- `pytest -q`
- `python tests/test_generator.py -q`


------
https://chatgpt.com/codex/tasks/task_b_686b97c89b00832d9b12d786c43eeef7