### PR TITLE
Support Fortran optional arguments

### DIFF
--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -1342,6 +1342,7 @@ class Routine(Node):
             intent=intent,
             ad_target=None,
             is_constant=decl.parameter or getattr(decl, "constant", False),
+            optional=decl.optional,
             declared_in=decl.declared_in,
         )
 
@@ -2076,6 +2077,7 @@ class Declaration(Node):
     access: Optional[str] = None
     allocatable: bool = False
     pointer: bool = False
+    optional: bool = False
     declared_in: Optional[str] = None
 
     def __post_init__(self):
@@ -2096,6 +2098,7 @@ class Declaration(Node):
             self.access,
             self.allocatable,
             self.pointer,
+            self.optional,
             self.declared_in,
         )
 
@@ -2113,6 +2116,7 @@ class Declaration(Node):
             self.access,
             self.allocatable,
             self.pointer,
+            self.optional,
             self.declared_in,
         )
 
@@ -2125,6 +2129,7 @@ class Declaration(Node):
                 is_constant=self.parameter or self.constant,
                 allocatable=self.allocatable,
                 pointer=self.pointer,
+                optional=self.optional,
                 declared_in=self.declared_in,
             )
         else:
@@ -2141,6 +2146,7 @@ class Declaration(Node):
             is_constant=self.parameter or self.constant,
             allocatable=self.allocatable,
             pointer=self.pointer,
+            optional=self.optional,
             dims=self.dims,
             intent=self.intent,
             declared_in=self.declared_in,
@@ -2159,6 +2165,8 @@ class Declaration(Node):
             line += ", allocatable"
         if self.pointer:
             line += ", pointer"
+        if self.optional:
+            line += ", optional"
         if self.intent is not None:
             pad = "  " if self.intent == "in" else " "
             line += f", intent({self.intent})" + pad + f":: {self.name}"
@@ -2198,6 +2206,7 @@ class Declaration(Node):
                         is_constant=self.parameter or self.constant,
                         allocatable=self.allocatable,
                         pointer=self.pointer,
+                        optional=self.optional,
                         declared_in=self.declared_in,
                     )
                 )

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -89,6 +89,7 @@ def _make_fwd_rev_wrapper(routine_org: Routine, vars: list[str]) -> Subroutine:
                 arg.intent,
                 allocatable=arg.allocatable,
                 pointer=arg.pointer,
+                optional=arg.optional,
                 declared_in="routine",
             )
         )
@@ -289,6 +290,7 @@ def _prepare_fwd_ad_header(routine_org, has_mod_grad_var):
                 var.intent,
                 allocatable=var.allocatable,
                 pointer=var.pointer,
+                optional=var.optional,
                 declared_in="routine",
             )
         )
@@ -403,6 +405,7 @@ def _prepare_rev_ad_header(routine_org, has_mod_grad_var):
                 var.intent,
                 allocatable=var.allocatable,
                 pointer=var.pointer,
+                optional=var.optional,
                 declared_in="routine",
             )
         )
@@ -537,6 +540,7 @@ def _generate_ad_subroutine(
                             init_val=base_decl.init_val if base_decl else None,
                             allocatable=base_decl.allocatable if base_decl else False,
                             pointer=base_decl.pointer if base_decl else False,
+                            optional=base_decl.optional if base_decl else False,
                             declared_in="routine",
                         )
                     )
@@ -672,6 +676,7 @@ def _generate_ad_subroutine(
                             init_val=base_decl.init_val,
                             allocatable=base_decl.allocatable,
                             pointer=base_decl.pointer,
+                            optional=base_decl.optional,
                             declared_in="routine",
                         )
                     )
@@ -791,6 +796,7 @@ def _generate_ad_subroutine(
                 init_val=base_decl.init_val if base_decl else None,
                 allocatable=base_decl.allocatable if base_decl else False,
                 pointer=base_decl.pointer if base_decl else False,
+                optional=base_decl.optional if base_decl else False,
                 declared_in="routine",
             )
         )
@@ -884,6 +890,7 @@ def generate_ad(
                                              #access = decl.access,
                                              allocatable = decl.allocatable,
                                              pointer = decl.pointer,
+                                             optional = decl.optional,
                                              declared_in = "module",
                                              )
                                 )

--- a/fautodiff/operators.py
+++ b/fautodiff/operators.py
@@ -677,6 +677,7 @@ class OpVar(OpLeaf):
     reference: Optional["OpVar"] = field(repr=False, default=None)
     allocatable: Optional[bool] = field(default=None, repr=False)
     pointer: Optional[bool] = field(default=None, repr=False)
+    optional: Optional[bool] = field(default=None, repr=False)
     declared_in: Optional[str] = field(default=None, repr=False)
     reduced_dims: Optional[List[int]] = field(init=False, repr=False, default=None)
 
@@ -693,6 +694,7 @@ class OpVar(OpLeaf):
         is_constant: Optional[bool] = None,
         allocatable: Optional[bool] = None,
         pointer: Optional[bool] = None,
+        optional: Optional[bool] = None,
         declared_in: Optional[str] = None,
     ):
         super().__init__(args=[])
