### PR TITLE
Add PointerAssignment node for pointer assignment statements

### DIFF
--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -18,6 +18,7 @@ from typing import List, Tuple, Optional
 
 from .code_tree import (
     Assignment,
+    PointerAssignment,
     Block,
     CallStatement,
     Declaration,
@@ -630,6 +631,10 @@ def _parse_routine(content,
             lhs = _stmt2op(stmt.items[0], decl_map)
             rhs = _stmt2op(stmt.items[2], decl_map)
             return Assignment(lhs, rhs, False, info)
+        if isinstance(stmt, Fortran2003.Pointer_Assignment_Stmt):
+            lhs = _stmt2op(stmt.items[0], decl_map)
+            rhs = _stmt2op(stmt.items[2], decl_map)
+            return PointerAssignment(lhs, rhs, info=info)
         if isinstance(stmt, Fortran2003.Write_Stmt):
             return None
         if isinstance(stmt, Fortran2003.Call_Stmt):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -485,5 +485,24 @@ class TestParser(unittest.TestCase):
             "real, pointer :: p(:)"
         )
 
+    def test_parse_pointer_assignment(self):
+        src = textwrap.dedent(
+            """
+            module test
+            contains
+              subroutine foo(p, q)
+                real, pointer :: p
+                real :: q
+                p => q
+              end subroutine foo
+            end module test
+            """
+        )
+        module = parser.parse_src(src)[0]
+        routine = module.routines[0]
+        stmt = routine.content.first()
+        self.assertIsInstance(stmt, code_tree.PointerAssignment)
+        self.assertEqual(render_program(Block([stmt])), "p => q\n")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add PointerAssignment node in code_tree
- parse Pointer_Assignment_Stmt in parser
- render pointer assignment as `p => q`
- forward pointer assignments during AD generation
- test pointer declaration and pointer assignment parsing

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68790047b140832d9063bb96c72795ee