### PR TITLE
Support allocatable attribute in declarations

### DIFF
--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -1454,6 +1454,7 @@ class Declaration(Node):
     constant: bool = False
     init: Optional[str] = None
     access: Optional[str] = None
+    allocatable: bool = False
 
     def __post_init__(self):
         super().__post_init__()
@@ -1462,7 +1463,13 @@ class Declaration(Node):
 
     def iter_assign_vars(self, without_savevar: bool = False) -> Iterator[OpVar]:
         if self.intent in ("in", "inout"):
-            yield OpVar(name=self.name, typename=self.typename, kind=self.kind, is_constant=self.parameter or self.constant)
+            yield OpVar(
+                name=self.name,
+                typename=self.typename,
+                kind=self.kind,
+                is_constant=self.parameter or self.constant,
+                allocatable=self.allocatable,
+            )
         else:
             return iter(())
 
@@ -1478,6 +1485,8 @@ class Declaration(Node):
             line += ", parameter"
         if self.access is not None:
             line += f", {self.access}"
+        if self.allocatable:
+            line += ", allocatable"
         if self.intent is not None:
             pad = "  " if self.intent == "in" else " "
             line += f", intent({self.intent})" + pad + f":: {self.name}"
@@ -1509,7 +1518,15 @@ class Declaration(Node):
         if self.intent in ("in", "inout"):
             if self.name.endswith(AD_SUFFIX):
                 vars = vars.copy()
-                vars.push(OpVar(self.name, typename=self.typename, kind=self.kind, is_constant=self.parameter or self.constant))
+                vars.push(
+                    OpVar(
+                        self.name,
+                        typename=self.typename,
+                        kind=self.kind,
+                        is_constant=self.parameter or self.constant,
+                        allocatable=self.allocatable,
+                    )
+                )
         return vars
 
 

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -154,6 +154,7 @@ def _write_fadmod(mod: Module, routine_map: dict, directory: Path) -> None:
                     "constant": d.constant,
                     "init": d.init,
                     "access": d.access,
+                    "allocatable": d.allocatable,
                 }
 
     if not routines_data and not variables_data:
@@ -208,6 +209,7 @@ def _prepare_fwd_ad_header(routine_org):
                 intent=arg.intent,
                 ad_target=True,
                 is_constant=arg.is_constant,
+                allocatable=arg.allocatable,
             )
             args.append(var)
             grad_args.append(var)
@@ -228,7 +230,14 @@ def _prepare_fwd_ad_header(routine_org):
     arg_info["name_fwd_ad"] = ad_name
     for var in args:
         subroutine.decls.append(
-            Declaration(var.name, var.typename, var.kind, var.dims, var.intent)
+            Declaration(
+                var.name,
+                var.typename,
+                var.kind,
+                var.dims,
+                var.intent,
+                allocatable=var.allocatable,
+            )
         )
         arg_info["args_fwd_ad"].append(var.name)
         arg_info["intents_fwd_ad"].append(var.intent)
@@ -293,6 +302,7 @@ def _prepare_rev_ad_header(routine_org):
                     intent="inout",
                     ad_target=True,
                     is_constant=arg.is_constant,
+                    allocatable=arg.allocatable,
                 )
                 args.append(var)
                 grad_args.append(var)
@@ -314,6 +324,7 @@ def _prepare_rev_ad_header(routine_org):
                     intent=grad_intent,
                     ad_target=True,
                     is_constant=arg.is_constant,
+                    allocatable=arg.allocatable,
                 )
                 args.append(var)
                 grad_args.append(var)
@@ -329,7 +340,14 @@ def _prepare_rev_ad_header(routine_org):
     arg_info["name_rev_ad"] = ad_name
     for var in args:
         subroutine.decls.append(
-            Declaration(var.name, var.typename, var.kind, var.dims, var.intent)
+            Declaration(
+                var.name,
+                var.typename,
+                var.kind,
+                var.dims,
+                var.intent,
+                allocatable=var.allocatable,
+            )
         )
         arg_info["args_rev_ad"].append(var.name)
         arg_info["intents_rev_ad"].append(var.intent)
@@ -429,6 +447,7 @@ def _generate_ad_subroutine(
                             None,
                             base_decl.parameter if base_decl else False,
                             init=base_decl.init if base_decl else None,
+                            allocatable=base_decl.allocatable if base_decl else False,
                         )
                     )
 
@@ -503,6 +522,7 @@ def _generate_ad_subroutine(
                         None,
                         base_decl.parameter,
                         init=base_decl.init,
+                        allocatable=base_decl.allocatable,
                     )
             if decl is not None:
                 if decl.intent is not None and decl.intent == "out":