@@ -713,6 +715,7 @@ class OpVar(OpLeaf):
         self.is_constant = is_constant
         self.allocatable = allocatable
         self.pointer = pointer
+        self.optional = optional
         self.declared_in = declared_in
         if self.ad_target is None and self.typename is not None:
             typename = self.typename.lower()
@@ -750,6 +753,7 @@ class OpVar(OpLeaf):
             is_constant=self.is_constant,
             allocatable=self.allocatable,
             pointer=self.pointer,
+            optional=self.optional,
             declared_in=self.declared_in,
         )
 
@@ -772,6 +776,7 @@ class OpVar(OpLeaf):
             is_constant=self.is_constant,
             allocatable=self.allocatable,
             pointer=self.pointer,
+            optional=self.optional,
             declared_in=self.declared_in,
         )
 

--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -133,6 +133,7 @@ def _stmt2op(stmt, decl_map:dict) -> Operator:
             is_constant=decl.parameter or getattr(decl, "constant", False),
             allocatable=getattr(decl, "allocatable", False),
             pointer=getattr(decl, "pointer", False),
+            optional=getattr(decl, "optional", False),
             declared_in=decl.declared_in,
         )
 
@@ -150,6 +151,7 @@ def _stmt2op(stmt, decl_map:dict) -> Operator:
                 is_constant=decl.parameter or getattr(decl, "constant", False),
                 allocatable=getattr(decl, "allocatable", False),
                 pointer=getattr(decl, "pointer", False),
+                optional=getattr(decl, "optional", False),
                 declared_in=decl.declared_in,
             )
         else:  # must be function
@@ -290,6 +292,7 @@ def _clone_decl(decl: Declaration, declared_in: str) -> Declaration:
         access=decl.access,
         allocatable=decl.allocatable,
         pointer=decl.pointer,
+        optional=decl.optional,
         declared_in=declared_in,
     )
 
@@ -343,6 +346,7 @@ def _parse_decl_stmt(
     access = None
     allocatable = False
     pointer = False
+    optional = False
     attrs = stmt.items[1]
     if attrs is not None:
         for attr in attrs.items:
@@ -358,6 +362,8 @@ def _parse_decl_stmt(
                 allocatable = True
             if name == "pointer":
                 pointer = True
+            if name == "optional":
+                optional = True
             if allow_access and name in ("public", "private"):
                 access = name
 
@@ -391,6 +397,7 @@ def _parse_decl_stmt(
                 access=access,
                 allocatable=allocatable,
                 pointer=pointer,
+                optional=optional,
                 declared_in=declared_in,
             )
         )
@@ -523,6 +530,7 @@ def _search_use(name: str, only: Optional[List[str]], decl_map: dict, module_map
                         init_val=info.get("init_val"),
                         access=info.get("access"),
                         pointer=info.get("pointer", False),
+                        optional=info.get("optional", False),
                         declared_in="use",
                     )
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -228,6 +228,32 @@ class TestGenerator(unittest.TestCase):
         self.assertIn("foo", routines)
         self.assertTrue(routines["foo"].get("skip"))
 
+    def test_optional_argument(self):
+        code_tree.Node.reset()
+        import textwrap
+        from tempfile import TemporaryDirectory
+
+        src = textwrap.dedent(
+            """
+            module optmod
+            contains
+              subroutine foo(x, y)
+                real, intent(inout) :: x
+                real, intent(in), optional :: y
+                if (present(y)) then
+                  x = x + y
+                end if
+              end subroutine foo
+            end module optmod
+            """
+        )
+
+        with TemporaryDirectory() as tmp:
+            src_path = Path(tmp) / "opt.f90"
+            src_path.write_text(src)
+            generated = generator.generate_ad(str(src_path), warn=False)
+            self.assertIn("real, optional, intent(in)  :: y", generated)
+
 
 def _make_example_test(src: Path):
     def test(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -504,5 +504,29 @@ class TestParser(unittest.TestCase):
         self.assertIsInstance(stmt, code_tree.PointerAssignment)
         self.assertEqual(render_program(Block([stmt])), "p => q\n")
 
+    def test_parse_optional_argument(self):
+        src = textwrap.dedent(
+            """
+            module optmod
+            contains
+              subroutine foo(x, y)
+                real, intent(inout) :: x
+                real, intent(in), optional :: y
+                if (present(y)) then
+                  x = x + y
+                end if
+              end subroutine foo
+            end module optmod
+            """
+        )
+        module = parser.parse_src(src)[0]
+        routine = module.routines[0]
+        decl = routine.decls.find_by_name("y")
+        self.assertTrue(decl.optional)
+        self.assertEqual(
+            render_program(Block([decl])).strip(),
+            "real, optional, intent(in)  :: y",
+        )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `optional` attribute to internal Declaration and OpVar representations
- parse OPTIONAL attribute in declarations
- preserve optional arguments in generated AD code
- test parser and generator handling of optional parameters

## Testing
- `python -m pytest tests/test_parser.py::TestParser::test_parse_optional_argument -q`
- `python -m pytest tests/test_generator.py::TestGenerator::test_optional_argument -q`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6879fd433538832dba5e6fee805c4523