### PR TITLE
Add allocation example

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -17,6 +17,7 @@ $(OUTDIR)/%_ad.o: $(OUTDIR)/%.mod
 # Cross-module dependencies
 $(OUTDIR)/cross_mod_b.o: $(OUTDIR)/cross_mod_a.mod
 $(OUTDIR)/cross_mod_b_ad.o: $(OUTDIR)/cross_mod_b.mod $(OUTDIR)/cross_mod_a_ad.mod
+$(OUTDIR)/allocate_ad.o: $(OUTDIR)/allocate_example.mod
 
 clean:
 	rm -f $(OUTDIR)/*.o $(OUTDIR)/*.mod

--- a/examples/allocate.f90
+++ b/examples/allocate.f90
@@ -1,0 +1,18 @@
+module allocate_example
+  implicit none
+contains
+
+  subroutine allocate_and_sum(n, x, res)
+    integer, intent(in) :: n
+    real, intent(in) :: x
+    real, intent(out) :: res
+    real, allocatable :: arr(:)
+
+    allocate(arr(n))
+    res = x * 2.0
+    deallocate(arr)
+
+    return
+  end subroutine allocate_and_sum
+
+end module allocate_example

--- a/examples/allocate_ad.f90
+++ b/examples/allocate_ad.f90
@@ -1,0 +1,30 @@
+module allocate_example_ad
+  use allocate_example
+  implicit none
+
+contains
+
+  subroutine allocate_and_sum_fwd_ad(n, x, x_ad, res_ad)
+    integer, intent(in)  :: n
+    real, intent(in)  :: x
+    real, intent(in)  :: x_ad
+    real, intent(out) :: res_ad
+
+    res_ad = x_ad * 2.0 ! res = x * 2.0
+
+    return
+  end subroutine allocate_and_sum_fwd_ad
+
+  subroutine allocate_and_sum_rev_ad(n, x, x_ad, res_ad)
+    integer, intent(in)  :: n
+    real, intent(in)  :: x
+    real, intent(out) :: x_ad
+    real, intent(inout) :: res_ad
+
+    x_ad = res_ad * 2.0 ! res = x * 2.0
+    res_ad = 0.0 ! res = x * 2.0
+
+    return
+  end subroutine allocate_and_sum_rev_ad
+
+end module allocate_example_ad

--- a/tests/fortran_runtime/Makefile
+++ b/tests/fortran_runtime/Makefile
@@ -8,8 +8,8 @@ vpath %.f90 ../../fortran_modules
 vpath %.f90 .
 
 PROGRAMS = run_simple_math run_arrays run_call_example run_control_flow run_cross_mod \
-           run_data_storage run_intrinsic_func run_real_kind run_save_vars run_store_vars \
-           run_directives run_parameter_var run_module_vars
+	   run_data_storage run_intrinsic_func run_real_kind run_save_vars run_store_vars \
+	   run_directives run_parameter_var run_module_vars run_allocate
 
 all: $(PROGRAMS)
 
@@ -38,11 +38,13 @@ $(OUTDIR)/run_store_vars.o: $(OUTDIR)/store_vars.o $(OUTDIR)/store_vars_ad.o \
 $(OUTDIR)/run_directives.o: $(OUTDIR)/directives.o $(OUTDIR)/directives_ad.o
 $(OUTDIR)/run_parameter_var.o: $(OUTDIR)/parameter_var.o $(OUTDIR)/parameter_var_ad.o
 $(OUTDIR)/run_module_vars.o: $(OUTDIR)/module_vars.o $(OUTDIR)/module_vars_ad.o
+$(OUTDIR)/run_allocate.o: $(OUTDIR)/allocate.o $(OUTDIR)/allocate_ad.o
 
 # Additional module dependencies
 $(OUTDIR)/store_vars_ad.o: $(OUTDIR)/store_vars.mod $(OUTDIR)/data_storage.o
 $(OUTDIR)/cross_mod_b.o: $(OUTDIR)/cross_mod_a.mod
 $(OUTDIR)/cross_mod_b_ad.o: $(OUTDIR)/cross_mod_b.mod $(OUTDIR)/cross_mod_a_ad.mod
+$(OUTDIR)/allocate_ad.o: $(OUTDIR)/allocate_example.mod
 
 run_simple_math: $(OUTDIR)/run_simple_math.o $(OUTDIR)/simple_math.o $(OUTDIR)/simple_math_ad.o
 	$(FC) $^ -o $@
@@ -81,6 +83,9 @@ run_parameter_var: $(OUTDIR)/run_parameter_var.o $(OUTDIR)/parameter_var.o $(OUT
 	$(FC) $^ -o $@
 
 run_module_vars: $(OUTDIR)/run_module_vars.o $(OUTDIR)/module_vars.o $(OUTDIR)/module_vars_ad.o
+	$(FC) $^ -o $@
+
+run_allocate: $(OUTDIR)/run_allocate.o $(OUTDIR)/allocate.o $(OUTDIR)/allocate_ad.o
 	$(FC) $^ -o $@
 
 

--- a/tests/fortran_runtime/run_allocate.f90
+++ b/tests/fortran_runtime/run_allocate.f90
@@ -1,0 +1,70 @@
+program run_allocate
+  use allocate_example
+  use allocate_example_ad
+  implicit none
+  real, parameter :: tol = 1.0e-4
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_allocate_and_sum = 1
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("allocate_and_sum")
+              i_test = I_allocate_and_sum
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_allocate_and_sum .or. i_test == I_all) then
+     call test_allocate_and_sum
+  end if
+
+  stop
+contains
+
+  subroutine test_allocate_and_sum
+    integer, parameter :: n = 5
+    real :: x, res
+    real :: x_ad, res_ad
+    real :: res_eps, fd, eps
+    real :: inner1, inner2
+
+    eps = 1.0e-3
+    x = 2.0
+    call allocate_and_sum(n, x, res)
+    call allocate_and_sum(n, x + eps, res_eps)
+    fd = (res_eps - res) / eps
+    x_ad = 1.0
+    call allocate_and_sum_fwd_ad(n, x, x_ad, res_ad)
+    if (abs((res_ad - fd) / fd) > tol) then
+       print *, 'test_allocate_and_sum_fwd failed', res_ad, fd
+       error stop 1
+    end if
+
+    inner1 = res_ad**2
+    call allocate_and_sum_rev_ad(n, x, x_ad, res_ad)
+    inner2 = x_ad
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_allocate_and_sum_rev failed', inner1, inner2
+       error stop 1
+    end if
+
+    return
+  end subroutine test_allocate_and_sum
+
+end program run_allocate

--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -105,6 +105,10 @@ class TestFortranADCode(unittest.TestCase):
     def test_module_vars(self):
         self._run_test('module_vars', ['inc_and_use'])
 
+    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
+    def test_allocate(self):
+        self._run_test('allocate', ['allocate_and_sum'])
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add a simple allocation example to demonstrate allocating and freeing an array
- provide the generated AD version of the example
- create runtime driver for the new example
- build the new program in example and runtime Makefiles
- run the allocation check from `test_fortran_adcode.py`

## Testing
- `python tests/test_generator.py`
- `python tests/test_fortran_adcode.py`

------
https://chatgpt.com/codex/tasks/task_b_686cbe9f5c3c832d9170aa459edcaa1c