### PR TITLE
Refine pruning for module grad vars

### DIFF
--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -473,7 +473,7 @@ def _generate_ad_subroutine(
         if var.ad_target:
             mod_ad_vars.append(var.add_suffix(AD_SUFFIX))
             has_mod_grad_input = True
-    if not has_grad_input and not has_mod_grad_input:
+    if reverse and not has_grad_input and not has_mod_grad_input:
         for arg in out_grad_args:
             lhs = OpVar(arg.name, kind=arg.kind)
             ad_block.append(Assignment(lhs, OpReal("0.0", kind=arg.kind)))
@@ -749,7 +749,7 @@ def _generate_ad_subroutine(
     if reverse:
         prune_targets = VarList(grad_args + mod_ad_vars)
     else:
-        prune_targets = VarList(grad_args + mod_ad_vars + out_args)
+        prune_targets = VarList(grad_args + mod_vars + mod_ad_vars + out_args)
     subroutine = subroutine.prune_for(prune_targets, mod_vars)
 
     mod_var_names = [var.name for var in mod_vars + mod_ad_vars]


### PR DESCRIPTION
## Summary
- call original code for forward mode even when gradients are absent
- preserve updates to module variables in forward AD by pruning with module gradient vars
- regenerate allocate_vars example

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_687202438070832da779540dcf3679dc