### PR TITLE
Update Fortran support docs

### DIFF
--- a/doc/fortran_support.md
+++ b/doc/fortran_support.md
@@ -24,12 +24,12 @@ This document summarizes the Fortran constructs handled by the AD code generator
 
 ## Dynamic Allocation
 - `allocate` and `deallocate` statements generate corresponding operations for AD variables.
-- Module variables imported with `use` remain constants unless `DIFF_MODULE_VARS` is specified.
+- Module variables imported with `use` are differentiated by default. Use the `CONSTANT_VARS` directive to mark them as constants.
 - If no `_ad` variable exists for such module variables, any `allocate` or `deallocate` is omitted.
 
 ## Parameter and Module Variables
 - Parameter constants remain untouched.
-- Module variables can be differentiated with the `DIFF_MODULE_VARS` directive.
+- Module variables and variables imported with `use` are differentiated by default. Use `CONSTANT_VARS` to treat them as constants.
 
 ## Module variables in reverse mode
 


### PR DESCRIPTION
## Summary
- clarify that module variables and `use`-imported variables are differentiated by default
- mention using `CONSTANT_VARS` to mark them as constants

## Testing
- `python tests/test_generator.py`
- `python tests/test_fortran_adcode.py` *(fails: cannot compile Fortran runtime)*

------
https://chatgpt.com/codex/tasks/task_b_6870d857df24832d990028d339e96668