### PR TITLE
Fix logical constant parsing

### DIFF
--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -47,6 +47,8 @@ from .operators import (
     OpFunc,
     OpFuncUser,
     OpInt,
+    OpFalse,
+    OpTrue,
     OpLogic,
     OpMul,
     OpNeg,
@@ -179,7 +181,12 @@ def _stmt2op(stmt, decl_map:dict) -> Operator:
         return OpChr(name=name)
 
     if isinstance(stmt, Fortran2003.Logical_Literal_Constant):
-        return OpVar(name=stmt.string, typename="logical")
+        const = stmt.string.lower()
+        if const in (".true.", ".t."):
+            return OpTrue()
+        if const in (".false.", ".f."):
+            return OpFalse()
+        raise ValueError(f"Unsupported logical constant: {stmt.string}")
 
     if isinstance(stmt, Fortran2003.Mult_Operand):
         if stmt.items[1] == "**":


### PR DESCRIPTION
## Summary
- parse Fortran logical literals into `OpTrue` or `OpFalse`
- ensure generator tests pass

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_6879f10dd5cc832dbc84d331121d252c