### PR TITLE
Add CONSTANT_VARS directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,56 +92,8 @@ Generate reverse mode only:
 bin/fautodiff --mode reverse examples/simple_math.f90
 ```
 
-## Optimization Directives
-
-Comment directives may be placed immediately before a subroutine or function
-definition to influence how the AD code is generated. They are optional
-comments processed by ``fautodiff`` and do not change the original Fortran
-semantics.
-
-Use ``CONSTANT_ARGS`` to mark arguments that should be treated as constants
-during differentiation. Specify the argument names after a colon:
-
-```fortran
-!$FAD CONSTANT_ARGS: arg1, arg2
-subroutine foo(arg1, arg2, arg3)
-  ! ...
-end subroutine foo
-```
-
-Arguments listed in ``CONSTANT_ARGS`` do not receive corresponding ``_ad``
-variables in the generated routine. See ``examples/directives.f90``
-for a full example that also demonstrates skipping a routine with ``SKIP``.
-
-Use ``SKIP`` to indicate that a routine should be parsed but skipped when
-generating AD code:
-
-```fortran
-!$FAD SKIP
-subroutine skip_me(x)
-  ! ...
-end subroutine skip_me
-```
-
-Use ``DIFF_MODULE_VARS`` to differentiate selected module variables which are
-normally treated as constants. Place the directive before ``contains``:
-
-```fortran
-module test
-  real :: c
-  !$FAD DIFF_MODULE_VARS: c
-contains
-  subroutine foo(x)
-    real, intent(inout) :: x
-    c = c + x
-  end subroutine foo
-end module test
-```
-
-Module variables or names brought in with ``use`` remain constants unless
-``DIFF_MODULE_VARS`` (or other directives) requests their differentiation.  If
-no corresponding ``_ad`` variable exists, any ``allocate`` or ``deallocate``
-statements for such variables are omitted from the generated code.
+See ``doc/directives.md`` for a description of optional directives that can
+control how AD code is generated.
 
 Run the included tests with:
 

--- a/doc/directives.md
+++ b/doc/directives.md
@@ -1,0 +1,28 @@
+# Directives
+
+Optional directives can be added in Fortran comments to adjust how the
+automatic differentiation code is generated. Each directive starts with
+`!$FAD` and may appear immediately before a subroutine, function or
+module definition.
+
+## CONSTANT_VARS
+
+```
+!$FAD CONSTANT_VARS: var1, var2
+```
+
+Variables listed after the colon are treated as constants during
+ differentiation. This directive can be applied to routine arguments,
+local variables or module level variables. A constant variable does not
+receive a corresponding `_ad` variable and no derivatives are computed
+for it.
+
+## SKIP
+
+```
+!$FAD SKIP
+```
+
+Use `SKIP` before a routine to parse it but omit the generation of AD
+code.
+

--- a/examples/allocate_vars.f90
+++ b/examples/allocate_vars.f90
@@ -3,7 +3,7 @@ module allocate_vars
 
   real, allocatable :: mod_arr(:)
   real, allocatable :: mod_arr_diff(:)
-  !$FAD DIFF_MODULE_VARS: mod_arr_diff
+  !$FAD CONSTANT_VARS: mod_arr
 contains
 
   subroutine allocate_and_sum(n, x, res)

--- a/examples/directives.f90
+++ b/examples/directives.f90
@@ -3,7 +3,7 @@ module directives
 
 contains
 
-!$FAD CONSTANT_ARGS: z
+!$FAD CONSTANT_VARS: z
   subroutine add_const(x, y, z)
     real, intent(in) :: x
     real, intent(out) :: y

--- a/examples/module_vars.f90
+++ b/examples/module_vars.f90
@@ -2,7 +2,7 @@ module module_vars
   implicit none
   real :: c = 2.0
   real :: a
-  !$FAD DIFF_MODULE_VARS: a
+  !$FAD CONSTANT_VARS: c
 contains
   subroutine inc_and_use(x, y)
     real, intent(in) :: x


### PR DESCRIPTION
## Summary
- change parser to treat module variables as AD by default
- introduce `CONSTANT_VARS` directive for modules and routines
- document directives in `doc/directives.md`
- update examples and tests for the new directive

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6870c5449e80832da014aca71f642047