### PR TITLE
Update docs on forward-mode outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ Generate reverse mode only:
 bin/fautodiff --mode reverse examples/simple_math.f90
 ```
 
+### Calling forward-mode routines
+
+Forward-mode subroutines execute the original computations and return each
+``intent(out)`` variable along with its derivative. Arguments consist of the
+original inputs followed by their derivative counterparts.
+
+```fortran
+real :: x, x_ad, y, y_ad
+x = 2.0
+x_ad = 1.0
+call foo_fwd_ad(x, x_ad, y, y_ad)
+```
+
+
 See ``doc/directives.md`` for a description of optional directives that can
 control how AD code is generated. Details on how module variable assignments are
 handled in reverse mode are in the

--- a/doc/fortran_support.md
+++ b/doc/fortran_support.md
@@ -5,6 +5,7 @@ This document summarizes the Fortran constructs handled by the AD code generator
 ## Modules and Routines
 - Each module in the input becomes a `<module>_ad` module.
 - Every subroutine or function produces `<name>_fwd_ad` and `<name>_rev_ad` versions.
+- Forward-mode routines also return the original `intent(out)` variables together with their gradients. These routines execute the original computations internally so callers do not need to invoke the non-AD version.
 - Integer variables are treated as constants and do not receive `_ad` counterparts.
 
 ## Control Flow Constructs


### PR DESCRIPTION
## Summary
- document that forward-mode subroutines return both the `intent(out)` variables and their derivatives
- add example of calling a forward-mode routine

## Testing
- `python tests/test_generator.py -v`

------
https://chatgpt.com/codex/tasks/task_b_6872082defe8832d97fe06b0ee6a94c9