### PR TITLE
Add call_module_vars example and tests

### DIFF
--- a/examples/call_module_vars.f90
+++ b/examples/call_module_vars.f90
@@ -1,0 +1,14 @@
+module call_module_vars
+  use module_vars
+  implicit none
+contains
+  subroutine call_inc_and_use(x, y)
+    real, intent(in) :: x
+    real, intent(out) :: y
+    real :: z
+    z = a
+    call inc_and_use(x, y)
+    y = y + z * a
+    return
+  end subroutine call_inc_and_use
+end module call_module_vars

--- a/examples/call_module_vars_ad.f90
+++ b/examples/call_module_vars_ad.f90
@@ -1,0 +1,39 @@
+module call_module_vars_ad
+  use call_module_vars
+  implicit none
+
+contains
+
+  subroutine call_inc_and_use_fwd_ad(x, x_ad, y_ad)
+    real, intent(in)  :: x
+    real, intent(in)  :: x_ad
+    real, intent(out) :: y_ad
+    real :: z_ad
+    real :: z
+
+    z_ad = a_ad ! z = a
+    z = a
+    call inc_and_use_fwd_ad(x, x_ad, y_ad) ! call inc_and_use(x, y)
+    y_ad = y_ad + z_ad * a + a_ad * z ! y = y + z * a
+
+    return
+  end subroutine call_inc_and_use_fwd_ad
+
+  subroutine call_inc_and_use_rev_ad(x, x_ad, y_ad)
+    real, intent(in)  :: x
+    real, intent(out) :: x_ad
+    real, intent(inout) :: y_ad
+    real :: z_ad
+    real :: z
+
+    z = a
+
+    z_ad = y_ad * a ! y = y + z * a
+    a_ad = y_ad * z + a_ad ! y = y + z * a
+    call inc_and_use_rev_ad(x, x_ad, y_ad) ! call inc_and_use(x, y)
+    a_ad = z_ad + a_ad ! z = a
+
+    return
+  end subroutine call_inc_and_use_rev_ad
+
+end module call_module_vars_ad

--- a/tests/fortran_runtime/Makefile
+++ b/tests/fortran_runtime/Makefile
@@ -8,8 +8,8 @@ vpath %.f90 ../../fortran_modules
 vpath %.f90 .
 
 PROGRAMS = run_simple_math run_arrays run_call_example run_control_flow run_cross_mod \
-	   run_data_storage run_intrinsic_func run_real_kind run_save_vars run_store_vars \
-	   run_directives run_parameter_var run_module_vars run_allocate
+           run_data_storage run_intrinsic_func run_real_kind run_save_vars run_store_vars \
+           run_directives run_parameter_var run_module_vars run_call_module_vars run_allocate
 
 all: $(PROGRAMS)
 
@@ -38,6 +38,7 @@ $(OUTDIR)/run_store_vars.o: $(OUTDIR)/store_vars.o $(OUTDIR)/store_vars_ad.o \
 $(OUTDIR)/run_directives.o: $(OUTDIR)/directives.o $(OUTDIR)/directives_ad.o
 $(OUTDIR)/run_parameter_var.o: $(OUTDIR)/parameter_var.o $(OUTDIR)/parameter_var_ad.o
 $(OUTDIR)/run_module_vars.o: $(OUTDIR)/module_vars.o $(OUTDIR)/module_vars_ad.o
+$(OUTDIR)/run_call_module_vars.o: $(OUTDIR)/call_module_vars.o $(OUTDIR)/call_module_vars_ad.o $(OUTDIR)/module_vars.o $(OUTDIR)/module_vars_ad.o
 $(OUTDIR)/run_allocate_vars.o: $(OUTDIR)/allocate_vars.o $(OUTDIR)/allocate_vars_ad.o
 
 # Additional module dependencies
