### PR TITLE
Fix reference to test file in AGENTS docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ This file provides guidelines for contributors about the repository and develop 
   AD output against the expected Fortran code.
 - When adding modules or subroutines under ``examples/``, also create a driver and
   test subroutine in ``tests/fortran_runtime`` to verify the generated AD code via
-  finite differences. Update the ``Makefile`` and ``tests/test_forward_adcode.py``
+  finite differences. Update the ``Makefile`` and ``tests/test_fortran_adcode.py``
   to build and run the new checks.
 
 ## 6. Generator Usage


### PR DESCRIPTION
## Summary
- update AGENTS instructions to mention `tests/test_fortran_adcode.py`

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_6870e48f7b78832dbaf43472e2b39c2a