### PR TITLE
Add module variable example and tests

### DIFF
--- a/examples/module_vars.f90
+++ b/examples/module_vars.f90
@@ -1,0 +1,14 @@
+module module_vars
+  implicit none
+  real :: c
+contains
+  subroutine inc_and_use(x, y)
+    real, intent(in) :: x
+    real, intent(out) :: y
+
+    y = (c + x) * 2.0
+    c = c + x
+
+    return
+  end subroutine inc_and_use
+end module module_vars

--- a/examples/module_vars_ad.f90
+++ b/examples/module_vars_ad.f90
@@ -1,0 +1,28 @@
+module module_vars_ad
+  use module_vars
+  implicit none
+
+contains
+
+  subroutine inc_and_use_fwd_ad(x, x_ad, y_ad)
+    real, intent(in)  :: x
+    real, intent(in)  :: x_ad
+    real, intent(out) :: y_ad
+
+    y_ad = x_ad * 2.0 ! y = (c + x) * 2.0
+
+    return
+  end subroutine inc_and_use_fwd_ad
+
+  subroutine inc_and_use_rev_ad(x, x_ad, y_ad)
+    real, intent(in)  :: x
+    real, intent(out) :: x_ad
+    real, intent(inout) :: y_ad
+
+    x_ad = y_ad * 2.0 ! y = (c + x) * 2.0
+    y_ad = 0.0 ! y = (c + x) * 2.0
+
+    return
+  end subroutine inc_and_use_rev_ad
+
+end module module_vars_ad

--- a/tests/fortran_runtime/Makefile
+++ b/tests/fortran_runtime/Makefile
@@ -9,7 +9,7 @@ vpath %.f90 .
 
 PROGRAMS = run_simple_math run_arrays run_call_example run_control_flow run_cross_mod \
            run_data_storage run_intrinsic_func run_real_kind run_save_vars run_store_vars \
-           run_directives run_parameter_var
+           run_directives run_parameter_var run_module_vars
 
 all: $(PROGRAMS)
 
@@ -37,6 +37,7 @@ $(OUTDIR)/run_store_vars.o: $(OUTDIR)/store_vars.o $(OUTDIR)/store_vars_ad.o \
   $(OUTDIR)/data_storage.o
 $(OUTDIR)/run_directives.o: $(OUTDIR)/directives.o $(OUTDIR)/directives_ad.o
 $(OUTDIR)/run_parameter_var.o: $(OUTDIR)/parameter_var.o $(OUTDIR)/parameter_var_ad.o
+$(OUTDIR)/run_module_vars.o: $(OUTDIR)/module_vars.o $(OUTDIR)/module_vars_ad.o
 
 # Additional module dependencies
 $(OUTDIR)/store_vars_ad.o: $(OUTDIR)/store_vars.mod $(OUTDIR)/data_storage.o
@@ -77,6 +78,9 @@ run_directives: $(OUTDIR)/run_directives.o $(OUTDIR)/directives.o $(OUTDIR)/dire
 	$(FC) $^ -o $@
 
 run_parameter_var: $(OUTDIR)/run_parameter_var.o $(OUTDIR)/parameter_var.o $(OUTDIR)/parameter_var_ad.o
+	$(FC) $^ -o $@
+
+run_module_vars: $(OUTDIR)/run_module_vars.o $(OUTDIR)/module_vars.o $(OUTDIR)/module_vars_ad.o
 	$(FC) $^ -o $@
 
 

--- a/tests/fortran_runtime/run_module_vars.f90
+++ b/tests/fortran_runtime/run_module_vars.f90
@@ -1,0 +1,72 @@
+program run_module_vars
+  use module_vars
+  use module_vars_ad
+  implicit none
+  real, parameter :: tol = 1.0e-4
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_inc_and_use = 1
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("inc_and_use")
+              i_test = I_inc_and_use
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_inc_and_use .or. i_test == I_all) then
+     call test_inc_and_use
+  end if
+
+  stop
+contains
+
+  subroutine test_inc_and_use
+    real :: x, y
+    real :: x_ad, y_ad
+    real :: y_eps, fd, eps
+    real :: inner1, inner2
+
+    eps = 1.0e-3
+    c = 1.0
+    x = 2.0
+    call inc_and_use(x, y)
+    c = 1.0
+    call inc_and_use(x + eps, y_eps)
+    fd = (y_eps - y) / eps
+    c = 1.0
+    x_ad = 1.0
+    call inc_and_use_fwd_ad(x, x_ad, y_ad)
+    if (abs((y_ad - fd) / fd) > tol) then
+       print *, 'test_inc_and_use_fwd failed', y_ad, fd
+       error stop 1
+    end if
+
+    inner1 = y_ad**2
+    call inc_and_use_rev_ad(x, x_ad, y_ad)
+    inner2 = x_ad
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_inc_and_use_rev failed', inner1, inner2
+       error stop 1
+    end if
+
+    return
+  end subroutine test_inc_and_use
+
+end program run_module_vars

--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -101,6 +101,10 @@ class TestFortranADCode(unittest.TestCase):
     def test_parameter_var(self):
         self._run_test('parameter_var', ['compute_area'])
 
+    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
+    def test_module_vars(self):
+        self._run_test('module_vars', ['inc_and_use'])
+
 
 
 if __name__ == '__main__':

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -207,6 +207,16 @@ class TestParser(unittest.TestCase):
         var = module.routines[0].get_var("c")
         self.assertFalse(var.ad_target)
 
+    def test_parse_example_module_vars(self):
+        base = Path(__file__).resolve().parents[1]
+        src = base / "examples" / "module_vars.f90"
+        modules = parser.parse_file(str(src))
+        self.assertEqual(len(modules), 1)
+        mod = modules[0]
+        decl = mod.decls.find_by_name("c")
+        self.assertIsNotNone(decl)
+        self.assertEqual(mod.routines[0].name, "inc_and_use")
+
     def test_module_decl_with_intent_error(self):
         src = textwrap.dedent(
             """


### PR DESCRIPTION
## Summary
- add `module_vars.f90` example with a module variable
- include generated AD output for the example
- extend generator and parser tests for module variables
- add runtime driver and Makefile rules for new example
- run new driver from `test_fortran_adcode`

## Testing
- `python tests/test_parser.py`
- `python tests/test_generator.py`
- `python tests/test_fortran_adcode.py`

------
https://chatgpt.com/codex/tasks/task_b_686bdfa6a930832da5cb1dca0c0be593