### PR TITLE
Add Python packaging metadata and install tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ can be found in ``doc/fortran_support.md``.
 
 ## Installation
 
-The parser relies on the `fparser` package (version **0.2.0 or later**) which can be installed via pip:
+The parser relies on the `fparser` package (version **0.2.0 or later**).
+
+Install `fautodiff` and its dependencies with:
 
 ```bash
-pip install "fparser>=0.2.0"
+pip install .
 ```
 
 ## Generating AD code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fautodiff"
+version = "0.1.0"
+description = "Autodiff code generator for Fortran"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "BSD-2-Clause"}
+authors = [{name = "Seiya Nishizawa"}]
+classifiers = [
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+]
+dependencies = [
+    "fparser>=0.2.0",
+]
+
+[project.scripts]
+fautodiff = "fautodiff.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+license = BSD-2-Clause
+license_files = LICENSE
+classifiers =
+    License :: OSI Approved :: BSD License
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,27 @@
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestPackaging(unittest.TestCase):
+    def test_install_and_import(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subprocess.check_call(
+                [sys.executable, "-m", "pip", "install", ".", "--target", tmpdir],
+                cwd=ROOT,
+            )
+            env = os.environ.copy()
+            env["PYTHONPATH"] = tmpdir
+            subprocess.check_call(
+                [sys.executable, "-c", "import fautodiff"],
+                env=env,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- package project via `pyproject.toml` with console entry point
- document how to install with `pip install .`
- verify install by importing package in a new test

## Testing
- `python tests/test_package.py`
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_688ca604b358832d939150474c63d997