### PR TITLE
Save only non-default fadmod variable fields

### DIFF
--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -200,17 +200,24 @@ def _write_fadmod(mod: Module, routine_map: dict, directory: Path) -> None:
     if mod.decls is not None:
         for d in mod.decls.iter_children():
             if isinstance(d, Declaration):
-                variables_data[d.name] = {
-                    "typename": d.typename,
-                    "kind": d.kind,
-                    "dims": list(d.dims) if d.dims is not None else None,
-                    "parameter": d.parameter,
-                    "constant": d.constant,
-                    "init_val": d.init_val,
-                    "access": d.access,
-                    "allocatable": d.allocatable,
-                    "pointer": d.pointer,
-                }
+                info = {"typename": d.typename}
+                if d.kind is not None:
+                    info["kind"] = d.kind
+                if d.dims is not None:
+                    info["dims"] = list(d.dims)
+                if d.parameter:
+                    info["parameter"] = True
+                if d.constant:
+                    info["constant"] = True
+                if d.init_val is not None:
+                    info["init_val"] = d.init_val
+                if d.access is not None:
+                    info["access"] = d.access
+                if d.allocatable:
+                    info["allocatable"] = True
+                if d.pointer:
+                    info["pointer"] = True
+                variables_data[d.name] = info
 
     if not routines_data and not variables_data:
         return

--- a/fortran_modules/mpi.fadmod
+++ b/fortran_modules/mpi.fadmod
@@ -1692,291 +1692,162 @@
   "variables": {
     "MPI_COMM_WORLD": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_STATUS_SIZE": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_STATUS_IGNORE": {
       "typename": "integer",
-      "kind": null,
       "dims": [
         "MPI_STATUS_SIZE"
       ],
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_SUM": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_MAX": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_MIN": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_PROD": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_MAXLOC": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_MINLOC": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_LAND": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_LOR": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_LXOR": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_BAND": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_BOR": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_BXOR": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_REPLACE": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_INT": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_INTEGER": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_REAL": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_DOUBLE_PRECISION": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_COMPLEX": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_DOUBLE_COMPLEX": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_LOGICAL": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_CHARACTER": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_BYTE": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     },
     "MPI_REAL8": {
       "typename": "integer",
-      "kind": null,
-      "dims": null,
       "parameter": true,
       "constant": true,
-      "init_val": null,
-      "access": "public",
-      "allocatable": false,
-      "pointer": false
+      "access": "public"
     }
   }
 }

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -151,6 +151,24 @@ class TestGenerator(unittest.TestCase):
         variables = data.get("variables", {})
         self.assertIn("c", variables)
 
+    def test_fadmod_variable_defaults(self):
+        code_tree.Node.reset()
+        fadmod = Path("module_vars.fadmod")
+        if fadmod.exists():
+            fadmod.unlink()
+        generator.generate_ad("examples/module_vars.f90", warn=False)
+        data = json.loads(fadmod.read_text())
+        var_a = data.get("variables", {}).get("a")
+        self.assertIsNotNone(var_a)
+        self.assertIn("typename", var_a)
+        self.assertNotIn("parameter", var_a)
+        self.assertNotIn("constant", var_a)
+        self.assertNotIn("dims", var_a)
+        self.assertNotIn("kind", var_a)
+        self.assertNotIn("init_val", var_a)
+        self.assertNotIn("allocatable", var_a)
+        self.assertNotIn("pointer", var_a)
+
     def test_module_vars_directive(self):
         code_tree.Node.reset()
         import textwrap


### PR DESCRIPTION
## Summary
- store variable info in fadmod files without default-valued fields
- test that fadmod variables omit default parameters
- purge unused default fields from existing mpi.fadmod

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_687a1c4fe278832da3ecf310eda7fad2