### PR TITLE
Fix _find_save_assign parameter usage

### DIFF
--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -591,14 +591,14 @@ def _generate_ad_subroutine(
                 subroutine.decls.append(decl)
 
     subroutine.build_parent()
-    def _find_save_assign(node: Node, save_assignes: dict) -> None:
+    def _find_save_assign(node: Node, save_assigns: dict) -> None:
         if isinstance(node, SaveAssignment) and not node.pushpop:
             name = node.tmpvar.name
             if name not in save_assigns:
                 save_assigns[name] = []
             save_assigns[name].append(node)
         for child in node.iter_children():
-            _find_save_assign(child, save_assignes)
+            _find_save_assign(child, save_assigns)
     save_assigns = dict()
     _find_save_assign(subroutine, save_assigns)
     #print(render_program(subroutine))


### PR DESCRIPTION
## Summary
- rename parameter `save_assignes` to `save_assigns`
- rely on the passed dictionary inside `_find_save_assign`

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_6871077462cc832d809cbf5fca33a9f2