@@ -557,6 +577,7 @@ def _generate_ad_subroutine(
                 None,
                 base_decl.parameter if base_decl else False,
                 init=base_decl.init if base_decl else None,
+                allocatable=base_decl.allocatable if base_decl else False,
             )
         )
 

--- a/fautodiff/operators.py
+++ b/fautodiff/operators.py
@@ -623,6 +623,7 @@ class OpVar(OpLeaf):
     ad_target: Optional[bool] = field(default=None, repr=False)
     is_constant: Optional[bool] = field(default=None, repr=False)
     reference: Optional["OpVar"] = field(repr=False, default=None)
+    allocatable: Optional[bool] = field(default=None, repr=False)
     reduced_dims: Optional[List[int]] = field(init=False, repr=False, default=None)
 
     def __init__(
@@ -636,6 +637,7 @@ class OpVar(OpLeaf):
         intent: Optional[str] = None,
         ad_target: Optional[bool] = None,
         is_constant: Optional[bool] = None,
+        allocatable: Optional[bool] = None,
     ):
         super().__init__(args=[])
         if not isinstance(name, str):
@@ -653,6 +655,7 @@ class OpVar(OpLeaf):
         self.intent = intent
         self.ad_target = ad_target
         self.is_constant = is_constant
+        self.allocatable = allocatable
         if self.ad_target is None and self.typename is not None:
             typename = self.typename.lower()
             is_real_type = typename.startswith("real") or typename.startswith("double")
@@ -683,6 +686,7 @@ class OpVar(OpLeaf):
             intent=self.intent,
             ad_target=self.ad_target,
             is_constant=self.is_constant,
+            allocatable=self.allocatable,
         )
 
     def add_suffix(self, suffix: Optional[str] = None) -> "OpVar":
@@ -702,6 +706,7 @@ class OpVar(OpLeaf):
             intent=self.intent,
             ad_target=self.ad_target,
             is_constant=self.is_constant,
+            allocatable=self.allocatable,
         )
 
     def collect_vars(self, without_index: bool = False) -> List[OpVar]:

--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -126,6 +126,7 @@ def _stmt2op(stmt, decls:Block):
             typename=decl.typename,
             kind=kind,
             is_constant=decl.parameter or getattr(decl, "constant", False),
+            allocatable=getattr(decl, "allocatable", False),
         )
 
     if isinstance(stmt, Fortran2003.Part_Ref):
@@ -149,6 +150,7 @@ def _stmt2op(stmt, decls:Block):
                 typename=decl.typename,
                 kind=decl.kind,
                 is_constant=decl.parameter or getattr(decl, "constant", False),
+                allocatable=getattr(decl, "allocatable", False),
             )
 
     if isinstance(stmt, Fortran2003.Subscript_Triplet):
@@ -302,6 +304,7 @@ def _parse_decl_stmt(
     dim_attr = None
     parameter = False
     access = None
+    allocatable = False
     attrs = stmt.items[1]
     if attrs is not None:
         for attr in attrs.items:
@@ -313,6 +316,8 @@ def _parse_decl_stmt(
                 break
             if name == "parameter":
                 parameter = True
+            if name == "allocatable":
+                allocatable = True
             if allow_access and name in ("public", "private"):
                 access = name
 
@@ -344,6 +349,7 @@ def _parse_decl_stmt(
                 constant,
                 init=init,
                 access=access,
+                allocatable=allocatable,
             )
         )
 
@@ -855,6 +861,7 @@ def _parse_routine(content, src_name: str, module: Optional[Module]=None, module
                                         info.get("constant", False),
                                         init=info.get("init"),
                                         access=info.get("access"),
+                                        allocatable=info.get("allocatable", False),
                                     )
                                 )
 
@@ -918,6 +925,7 @@ def _parse_routine(content, src_name: str, module: Optional[Module]=None, module
                                         info.get("constant", False),
                                         init=info.get("init"),
                                         access=info.get("access"),
+                                        allocatable=info.get("allocatable", False),
                                     )
                                 )
             if module.decls is not None:
@@ -949,6 +957,7 @@ def _parse_routine(content, src_name: str, module: Optional[Module]=None, module
                                     info.get("constant", False),
                                     init=info.get("init"),
                                     access=info.get("access"),
+                                    allocatable=info.get("allocatable", False),
                                 )
                             )
 


### PR DESCRIPTION
## Summary
- handle `allocatable` attribute when parsing declarations
- store this property on `OpVar`
- include allocatable info when writing `.fadmod` files

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_686cb60de744832d9693163014d1580f