### PR TITLE
Document module variable restore in reverse mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,10 @@ bin/fautodiff --mode reverse examples/simple_math.f90
 ```
 
 See ``doc/directives.md`` for a description of optional directives that can
-control how AD code is generated.
+control how AD code is generated. Details on how module variable assignments are
+handled in reverse mode are in the
+[Module variables in reverse mode](doc/fortran_support.md#module-variables-in-reverse-mode)
+section.
 
 Run the included tests with:
 

--- a/doc/fortran_support.md
+++ b/doc/fortran_support.md
@@ -31,4 +31,29 @@ This document summarizes the Fortran constructs handled by the AD code generator
 - Parameter constants remain untouched.
 - Module variables can be differentiated with the `DIFF_MODULE_VARS` directive.
 
+## Module variables in reverse mode
+
+When a routine assigns to a module variable the reverse-mode version saves the
+old value in a temporary before the assignment.  Derivative updates for later
+statements are computed and then the original value is restored so that the
+derivative of the assignment itself can be propagated correctly.  The temporary
+is named `a_save_<n>_ad` where `<n>` is a counter.
+
+Example from `examples/module_vars_ad.f90`:
+
+```fortran
+  real :: a_save_19_ad
+
+  y = (c + x) * a
+  a_save_19_ad = a
+  a = a + x
+
+  a_ad = y_ad * y + a_ad ! y = y * a
+  y_ad = y_ad * a ! y = y * a
+  a = a_save_19_ad
+```
+
+The old value is restored before accumulating derivatives for `a = a + x` and
+earlier statements.
+
 The generator internally builds a tree of nodes (`Block`, `Assignment`, `IfBlock`, and so on) defined in `fautodiff.code_tree` and renders it back to Fortran after inserting derivative updates.


### PR DESCRIPTION
## Summary
- document storing and restoring module variables in reverse mode
- link from README to new section

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_6870d5626668832d82a5bb29c945f33f