### PR TITLE
Support module declarations in Routine

### DIFF
--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -902,6 +902,7 @@ class Routine(Node):
     decls: Block = field(default_factory=Block)
     content: Block = field(default_factory=Block)
     directives: dict = field(default_factory=dict)
+    mod_decls: Optional[Block] = None
     ad_init: Optional[Block] = None
     ad_content: Optional[Block] = None
     kind: ClassVar[str] = "subroutine"
@@ -948,6 +949,8 @@ class Routine(Node):
 
     def get_var(self, name: str) -> Optional[OpVar]:
         decl = self.decls.find_by_name(name)
+        if decl is None and self.mod_decls is not None:
+            decl = self.mod_decls.find_by_name(name)
         if decl is None:
             return None
         intent = decl.intent
@@ -972,7 +975,11 @@ class Routine(Node):
         return vars
 
     def is_declared(self, name: str) -> bool:
-        return self.decls.find_by_name(name) is not None
+        if self.decls.find_by_name(name) is not None:
+            return True
+        if self.mod_decls is not None and self.mod_decls.find_by_name(name) is not None:
+            return True
+        return False
 
     def required_vars(self, vars: Optional[VarList] = None, no_accumulate: bool = False, without_savevar: bool = False) -> VarList:
         for block in reversed(self._all_blocks()):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -143,6 +143,17 @@ class TestParser(unittest.TestCase):
         self.assertIsNotNone(decl)
         self.assertEqual(decl.kind, "RP")
 
+    def test_routine_mod_decls(self):
+        src = Path(__file__).resolve().parents[1] / "examples" / "real_kind.f90"
+        module = parser.parse_file(str(src))[0]
+        routine = next(r for r in module.routines if r.name == "scale_rp")
+        self.assertTrue(routine.is_declared("RP"))
+        decl = routine.mod_decls.find_by_name("RP")
+        self.assertIsNotNone(decl)
+        var = routine.get_var("RP")
+        self.assertIsNotNone(var)
+        self.assertTrue(var.is_constant)
+
     def test_module_level_decls(self):
         src = textwrap.dedent(
             """


### PR DESCRIPTION
## Summary
- extend `Routine` with `mod_decls`
- include module and imported declarations when parsing routines
- search `mod_decls` in `Routine.get_var` and `Routine.is_declared`
- add regression test for `mod_decls`

## Testing
- `python tests/test_generator.py`
- `pytest tests/test_parser.py::TestParser::test_routine_mod_decls -q`


------
https://chatgpt.com/codex/tasks/task_b_686bbedd53f4832d904bf7f72c36b245