### PR TITLE
Fix recursion in Node.has_reference_to

### DIFF
--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -81,7 +81,7 @@ class Node:
         """Return ``True`` if ``var`` is refered within this node."""
         if any(var == v.name for v in self.iter_ref_vars()):
             return True
-        return any(child.has_ref_to(var) for child in self.iter_children())
+        return any(child.has_reference_to(var) for child in self.iter_children())
 
     def has_assignment_to(self, var: str) -> bool:
         """Return ``True`` if ``var`` is assigned within this node."""


### PR DESCRIPTION
## Summary
- Fix recursive call in Node.has_reference_to to search children properly

## Testing
- `python tests/test_code_tree.py`
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_688ca05bf238832d8723e91df6aa05dc