### PR TITLE
Remove trailing whitespace across project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,9 +174,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the enitre vscode folder
 # .vscode/
 

--- a/examples/allocate_vars.f90
+++ b/examples/allocate_vars.f90
@@ -33,7 +33,7 @@ contains
 
     allocate(mod_arr(n))
     allocate(mod_arr_diff(n))
-    
+
     do i = 1, n
       mod_arr(i) = i * 2.0
       mod_arr_diff(i) = i * x

--- a/fautodiff/operators.py
+++ b/fautodiff/operators.py
@@ -792,7 +792,7 @@ class OpNeg(OpUnary):
 
     def derivative(self, var: OpVar, target: Optional[OpVar] = None, info: Optional[dict] = None, warnings: Optional[List[str]] = None) -> Operator:
         return - self.args[0].derivative(var, target, info, warnings)
-     
+
 @dataclass
 class OpAnd(OpUnary):
 
@@ -973,7 +973,7 @@ class OpFunc(Operator):
 
         if self.name in NONDIFF_INTRINSICS:
             return OpInt(0, target=target)
-        
+
         kind = target.kind if target is not None else None
 
         def _pi(target):
@@ -981,7 +981,7 @@ class OpFunc(Operator):
 
         if len(self.args) == 0:
             raise ValueError(f"Function ({self.name}) is not supported")
-        
+
         # One argument intrinsics map
         arg0 = self.args[0]
         dvar0 = arg0.derivative(var, target, info, warnings)

--- a/fautodiff/var_list.py
+++ b/fautodiff/var_list.py
@@ -279,7 +279,7 @@ class VarList:
             i = AryIndex.get_diff_dim(index, var.index) # index and var.index is either OpInt or OpRange
             if i is None:
                 raise RuntimeError(f"Unexpected: {var} {self}")
- 
+
             index = index.copy()
             self.vars[name][pos] = index
 

--- a/tests/fortran_runtime/run_simple_math.f90
+++ b/tests/fortran_runtime/run_simple_math.f90
@@ -41,7 +41,7 @@ program run_simple_math
         deallocate(arg)
      end if
   end if
-           
+
   if (i_test == I_add_numbers .or. i_test == I_all) then
      call test_add_numbers
   end if


### PR DESCRIPTION
## Summary
- strip trailing whitespace in source and example files

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_68720aa9b44c832dba999af3fe159b24