### PR TITLE
docs: clarify reverse-mode usage and CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # fautodiff
 Autodiff code generator for Fortran
 
-This is a source-to-source conversion tool that generates automatic differentiation code from Fortran programs.
-Documentation of the supported Fortran constructs can be found under
-``doc/fortran_support.md``.
+This source-to-source tool parses existing Fortran programs and emits new modules
+with ``_ad`` suffixes, preserving the original structure while providing forward
+and reverse mode derivatives. Documentation of the supported Fortran constructs
+can be found in ``doc/fortran_support.md``.
 
 ## Installation
 
@@ -72,6 +73,11 @@ Generate reverse mode only:
 bin/fautodiff --mode reverse examples/simple_math.f90
 ```
 
+Suppress warnings about unsupported derivatives with ``--no-warn``:
+```bash
+bin/fautodiff --no-warn examples/simple_math.f90
+```
+
 Each module's routine signatures are also written to a `<module>.fadmod` file when AD code is generated.
 These JSON files can be loaded when differentiating another file that uses the module.
 Add search directories with ``-I`` (repeat as needed), choose the output directory with ``-M DIR`` (defaults to the current directory), and disable writing with ``--no-fadmod``:
@@ -111,10 +117,12 @@ call foo_fwd_ad(x, x_ad, y, y_ad) ! x: in, x_ad: in, y: out, y_ad: out
 
 ### Calling reverse-mode routines
 
-Reverse-mode subroutines return each ``intent(in)`` or ``intent(inout)`` variable along with its derivative.
-Arguments consist of the original inputs followed by their derivative counterparts:
+Reverse-mode subroutines accept the original inputs and the derivatives of any
+``intent(out)`` results. They return derivatives for ``intent(in)`` arguments and
+update the derivatives of ``intent(inout)`` and ``intent(out)`` variables in
+place:
 ```fortran
-real :: x, x_ad, y, y_ad
+real :: x, x_ad, y_ad
 x = 2.0
 y_ad = 1.0
 call foo_rev_ad(x, x_ad, y_ad) ! x: in, x_ad: out, y_ad: inout

--- a/doc/directives.md
+++ b/doc/directives.md
@@ -18,5 +18,10 @@ A constant variable does not receive a corresponding `_ad` variable and no deriv
 ```
 !$FAD SKIP
 ```
+Use `SKIP` before a routine to parse it but omit the generation of AD code:
 
-Use `SKIP` before a routine to parse it but omit the generation of AD code.
+```fortran
+!$FAD SKIP
+subroutine helper(...)
+```
+

--- a/doc/fortran_support.md
+++ b/doc/fortran_support.md
@@ -4,7 +4,7 @@ This document summarizes the Fortran constructs handled by the AD code generator
 
 ## Modules and routines
 - Each module in the input becomes a `<module>_ad` module.
-- Every subroutine or function produces `<name>_fwd_ad` and `<name>_rev_ad` versions.
+- By default, every subroutine or function produces `<name>_fwd_ad` and `<name>_rev_ad` versions. The command line `--mode` flag can restrict generation to only forward or reverse routines.
 - Forward-mode routines also return the original `intent(out)` variables together with their gradients. These routines execute the original computations internally so callers do not need to invoke the non-AD version.
 - Integer variables are treated as constants and do not receive `_ad` counterparts.
 


### PR DESCRIPTION
## Summary
- clarify repository overview and highlight `_ad` modules
- document `--no-warn` CLI option and revise reverse-mode usage example
- mention `--mode` flag in Fortran feature doc and add `SKIP` directive example
- fix reverse-mode snippet so derivative of `intent(out)` variable is marked `inout`

## Testing
- `python tests/test_generator.py`
- `python tests/test_fortran_runtime.py`
- `python tests/test_fortran_adcode.py`


------
https://chatgpt.com/codex/tasks/task_b_688c905756b0832dbcd93329cca0ff00