### PR TITLE
Add nested reference test

### DIFF
--- a/tests/test_code_tree.py
+++ b/tests/test_code_tree.py
@@ -129,6 +129,20 @@ class TestNodeMethods(unittest.TestCase):
         self.assertFalse(outer.has_assignment_to("b"))
         self.assertFalse(outer.has_assignment_to("c"))
 
+    def test_has_reference_to(self):
+        inner = Block([
+            Assignment(OpVar("b"), OpVar("a")),
+        ])
+        loop = DoLoop(
+            inner,
+            index=OpVar("i"),
+            range=OpRange([OpInt(1), OpInt(10)])
+        )
+        outer = Block([loop])
+        self.assertTrue(outer.has_reference_to("a"))
+        self.assertFalse(outer.has_reference_to("c"))
+        self.assertFalse(outer.has_reference_to("b"))
+
     def test_ids_and_clone(self):
         blk = Block([Assignment(OpVar("a"), OpInt(1))])
         for child in blk.iter_children():


### PR DESCRIPTION
## Summary
- test has_reference_to on nested blocks

## Testing
- `python tests/test_code_tree.py`
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_688ca5edef3c832db7192e2796f9a370