### PR TITLE
Add MPI routine variants

### DIFF
--- a/fortran_modules/mpi.fadmod
+++ b/fortran_modules/mpi.fadmod
@@ -335,1139 +335,6 @@
       ],
       "module": "mpi"
     },
-    "MPI_Reduce": {
-      "args": [
-        "sendbuf",
-        "recvbuf",
-        "count",
-        "datatype",
-        "op",
-        "root",
-        "comm",
-        "ierr"
-      ],
-      "intents": [
-        "in",
-        "out",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "dims": [
-        [
-          "count"
-        ],
-        [
-          "count"
-        ],
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "type": [
-        "real",
-        "real",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer"
-      ],
-      "kind": [
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "name_fwd_ad": "mpi_reduce_fwd_ad",
-      "args_fwd_ad": [
-        "sendbuf",
-        "sendbuf_ad",
-        "recvbuf",
-        "recvbuf_ad",
-        "count",
-        "datatype",
-        "op",
-        "root",
-        "comm",
-        "ierr"
-      ],
-      "intents_fwd_ad": [
-        "in",
-        "in",
-        "out",
-        "out",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "name_rev_ad": "mpi_reduce_rev_ad",
-      "args_rev_ad": [
-        "sendbuf",
-        "sendbuf_ad",
-        "recvbuf",
-        "recvbuf_ad",
-        "count",
-        "datatype",
-        "op",
-        "root",
-        "comm",
-        "ierr"
-      ],
-      "intents_rev_ad": [
-        "in",
-        "in",
-        "out",
-        "out",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "module": "mpi"
-    },
-    "MPI_Allreduce": {
-      "args": [
-        "sendbuf",
-        "recvbuf",
-        "count",
-        "datatype",
-        "op",
-        "comm",
-        "ierr"
-      ],
-      "intents": [
-        "in",
-        "out",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "dims": [
-        [
-          "count"
-        ],
-        [
-          "count"
-        ],
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "type": [
-        "real",
-        "real",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer"
-      ],
-      "kind": [
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "name_fwd_ad": "mpi_allreduce_fwd_ad",
-      "args_fwd_ad": [
-        "sendbuf",
-        "sendbuf_ad",
-        "recvbuf",
-        "recvbuf_ad",
-        "count",
-        "datatype",
-        "op",
-        "comm",
-        "ierr"
-      ],
-      "intents_fwd_ad": [
-        "in",
-        "in",
-        "out",
-        "out",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "name_rev_ad": "mpi_allreduce_rev_ad",
-      "args_rev_ad": [
-        "sendbuf",
-        "sendbuf_ad",
-        "recvbuf",
-        "recvbuf_ad",
-        "count",
-        "datatype",
-        "op",
-        "comm",
-        "ierr"
-      ],
-      "intents_rev_ad": [
-        "in",
-        "in",
-        "out",
-        "out",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "module": "mpi"
-    },
-    "MPI_Send": {
-      "args": [
-        "buf",
-        "count",
-        "datatype",
-        "dest",
-        "tag",
-        "comm",
-        "ierr"
-      ],
-      "intents": [
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "dims": [
-        [
-          "count"
-        ],
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "type": [
-        "real",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer"
-      ],
-      "kind": [
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "name_fwd_ad": "mpi_send_fwd_ad",
-      "args_fwd_ad": [
-        "buf",
-        "buf_ad",
-        "count",
-        "datatype",
-        "dest",
-        "tag",
-        "comm",
-        "ierr"
-      ],
-      "intents_fwd_ad": [
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "name_rev_ad": "mpi_send_rev_ad",
-      "args_rev_ad": [
-        "buf_ad",
-        "count",
-        "datatype",
-        "dest",
-        "tag",
-        "comm",
-        "ierr"
-      ],
-      "intents_rev_ad": [
-        "inout",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "module": "mpi"
-    },
-    "MPI_Isend": {
-      "args": [
-        "buf",
-        "count",
-        "datatype",
-        "dest",
-        "tag",
-        "comm",
-        "request",
-        "ierr"
-      ],
-      "intents": [
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out",
-        "out"
-      ],
-      "dims": [
-        [
-          "count"
-        ],
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "type": [
-        "real",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer"
-      ],
-      "kind": [
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "name_fwd_ad": "mpi_isend_fwd_ad",
-      "args_fwd_ad": [
-        "buf",
-        "buf_ad",
-        "count",
-        "datatype",
-        "dest",
-        "tag",
-        "comm",
-        "request",
-        "request_ad",
-        "ierr"
-      ],
-      "intents_fwd_ad": [
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out",
-        "out",
-        "out"
-      ],
-      "name_fwd_rev_ad": "mpi_isend_fwd_rev_ad",
-      "name_rev_ad": "mpi_isend_rev_ad",
-      "args_rev_ad": [
-        "buf_ad",
-        "count",
-        "datatype",
-        "dest",
-        "tag",
-        "comm",
-        "request_ad",
-        "ierr"
-      ],
-      "intents_rev_ad": [
-        "inout",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out",
-        "out"
-      ],
-      "module": "mpi"
-    },
-    "MPI_Irecv": {
-      "args": [
-        "buf",
-        "count",
-        "datatype",
-        "source",
-        "tag",
-        "comm",
-        "request",
-        "ierr"
-      ],
-      "intents": [
-        "out",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out",
-        "out"
-      ],
-      "dims": [
-        [
-          "count"
-        ],
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "type": [
-        "real",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer"
-      ],
-      "kind": [
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "name_fwd_ad": "mpi_irecv_fwd_ad",
-      "args_fwd_ad": [
-        "buf",
-        "buf_ad",
-        "count",
-        "datatype",
-        "source",
-        "tag",
-        "comm",
-        "request",
-        "request_ad",
-        "ierr"
-      ],
-      "intents_fwd_ad": [
-        "out",
-        "out",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out",
-        "out",
-        "out"
-      ],
-      "name_fwd_rev_ad": "mpi_irecv_fwd_rev_ad",
-      "name_rev_ad": "mpi_irecv_rev_ad",
-      "args_rev_ad": [
-        "buf_ad",
-        "count",
-        "datatype",
-        "source",
-        "tag",
-        "comm",
-        "request_ad",
-        "ierr"
-      ],
-      "intents_rev_ad": [
-        "inout",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out",
-        "out"
-      ],
-      "module": "mpi"
-    },
-    "MPI_Recv": {
-      "args": [
-        "buf",
-        "count",
-        "datatype",
-        "source",
-        "tag",
-        "comm",
-        "status",
-        "ierr"
-      ],
-      "intents": [
-        "out",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out",
-        "out"
-      ],
-      "dims": [
-        [
-          "count"
-        ],
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "type": [
-        "real",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer"
-      ],
-      "kind": [
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "name_fwd_ad": "mpi_recv_fwd_ad",
-      "args_fwd_ad": [
-        "buf",
-        "buf_ad",
-        "count",
-        "datatype",
-        "source",
-        "tag",
-        "comm",
-        "status",
-        "ierr"
-      ],
-      "intents_fwd_ad": [
-        "out",
-        "out",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out",
-        "out"
-      ],
-      "name_rev_ad": "mpi_recv_rev_ad",
-      "args_rev_ad": [
-        "buf_ad",
-        "count",
-        "datatype",
-        "source",
-        "tag",
-        "comm",
-        "ierr"
-      ],
-      "intents_rev_ad": [
-        "inout",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "module": "mpi"
-    },
-    "MPI_Put": {
-      "args": [
-        "origin",
-        "origin_count",
-        "origin_datatype",
-        "target_rank",
-        "target_disp",
-        "target_count",
-        "target_datatype",
-        "win",
-        "ierr"
-      ],
-      "intents": [
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "dims": [
-        [
-          "origin_count"
-        ],
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "type": [
-        "real",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer"
-      ],
-      "kind": [
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "name_fwd_ad": "mpi_put_fwd_ad",
-      "args_fwd_ad": [
-        "origin",
-        "origin_ad",
-        "origin_count",
-        "origin_datatype",
-        "target_rank",
-        "target_disp",
-        "target_count",
-        "target_datatype",
-        "win",
-        "ierr"
-      ],
-      "intents_fwd_ad": [
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "name_rev_ad": "mpi_put_rev_ad",
-      "args_rev_ad": [
-        "origin",
-        "origin_ad",
-        "origin_count",
-        "origin_datatype",
-        "target_rank",
-        "target_disp",
-        "target_count",
-        "target_datatype",
-        "win",
-        "ierr"
-      ],
-      "intents_rev_ad": [
-        "in",
-        "inout",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "module": "mpi"
-    },
-    "MPI_Get": {
-      "args": [
-        "origin",
-        "origin_count",
-        "origin_datatype",
-        "target_rank",
-        "target_disp",
-        "target_count",
-        "target_datatype",
-        "win",
-        "ierr"
-      ],
-      "intents": [
-        "out",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "dims": [
-        [
-          "origin_count"
-        ],
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "type": [
-        "real",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer"
-      ],
-      "kind": [
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "name_fwd_ad": "mpi_get_fwd_ad",
-      "args_fwd_ad": [
-        "origin",
-        "origin_ad",
-        "origin_count",
-        "origin_datatype",
-        "target_rank",
-        "target_disp",
-        "target_count",
-        "target_datatype",
-        "win",
-        "ierr"
-      ],
-      "intents_fwd_ad": [
-        "out",
-        "out",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "name_rev_ad": "mpi_get_rev_ad",
-      "args_rev_ad": [
-        "origin",
-        "origin_ad",
-        "origin_count",
-        "origin_datatype",
-        "target_rank",
-        "target_disp",
-        "target_count",
-        "target_datatype",
-        "win",
-        "ierr"
-      ],
-      "intents_rev_ad": [
-        "out",
-        "inout",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "module": "mpi"
-    },
-    "MPI_Accumulate": {
-      "args": [
-        "origin",
-        "origin_count",
-        "origin_datatype",
-        "target_rank",
-        "target_disp",
-        "target_count",
-        "target_datatype",
-        "op",
-        "win",
-        "ierr"
-      ],
-      "intents": [
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "dims": [
-        [
-          "origin_count"
-        ],
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "type": [
-        "real",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer"
-      ],
-      "kind": [
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "name_fwd_ad": "mpi_accumulate_fwd_ad",
-      "args_fwd_ad": [
-        "origin",
-        "origin_ad",
-        "origin_count",
-        "origin_datatype",
-        "target_rank",
-        "target_disp",
-        "target_count",
-        "target_datatype",
-        "op",
-        "win",
-        "ierr"
-      ],
-      "intents_fwd_ad": [
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "name_rev_ad": "mpi_accumulate_rev_ad",
-      "args_rev_ad": [
-        "origin",
-        "origin_ad",
-        "origin_count",
-        "origin_datatype",
-        "target_rank",
-        "target_disp",
-        "target_count",
-        "target_datatype",
-        "op",
-        "win",
-        "ierr"
-      ],
-      "intents_rev_ad": [
-        "in",
-        "inout",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out"
-      ],
-      "module": "mpi"
-    },
-    "MPI_Send_init": {
-      "args": [
-        "buf",
-        "count",
-        "datatype",
-        "dest",
-        "tag",
-        "comm",
-        "request",
-        "ierr"
-      ],
-      "intents": [
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out",
-        "out"
-      ],
-      "dims": [
-        [
-          "count"
-        ],
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "type": [
-        "real",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer"
-      ],
-      "kind": [
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "name_fwd_ad": "mpi_send_init_fwd_ad",
-      "args_fwd_ad": [
-        "buf",
-        "buf_ad",
-        "count",
-        "datatype",
-        "dest",
-        "tag",
-        "comm",
-        "request",
-        "request_ad",
-        "ierr"
-      ],
-      "intents_fwd_ad": [
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out",
-        "out",
-        "out"
-      ],
-      "name_fwd_rev_ad": "mpi_send_init_fwd_rev_ad",
-      "name_rev_ad": "mpi_send_init_rev_ad",
-      "args_rev_ad": [
-        "buf_ad",
-        "count",
-        "datatype",
-        "dest",
-        "tag",
-        "comm",
-        "request_ad",
-        "ierr"
-      ],
-      "intents_rev_ad": [
-        "inout",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "inout",
-        "out"
-      ],
-      "module": "mpi"
-    },
-    "MPI_Recv_init": {
-      "args": [
-        "buf",
-        "count",
-        "datatype",
-        "source",
-        "tag",
-        "comm",
-        "request",
-        "ierr"
-      ],
-      "intents": [
-        "out",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out",
-        "out"
-      ],
-      "dims": [
-        [
-          "count"
-        ],
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "type": [
-        "real",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer",
-        "integer"
-      ],
-      "kind": [
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      ],
-      "name_fwd_ad": "mpi_recv_init_fwd_ad",
-      "args_fwd_ad": [
-        "buf",
-        "buf_ad",
-        "count",
-        "datatype",
-        "source",
-        "tag",
-        "comm",
-        "request",
-        "request_ad",
-        "ierr"
-      ],
-      "intents_fwd_ad": [
-        "out",
-        "out",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "out",
-        "out",
-        "out"
-      ],
-      "name_fwd_rev_ad": "mpi_recv_init_fwd_rev_ad",
-      "name_rev_ad": "mpi_recv_init_rev_ad",
-      "args_rev_ad": [
-        "buf_ad",
-        "count",
-        "datatype",
-        "source",
-        "tag",
-        "comm",
-        "request_ad",
-        "ierr"
-      ],
-      "intents_rev_ad": [
-        "inout",
-        "in",
-        "in",
-        "in",
-        "in",
-        "in",
-        "inout",
-        "out"
-      ],
-      "module": "mpi"
-    },
     "MPI_Start": {
       "args": [
         "request",
@@ -1688,6 +555,4486 @@
     },
     "MPI_Request_free": {
       "skip": true
+    },
+    "MPI_Reduce_r4": {
+      "args": [
+        "sendbuf",
+        "recvbuf",
+        "count",
+        "datatype",
+        "op",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        [
+          "count"
+        ],
+        [
+          "count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_reduce_fwd_ad_r4",
+      "args_fwd_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_reduce_rev_ad_r4",
+      "args_rev_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Reduce_r8": {
+      "args": [
+        "sendbuf",
+        "recvbuf",
+        "count",
+        "datatype",
+        "op",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        [
+          "count"
+        ],
+        [
+          "count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_reduce_fwd_ad_r8",
+      "args_fwd_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_reduce_rev_ad_r8",
+      "args_rev_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Reduce_scalar_r4": {
+      "args": [
+        "sendbuf",
+        "recvbuf",
+        "count",
+        "datatype",
+        "op",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_reduce_fwd_ad_scalar_r4",
+      "args_fwd_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_reduce_rev_ad_scalar_r4",
+      "args_rev_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Reduce_scalar_r8": {
+      "args": [
+        "sendbuf",
+        "recvbuf",
+        "count",
+        "datatype",
+        "op",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_reduce_fwd_ad_scalar_r8",
+      "args_fwd_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_reduce_rev_ad_scalar_r8",
+      "args_rev_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Allreduce_r4": {
+      "args": [
+        "sendbuf",
+        "recvbuf",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        [
+          "count"
+        ],
+        [
+          "count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_allreduce_fwd_ad_r4",
+      "args_fwd_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_allreduce_rev_ad_r4",
+      "args_rev_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Allreduce_r8": {
+      "args": [
+        "sendbuf",
+        "recvbuf",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        [
+          "count"
+        ],
+        [
+          "count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_allreduce_fwd_ad_r8",
+      "args_fwd_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_allreduce_rev_ad_r8",
+      "args_rev_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Allreduce_scalar_r4": {
+      "args": [
+        "sendbuf",
+        "recvbuf",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_allreduce_fwd_ad_scalar_r4",
+      "args_fwd_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_allreduce_rev_ad_scalar_r4",
+      "args_rev_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Allreduce_scalar_r8": {
+      "args": [
+        "sendbuf",
+        "recvbuf",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_allreduce_fwd_ad_scalar_r8",
+      "args_fwd_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_allreduce_rev_ad_scalar_r8",
+      "args_rev_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Send_r4": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        [
+          "count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_send_fwd_ad_r4",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_send_rev_ad_r4",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Send_r8": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        [
+          "count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_send_fwd_ad_r8",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_send_rev_ad_r8",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Send_scalar_r4": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_send_fwd_ad_scalar_r4",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_send_rev_ad_scalar_r4",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Send_scalar_r8": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_send_fwd_ad_scalar_r8",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_send_rev_ad_scalar_r8",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Isend_r4": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        [
+          "count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_isend_fwd_ad_r4",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "out"
+      ],
+      "name_fwd_rev_ad": "mpi_isend_fwd_rev_ad_r4",
+      "name_rev_ad": "mpi_isend_rev_ad_r4",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Isend_r8": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        [
+          "count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_isend_fwd_ad_r8",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "out"
+      ],
+      "name_fwd_rev_ad": "mpi_isend_fwd_rev_ad_r8",
+      "name_rev_ad": "mpi_isend_rev_ad_r8",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Isend_scalar_r4": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_isend_fwd_ad_scalar_r4",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "out"
+      ],
+      "name_fwd_rev_ad": "mpi_isend_fwd_rev_ad_scalar_r4",
+      "name_rev_ad": "mpi_isend_rev_ad_scalar_r4",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Isend_scalar_r8": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_isend_fwd_ad_scalar_r8",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "out"
+      ],
+      "name_fwd_rev_ad": "mpi_isend_fwd_rev_ad_scalar_r8",
+      "name_rev_ad": "mpi_isend_rev_ad_scalar_r8",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Irecv_r4": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request",
+        "ierr"
+      ],
+      "intents": [
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        [
+          "count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_irecv_fwd_ad_r4",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "out"
+      ],
+      "name_fwd_rev_ad": "mpi_irecv_fwd_rev_ad_r4",
+      "name_rev_ad": "mpi_irecv_rev_ad_r4",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Irecv_r8": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request",
+        "ierr"
+      ],
+      "intents": [
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        [
+          "count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_irecv_fwd_ad_r8",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "out"
+      ],
+      "name_fwd_rev_ad": "mpi_irecv_fwd_rev_ad_r8",
+      "name_rev_ad": "mpi_irecv_rev_ad_r8",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Irecv_scalar_r4": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request",
+        "ierr"
+      ],
+      "intents": [
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_irecv_fwd_ad_scalar_r4",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "out"
+      ],
+      "name_fwd_rev_ad": "mpi_irecv_fwd_rev_ad_scalar_r4",
+      "name_rev_ad": "mpi_irecv_rev_ad_scalar_r4",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Irecv_scalar_r8": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request",
+        "ierr"
+      ],
+      "intents": [
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_irecv_fwd_ad_scalar_r8",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "out"
+      ],
+      "name_fwd_rev_ad": "mpi_irecv_fwd_rev_ad_scalar_r8",
+      "name_rev_ad": "mpi_irecv_rev_ad_scalar_r8",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Recv_r4": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "status",
+        "ierr"
+      ],
+      "intents": [
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        [
+          "count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_recv_fwd_ad_r4",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "status",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "name_rev_ad": "mpi_recv_rev_ad_r4",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Recv_r8": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "status",
+        "ierr"
+      ],
+      "intents": [
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        [
+          "count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_recv_fwd_ad_r8",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "status",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "name_rev_ad": "mpi_recv_rev_ad_r8",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Recv_scalar_r4": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "status",
+        "ierr"
+      ],
+      "intents": [
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_recv_fwd_ad_scalar_r4",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "status",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "name_rev_ad": "mpi_recv_rev_ad_scalar_r4",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Recv_scalar_r8": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "status",
+        "ierr"
+      ],
+      "intents": [
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_recv_fwd_ad_scalar_r8",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "status",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "name_rev_ad": "mpi_recv_rev_ad_scalar_r8",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Put_r4": {
+      "args": [
+        "origin",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        [
+          "origin_count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_put_fwd_ad_r4",
+      "args_fwd_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_put_rev_ad_r4",
+      "args_rev_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "in",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Put_r8": {
+      "args": [
+        "origin",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        [
+          "origin_count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_put_fwd_ad_r8",
+      "args_fwd_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_put_rev_ad_r8",
+      "args_rev_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "in",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Put_scalar_r4": {
+      "args": [
+        "origin",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_put_fwd_ad_scalar_r4",
+      "args_fwd_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_put_rev_ad_scalar_r4",
+      "args_rev_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "in",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Put_scalar_r8": {
+      "args": [
+        "origin",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_put_fwd_ad_scalar_r8",
+      "args_fwd_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_put_rev_ad_scalar_r8",
+      "args_rev_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "in",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Get_r4": {
+      "args": [
+        "origin",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents": [
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        [
+          "origin_count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_get_fwd_ad_r4",
+      "args_fwd_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_get_rev_ad_r4",
+      "args_rev_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "out",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Get_r8": {
+      "args": [
+        "origin",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents": [
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        [
+          "origin_count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_get_fwd_ad_r8",
+      "args_fwd_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_get_rev_ad_r8",
+      "args_rev_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "out",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Get_scalar_r4": {
+      "args": [
+        "origin",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents": [
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_get_fwd_ad_scalar_r4",
+      "args_fwd_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_get_rev_ad_scalar_r4",
+      "args_rev_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "out",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Get_scalar_r8": {
+      "args": [
+        "origin",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents": [
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_get_fwd_ad_scalar_r8",
+      "args_fwd_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_get_rev_ad_scalar_r8",
+      "args_rev_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "win",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "out",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Accumulate_r4": {
+      "args": [
+        "origin",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "op",
+        "win",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        [
+          "origin_count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_accumulate_fwd_ad_r4",
+      "args_fwd_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "op",
+        "win",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_accumulate_rev_ad_r4",
+      "args_rev_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "op",
+        "win",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "in",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Accumulate_r8": {
+      "args": [
+        "origin",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "op",
+        "win",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        [
+          "origin_count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_accumulate_fwd_ad_r8",
+      "args_fwd_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "op",
+        "win",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_accumulate_rev_ad_r8",
+      "args_rev_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "op",
+        "win",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "in",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Accumulate_scalar_r4": {
+      "args": [
+        "origin",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "op",
+        "win",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_accumulate_fwd_ad_scalar_r4",
+      "args_fwd_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "op",
+        "win",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_accumulate_rev_ad_scalar_r4",
+      "args_rev_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "op",
+        "win",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "in",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Accumulate_scalar_r8": {
+      "args": [
+        "origin",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "op",
+        "win",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_accumulate_fwd_ad_scalar_r8",
+      "args_fwd_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "op",
+        "win",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "mpi_accumulate_rev_ad_scalar_r8",
+      "args_rev_ad": [
+        "origin",
+        "origin_ad",
+        "origin_count",
+        "origin_datatype",
+        "target_rank",
+        "target_disp",
+        "target_count",
+        "target_datatype",
+        "op",
+        "win",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "in",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Send_init_r4": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        [
+          "count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_send_init_fwd_ad_r4",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "out"
+      ],
+      "name_fwd_rev_ad": "mpi_send_init_fwd_rev_ad_r4",
+      "name_rev_ad": "mpi_send_init_rev_ad_r4",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "inout",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Send_init_r8": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        [
+          "count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_send_init_fwd_ad_r8",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "out"
+      ],
+      "name_fwd_rev_ad": "mpi_send_init_fwd_rev_ad_r8",
+      "name_rev_ad": "mpi_send_init_rev_ad_r8",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "inout",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Send_init_scalar_r4": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_send_init_fwd_ad_scalar_r4",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "out"
+      ],
+      "name_fwd_rev_ad": "mpi_send_init_fwd_rev_ad_scalar_r4",
+      "name_rev_ad": "mpi_send_init_rev_ad_scalar_r4",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "inout",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Send_init_scalar_r8": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_send_init_fwd_ad_scalar_r8",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "out"
+      ],
+      "name_fwd_rev_ad": "mpi_send_init_fwd_rev_ad_scalar_r8",
+      "name_rev_ad": "mpi_send_init_rev_ad_scalar_r8",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "dest",
+        "tag",
+        "comm",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "inout",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Recv_init_r4": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request",
+        "ierr"
+      ],
+      "intents": [
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        [
+          "count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_recv_init_fwd_ad_r4",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "out"
+      ],
+      "name_fwd_rev_ad": "mpi_recv_init_fwd_rev_ad_r4",
+      "name_rev_ad": "mpi_recv_init_rev_ad_r4",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "inout",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Recv_init_r8": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request",
+        "ierr"
+      ],
+      "intents": [
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        [
+          "count"
+        ],
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_recv_init_fwd_ad_r8",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "out"
+      ],
+      "name_fwd_rev_ad": "mpi_recv_init_fwd_rev_ad_r8",
+      "name_rev_ad": "mpi_recv_init_rev_ad_r8",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "inout",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Recv_init_scalar_r4": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request",
+        "ierr"
+      ],
+      "intents": [
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "mpi_recv_init_fwd_ad_scalar_r4",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "out"
+      ],
+      "name_fwd_rev_ad": "mpi_recv_init_fwd_rev_ad_scalar_r4",
+      "name_rev_ad": "mpi_recv_init_rev_ad_scalar_r4",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "inout",
+        "out"
+      ],
+      "module": "mpi"
+    },
+    "MPI_Recv_init_scalar_r8": {
+      "args": [
+        "buf",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request",
+        "ierr"
+      ],
+      "intents": [
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8",
+        "8"
+      ],
+      "name_fwd_ad": "mpi_recv_init_fwd_ad_scalar_r8",
+      "args_fwd_ad": [
+        "buf",
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "out"
+      ],
+      "name_fwd_rev_ad": "mpi_recv_init_fwd_rev_ad_scalar_r8",
+      "name_rev_ad": "mpi_recv_init_rev_ad_scalar_r8",
+      "args_rev_ad": [
+        "buf_ad",
+        "count",
+        "datatype",
+        "source",
+        "tag",
+        "comm",
+        "request_ad",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "in",
+        "inout",
+        "out"
+      ],
+      "module": "mpi"
     }
   },
   "variables": {
@@ -1858,5 +5205,71 @@
       "MPI_Bcast_scalar_r4",
       "MPI_Bcast_scalar_r8"
     ],
+    "MPI_Reduce": [
+      "MPI_Reduce_r4",
+      "MPI_Reduce_r8",
+      "MPI_Reduce_scalar_r4",
+      "MPI_Reduce_scalar_r8"
+    ],
+    "MPI_Allreduce": [
+      "MPI_Allreduce_r4",
+      "MPI_Allreduce_r8",
+      "MPI_Allreduce_scalar_r4",
+      "MPI_Allreduce_scalar_r8"
+    ],
+    "MPI_Send": [
+      "MPI_Send_r4",
+      "MPI_Send_r8",
+      "MPI_Send_scalar_r4",
+      "MPI_Send_scalar_r8"
+    ],
+    "MPI_Isend": [
+      "MPI_Isend_r4",
+      "MPI_Isend_r8",
+      "MPI_Isend_scalar_r4",
+      "MPI_Isend_scalar_r8"
+    ],
+    "MPI_Irecv": [
+      "MPI_Irecv_r4",
+      "MPI_Irecv_r8",
+      "MPI_Irecv_scalar_r4",
+      "MPI_Irecv_scalar_r8"
+    ],
+    "MPI_Recv": [
+      "MPI_Recv_r4",
+      "MPI_Recv_r8",
+      "MPI_Recv_scalar_r4",
+      "MPI_Recv_scalar_r8"
+    ],
+    "MPI_Put": [
+      "MPI_Put_r4",
+      "MPI_Put_r8",
+      "MPI_Put_scalar_r4",
+      "MPI_Put_scalar_r8"
+    ],
+    "MPI_Get": [
+      "MPI_Get_r4",
+      "MPI_Get_r8",
+      "MPI_Get_scalar_r4",
+      "MPI_Get_scalar_r8"
+    ],
+    "MPI_Accumulate": [
+      "MPI_Accumulate_r4",
+      "MPI_Accumulate_r8",
+      "MPI_Accumulate_scalar_r4",
+      "MPI_Accumulate_scalar_r8"
+    ],
+    "MPI_Send_init": [
+      "MPI_Send_init_r4",
+      "MPI_Send_init_r8",
+      "MPI_Send_init_scalar_r4",
+      "MPI_Send_init_scalar_r8"
+    ],
+    "MPI_Recv_init": [
+      "MPI_Recv_init_r4",
+      "MPI_Recv_init_r8",
+      "MPI_Recv_init_scalar_r4",
+      "MPI_Recv_init_scalar_r8"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- create r4/r8 and scalar variants for MPI routines in mpi.fadmod
- update generic mappings accordingly

## Testing
- `python tests/test_generator.py` *(fails: Not found in routime_map)*

------
https://chatgpt.com/codex/tasks/task_b_687d9f7004ac832d93778021f4004fb3