@@ -86,9 +87,12 @@ run_parameter_var: $(OUTDIR)/run_parameter_var.o $(OUTDIR)/parameter_var.o $(OUT
 run_module_vars: $(OUTDIR)/run_module_vars.o $(OUTDIR)/module_vars.o $(OUTDIR)/module_vars_ad.o
 	$(FC) $^ -o $@
 
-run_allocate_vars: $(OUTDIR)/run_allocate_vars.o $(OUTDIR)/allocate_vars.o $(OUTDIR)/allocate_vars_ad.o
+run_call_module_vars: $(OUTDIR)/run_call_module_vars.o $(OUTDIR)/call_module_vars.o $(OUTDIR)/call_module_vars_ad.o $(OUTDIR)/module_vars.o $(OUTDIR)/module_vars_ad.o
 	$(FC) $^ -o $@
 
+run_allocate_vars: $(OUTDIR)/run_allocate_vars.o $(OUTDIR)/allocate_vars.o $(OUTDIR)/allocate_vars_ad.o
+	        $(FC) $^ -o $@
 
-clean:
+
+	clean:
 	rm -f $(OUTDIR)/*.o $(OUTDIR)/*.mod

--- a/tests/fortran_runtime/run_call_module_vars.f90
+++ b/tests/fortran_runtime/run_call_module_vars.f90
@@ -1,0 +1,75 @@
+program run_call_module_vars
+  use module_vars
+  use module_vars_ad
+  use call_module_vars
+  use call_module_vars_ad
+  implicit none
+  real, parameter :: tol = 1.0e-4
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_call_inc_and_use = 1
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("call_inc_and_use")
+              i_test = I_call_inc_and_use
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_call_inc_and_use .or. i_test == I_all) then
+     call test_call_inc_and_use
+  end if
+
+  stop
+contains
+
+  subroutine test_call_inc_and_use
+    real :: x, y
+    real :: x_ad, y_ad
+    real :: y_eps, fd, eps
+    real :: inner1, inner2
+
+    eps = 1.0e-3
+    a = 3.0
+    x = 2.0
+    call call_inc_and_use(x, y)
+    a = 3.0
+    call call_inc_and_use(x + eps, y_eps)
+    fd = (y_eps - y) / eps
+    a = 3.0
+    x_ad = 1.0
+    call call_inc_and_use_fwd_ad(x, x_ad, y_ad)
+    if (abs((y_ad - fd) / fd) > tol) then
+       print *, 'test_call_inc_and_use_fwd failed', y_ad, fd
+       error stop 1
+    end if
+
+    inner1 = y_ad**2 + a_ad**2
+    a = 3.0
+    call call_inc_and_use_rev_ad(x, x_ad, y_ad)
+    inner2 = x_ad
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_call_inc_and_use_rev failed', inner1, inner2
+       error stop 1
+    end if
+
+    return
+  end subroutine test_call_inc_and_use
+
+end program run_call_module_vars

--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -106,6 +106,10 @@ class TestFortranADCode(unittest.TestCase):
         self._run_test('module_vars', ['inc_and_use'])
 
     @unittest.skipIf(compiler is None, 'gfortran compiler not available')
+    def test_call_module_vars(self):
+        self._run_test('call_module_vars', ['call_inc_and_use'], deps=['module_vars', 'call_module_vars'])
+
+    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_allocate(self):
         self._run_test('allocate_vars', ['allocate_and_sum', 'module_vars'])
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -45,6 +45,17 @@ class TestGenerator(unittest.TestCase):
         expected = Path("examples/cross_mod_b_ad.f90").read_text()
         self.assertEqual(generated, expected)
 
+    def test_call_module_vars(self):
+        code_tree.Node.reset()
+        generator.generate_ad("examples/module_vars.f90", warn=False)
+        generated = generator.generate_ad(
+            "examples/call_module_vars.f90",
+            warn=False,
+            search_dirs=["."],
+        )
+        expected = Path("examples/call_module_vars_ad.f90").read_text()
+        self.assertEqual(generated, expected)
+
     def test_keyword_arg_call(self):
         code_tree.Node.reset()
         generated = generator.generate_ad("examples/keyword_args.f90", warn=False)
@@ -230,7 +241,7 @@ def _make_example_test(src: Path):
 
 examples_dir = Path("examples")
 for _src in sorted(examples_dir.glob("*.f90")):
-    if _src.name.endswith("_ad.f90") or _src.stem in {"cross_mod_a", "cross_mod_b"}:
+    if _src.name.endswith("_ad.f90") or _src.stem in {"cross_mod_a", "cross_mod_b", "call_module_vars"}:
         continue
     test_name = f"test_{_src.stem}"
     setattr(TestGenerator, test_name, _make_example_test(_src))


### PR DESCRIPTION
## Summary
- add new example `call_module_vars.f90` demonstrating module variable usage across calls
- generate reference AD code
- add Fortran runtime driver `run_call_module_vars.f90`
- update runtime Makefile and Python tests to include new case

## Testing
- `python -m pytest tests/test_generator.py -q`
- `python -m pytest tests/test_fortran_runtime.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6870d2b0af60832da68e304dc0ae1535