### PR TITLE
Update README with module allocation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ contains
 end module test
 ```
 
+Module variables or names brought in with ``use`` remain constants unless
+``DIFF_MODULE_VARS`` (or other directives) requests their differentiation.  If
+no corresponding ``_ad`` variable exists, any ``allocate`` or ``deallocate``
+statements for such variables are omitted from the generated code.
+
 Run the included tests with:
 
 ```bash


### PR DESCRIPTION
## Summary
- document that module and imported variables without AD derivatives don't need allocation

## Testing
- `python tests/test_generator.py`
- `python tests/test_fortran_runtime.py`


------
https://chatgpt.com/codex/tasks/task_b_686ce7566fa4832daa32d0caa41010df