### PR TITLE
Refactor VarDict and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ bin/fautodiff -M examples examples/cross_mod_a.f90
 bin/fautodiff -I examples examples/cross_mod_b.f90
 ```
 
+Generate code programmatically from Python:
+
+```python
+from fautodiff.generator import generate_ad
+
+ad_code = generate_ad("examples/simple_math.f90")
+print(ad_code)
+```
+
 Generate forward mode only:
 
 ```bash

--- a/fautodiff/var_dict.py
+++ b/fautodiff/var_dict.py
@@ -1,54 +1,58 @@
-class Vardict:
-    def __init__(self):
-        self._data = []
+"""Simple ordered dictionary used by the tests."""
 
-    def __setitem__(self, key, value):
-        for i, (k, _) in enumerate(self._data):
-            if k == key:
-                self._data[i] = (key, value)
-                return
-        self._data.append((key, value))
+from __future__ import annotations
+
+class VarDict:
+    """Ordered dictionary with a minimal API.
+
+    This class mimics part of :class:`dict` while preserving insertion order.
+    The previous implementation stored key/value pairs in a list which was
+    inefficient for lookups.  Using a real dictionary keeps the behaviour
+    unchanged but improves performance.
+    """
+
+    def __init__(self) -> None:
+        self._data: dict = {}
+
+    def __setitem__(self, key, value) -> None:
+        """Set ``key`` to ``value`` preserving insertion order."""
+        self._data[key] = value
 
     def __getitem__(self, key):
-        for k, v in self._data:
-            if k == key:
-                return v
-        raise KeyError(key)
+        return self._data[key]
 
-    def __contains__(self, key):
-        return any(k == key for k, _ in self._data)
+    def __contains__(self, key) -> bool:
+        return key in self._data
 
-    def __delitem__(self, key):
-        for i, (k, _) in enumerate(self._data):
-            if k == key:
-                del self._data[i]
-                return
-        raise KeyError(key)
+    def __delitem__(self, key) -> None:
+        del self._data[key]
 
     def keys(self):
-        return [k for k, _ in self._data]
+        return list(self._data.keys())
 
     def values(self):
-        return [v for _, v in self._data]
+        return list(self._data.values())
 
     def items(self):
-        return list(self._data)
+        return list(self._data.items())
 
     def __len__(self):
         return len(self._data)
 
     def __iter__(self):
-        for k, _ in self._data:
-            yield k
+        return iter(self._data)
 
     def __str__(self):
-        return ", ".join([f"{k}=>{v}" for k,v in self._data])
+        return ", ".join(f"{k}=>{v}" for k, v in self._data.items())
 
-    def remove(self, key):
-        del self[key]
+    def remove(self, key) -> None:
+        self._data.pop(key)
 
-    def copy(self) -> "Vardict":
+    def copy(self) -> "VarDict":
         obj = type(self)()
-        for k, v in self._data:
-            obj[k] = v
+        obj._data = self._data.copy()
         return obj
+
+
+# Backwards compatibility: old class name
+Vardict = VarDict

--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -40,9 +40,13 @@ class TestFortranADCode(unittest.TestCase):
             exe = self._build(tmp, f'run_{name}.out')
             for sub_name in sub_names:
                 # Allow runtime failures to keep coverage high
-                cmd = [str(exe), sub_name]
                 if use_mpi:
-                    cmd = [self.mpirun or 'mpirun', '-np', '2'] + cmd
+                    cmd = [self.mpirun or 'mpirun', '-np', '2']
+                    if os.geteuid() == 0:
+                        cmd.append('--allow-run-as-root')
+                    cmd += [str(exe), sub_name]
+                else:
+                    cmd = [str(exe), sub_name]
                 subprocess.run(cmd, check=True)
 
 

--- a/tests/test_vardict.py
+++ b/tests/test_vardict.py
@@ -4,12 +4,12 @@ import unittest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from fautodiff.var_dict import Vardict
+from fautodiff.var_dict import VarDict
 
 
-class TestVardict(unittest.TestCase):
+class TestVarDict(unittest.TestCase):
     def test_basic_operations(self):
-        vd = Vardict()
+        vd = VarDict()
         vd['a'] = 1
         vd['b'] = 2
         self.assertEqual(vd['a'], 1)


### PR DESCRIPTION
## Summary
- improve `var_dict` implementation using a real dictionary
- update tests to use `VarDict`
- allow MPI tests to run as root
- document Python API usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688633e34ab8832d9b53946051a2501b