### PR TITLE
Handle CLI errors and add tests

### DIFF
--- a/fautodiff/cli.py
+++ b/fautodiff/cli.py
@@ -1,5 +1,6 @@
 """Command line interface for the fautodiff generator."""
 import argparse
+import sys
 from . import generator
 
 
@@ -44,15 +45,20 @@ def main():
     )
     args = parser_arg.parse_args()
 
-    code = generator.generate_ad(
-        args.input,
-        args.output,
-        warn=not args.no_warn,
-        search_dirs=args.search_dirs,
-        write_fadmod=not args.no_fadmod,
-        fadmod_dir=args.fadmod_dir,
-        mode=args.mode,
-    )
+    try:
+        code = generator.generate_ad(
+            args.input,
+            args.output,
+            warn=not args.no_warn,
+            search_dirs=args.search_dirs,
+            write_fadmod=not args.no_fadmod,
+            fadmod_dir=args.fadmod_dir,
+            mode=args.mode,
+        )
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
     if args.output is None:
         print(code, end="")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,34 @@
+import subprocess
+import sys
+from pathlib import Path
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestCLI(unittest.TestCase):
+    def run_cli(self, *args):
+        return subprocess.run(
+            [sys.executable, "-m", "fautodiff.cli", *args],
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+        )
+
+    def test_cli_success(self):
+        src = ROOT / "examples" / "store_vars.f90"
+        result = self.run_cli(str(src), "--no-fadmod", "--no-warn")
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("module store_vars_ad", result.stdout)
+
+    def test_cli_invalid_input(self):
+        result = self.run_cli("nonexistent.f90")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Error", result.stderr)
+        self.assertEqual(result.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- wrap CLI code generation in try/except and exit with error message when generation fails
- add CLI tests covering success and failure cases

## Testing
- `python tests/test_generator.py`
- `python tests/test_cli.py`


------
https://chatgpt.com/codex/tasks/task_b_688ca06c8834832dbc7d3ab2c53b02b8