### PR TITLE
Fix argument ordering for keyword calls

### DIFF
--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -411,7 +411,7 @@ def _parse_routine(content, src_name):
         if isinstance(stmt, Fortran2003.Call_Stmt):
             name = stmt.items[0].tofortran()
             args = []
-            keywords = []
+            arg_keys = []
             if stmt.items[1] is not None:
                 for arg in stmt.items[1].items:
                     if isinstance(arg, str):
@@ -423,8 +423,8 @@ def _parse_routine(content, src_name):
                             key = str(arg.items[0])
                         val = arg.items[1]
                     args.append(_stmt2op(val, decls))
-                    keywords.append(key)
-            return CallStatement(name, args, keywords=keywords, info=info)
+                    arg_keys.append(key)
+            return CallStatement(name, args, arg_keys=arg_keys, info=info)
         if isinstance(stmt, Fortran2003.If_Construct):
             cond_blocks = []
             cond = _stmt2op(stmt.content[0].items[0], decls)

--- a/tests/test_code_tree.py
+++ b/tests/test_code_tree.py
@@ -578,7 +578,7 @@ class TestCallStatement(unittest.TestCase):
         self.assertEqual({str(v) for v in node.iter_assign_vars()}, {"b"})
 
     def test_keyword_render(self):
-        node = CallStatement("foo", [OpInt(1), OpInt(2)], keywords=["a", "b"]) 
+        node = CallStatement("foo", [OpInt(1), OpInt(2)], arg_keys=["a", "b"])
         self.assertEqual(render_program(Block([node])), "call foo(a=1, b=2)\n")
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -58,7 +58,7 @@ class TestParser(unittest.TestCase):
         routine = module.routines[0]
         stmt = routine.content.first()
         self.assertIsInstance(stmt, code_tree.CallStatement)
-        self.assertEqual(stmt.keywords, ["a", "b"])
+        self.assertEqual(stmt.arg_keys, ["a", "b"])
         self.assertEqual(render_program(Block([stmt])), "call foo(a=1, b=2)\n")
 
     def test_parse_call_stmt_in_function(self):


### PR DESCRIPTION
## Summary
- store keyword arguments in `arg_keys`
- use `arg_keys` instead of the deprecated `keywords` field

## Testing
- `pytest -q`
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_686b9a09b710832db7450041e040ca1b