### PR TITLE
Support pointer arrays in AD allocation

### DIFF
--- a/examples/pointer_arrays.f90
+++ b/examples/pointer_arrays.f90
@@ -1,0 +1,27 @@
+module pointer_arrays
+  implicit none
+  real, pointer :: mod_p(:)
+contains
+  subroutine pointer_example(n, x, res)
+    integer, intent(in) :: n
+    real, intent(in) :: x
+    real, intent(out) :: res
+    real, pointer :: p(:)
+    integer :: i
+
+    allocate(p(n))
+    allocate(mod_p(n))
+    do i = 1, n
+      p(i) = x
+      mod_p(i) = x
+    end do
+    res = 0.0
+    do i = 1, n
+      res = res + p(i) + mod_p(i)
+    end do
+    deallocate(p)
+    deallocate(mod_p)
+
+    return
+  end subroutine pointer_example
+end module pointer_arrays

--- a/examples/pointer_arrays_ad.f90
+++ b/examples/pointer_arrays_ad.f90
@@ -1,0 +1,106 @@
+module pointer_arrays_ad
+  use pointer_arrays
+  use fautodiff_data_storage
+  implicit none
+
+  real, pointer :: mod_p_ad(:)
+
+contains
+
+  subroutine pointer_example_fwd_ad(n, x, x_ad, res, res_ad)
+    integer, intent(in)  :: n
+    real, intent(in)  :: x
+    real, intent(in)  :: x_ad
+    real, intent(out) :: res
+    real, intent(out) :: res_ad
+    real, pointer :: p_ad(:)
+    integer :: i
+    real, pointer :: p(:)
+
+    p_ad(:) = 0.0
+
+    allocate(p(n))
+    if (.not. associated(p_ad)) then
+      allocate(p_ad(n))
+    end if
+    if (.not. associated(mod_p_ad)) then
+      allocate(mod_p_ad(n))
+    end if
+    do i = 1, n
+      p_ad(i) = x_ad ! p(i) = x
+      p(i) = x
+      mod_p_ad(i) = x_ad ! mod_p(i) = x
+      mod_p(i) = x
+    end do
+    res_ad = 0.0 ! res = 0.0
+    res = 0.0
+    do i = 1, n
+      res_ad = res_ad + p_ad(i) + mod_p_ad(i) ! res = res + p(i) + mod_p(i)
+      res = res + p(i) + mod_p(i)
+    end do
+    if (associated(p_ad)) then
+      deallocate(p_ad)
+    end if
+    if (associated(p)) then
+      deallocate(p)
+    end if
+    if (associated(mod_p_ad)) then
+      deallocate(mod_p_ad)
+    end if
+
+    return
+  end subroutine pointer_example_fwd_ad
+
+  subroutine pointer_example_rev_ad(n, x, x_ad, res_ad)
+    integer, intent(in)  :: n
+    real, intent(in)  :: x
+    real, intent(out) :: x_ad
+    real, intent(inout) :: res_ad
+    real, pointer :: p_ad(:)
+    integer :: i
+
+    allocate(p(n))
+
+    p_ad(:) = 0.0
+    x_ad = 0.0
+
+    if (.not. associated(mod_p_ad)) then
+      allocate(mod_p_ad(n))
+    end if
+    if (.not. associated(p_ad)) then
+      allocate(p_ad(n))
+    end if
+    do i = n, 1, - 1
+      p_ad(i) = res_ad ! res = res + p(i) + mod_p(i)
+      mod_p_ad(i) = res_ad ! res = res + p(i) + mod_p(i)
+    end do
+    res_ad = 0.0 ! res = 0.0
+    do i = n, 1, - 1
+      x_ad = mod_p_ad(i) + x_ad ! mod_p(i) = x
+      mod_p_ad(i) = 0.0 ! mod_p(i) = x
+      x_ad = p_ad(i) + x_ad ! p(i) = x
+      p_ad(i) = 0.0 ! p(i) = x
+    end do
+    if (associated(mod_p_ad)) then
+      deallocate(mod_p_ad)
+    end if
+    if (associated(p_ad)) then
+      deallocate(p_ad)
+    end if
+    deallocate(p)
+
+    return
+  end subroutine pointer_example_rev_ad
+
+  subroutine pointer_example_fwd_rev_ad(n, x, res)
+    integer, intent(in)  :: n
+    real, intent(in)  :: x
+    real, intent(out) :: res
+
+    call fautodiff_data_storage_push(mod_p)
+    call pointer_example(n, x, res)
+
+    return
+  end subroutine pointer_example_fwd_rev_ad
+
+end module pointer_arrays_ad

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -241,10 +241,18 @@ def _make_example_test(src: Path):
 
 examples_dir = Path("examples")
 for _src in sorted(examples_dir.glob("*.f90")):
-    if _src.name.endswith("_ad.f90") or _src.stem in {"cross_mod_a", "cross_mod_b", "call_module_vars"}:
+    if _src.name.endswith("_ad.f90") or _src.stem in {"cross_mod_a", "cross_mod_b", "call_module_vars", "pointer_arrays"}:
         continue
     test_name = f"test_{_src.stem}"
     setattr(TestGenerator, test_name, _make_example_test(_src))
+
+class TestPointerArrays(unittest.TestCase):
+    def test_pointer_arrays(self):
+        code_tree.Node.reset()
+        src = Path("examples/pointer_arrays.f90")
+        generated = generator.generate_ad(str(src), warn=False)
+        expected = src.with_name("pointer_arrays_ad.f90").read_text()
+        self.assertEqual(generated, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add pointer array example
- check associated status when allocating/deallocating pointer arrays
- extend Deallocate handling for pointer arrays
- test pointer array generation

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6879029a0d8c832da98dd1a485dd9151