### PR TITLE
Support WHERE and FORALL constructs

### DIFF
--- a/examples/where_forall.f90
+++ b/examples/where_forall.f90
@@ -1,0 +1,24 @@
+module where_forall
+  implicit none
+contains
+  subroutine where_example(n, a, b)
+    integer, intent(in) :: n
+    real, intent(inout) :: a(n)
+    real, intent(in) :: b(n)
+    where (a > 0.0)
+      a = a + b
+    elsewhere
+      a = -a
+    end where
+  end subroutine where_example
+
+  subroutine forall_example(n, a, b)
+    integer, intent(in) :: n
+    real, intent(in) :: a(n)
+    real, intent(out) :: b(n)
+    integer :: i
+    forall (i = 1:n)
+      b(i) = 2.0 * a(i)
+    end forall
+  end subroutine forall_example
+end module where_forall

--- a/examples/where_forall_ad.f90
+++ b/examples/where_forall_ad.f90
@@ -1,0 +1,78 @@
+module where_forall_ad
+  use where_forall
+  implicit none
+
+contains
+
+  subroutine where_example_fwd_ad(n, a, a_ad, b, b_ad)
+    integer, intent(in)  :: n
+    real, intent(inout) :: a(n)
+    real, intent(inout) :: a_ad(n)
+    real, intent(in)  :: b(n)
+    real, intent(in)  :: b_ad(n)
+
+    where (a > 0.0)
+      a_ad = a_ad + b_ad ! a = a + b
+      a = a + b
+    elsewhere
+      a_ad = - a_ad ! a = -a
+      a = - a
+    end where
+
+    return
+  end subroutine where_example_fwd_ad
+
+  subroutine where_example_rev_ad(n, a, a_ad, b, b_ad)
+    integer, intent(in)  :: n
+    real, intent(inout) :: a(n)
+    real, intent(inout) :: a_ad(n)
+    real, intent(in)  :: b(n)
+    real, intent(out) :: b_ad(n)
+
+    b_ad(:) = 0.0
+
+    where (a > 0.0)
+      b_ad = a_ad ! a = a + b
+    elsewhere
+      a_ad = - a_ad ! a = -a
+    end where
+
+    return
+  end subroutine where_example_rev_ad
+
+  subroutine forall_example_fwd_ad(n, a, a_ad, b, b_ad)
+    integer, intent(in)  :: n
+    real, intent(in)  :: a(n)
+    real, intent(in)  :: a_ad(n)
+    real, intent(out) :: b(n)
+    real, intent(out) :: b_ad(n)
+    integer :: i
+
+    b_ad(:) = 0.0
+
+    forall (i=1:n)
+      b_ad(i) = a_ad(i) * 2.0 ! b(i) = 2.0 * a(i)
+      b(i) = 2.0 * a(i)
+    end forall
+
+    return
+  end subroutine forall_example_fwd_ad
+
+  subroutine forall_example_rev_ad(n, a, a_ad, b_ad)
+    integer, intent(in)  :: n
+    real, intent(in)  :: a(n)
+    real, intent(out) :: a_ad(n)
+    real, intent(inout) :: b_ad(n)
+    integer :: i
+
+    a_ad(:) = 0.0
+
+    forall (i=1:n)
+      a_ad(i) = b_ad(i) * 2.0 ! b(i) = 2.0 * a(i)
+      b_ad(i) = 0.0 ! b(i) = 2.0 * a(i)
+    end forall
+
+    return
+  end subroutine forall_example_rev_ad
+
+end module where_forall_ad

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -35,6 +35,8 @@ from .code_tree import (
     DoWhile,
     IfBlock,
     SelectBlock,
+    WhereBlock,
+    ForallBlock,
     Allocate,
     Deallocate,
     Statement,
@@ -313,6 +315,10 @@ def _parse_pointer(node: Node,
     elif isinstance(node, DoAbst):
         map_ptr, map_ref_new = _parse_pointer(node._body, mod_vars, map_ptr, {}, True)
         for key in map_ref_new: # pointer is updated in the loop
+            map_ref[key] = None
+    elif isinstance(node, ForallBlock):
+        map_ptr, map_ref_new = _parse_pointer(node._body, mod_vars, map_ptr, {}, True)
+        for key in map_ref_new:
             map_ref[key] = None
     else:
         for child in [n for n in node.iter_children()]:

--- a/tests/fortran_runtime/Makefile
+++ b/tests/fortran_runtime/Makefile
@@ -18,7 +18,7 @@ PROGRAM_NAMES = run_simple_math.out run_arrays.out run_call_example.out run_cont
            run_intrinsic_func.out run_real_kind.out run_save_vars.out run_store_vars.out \
            run_directives.out run_parameter_var.out run_module_vars.out run_call_module_vars.out run_allocate_vars.out \
            run_exit_cycle.out run_pointer_arrays.out run_derived_alloc.out run_mpi_example.out \
-		   run_stack.out
+                   run_stack.out run_where_forall.out
 PROGRAMS = $(addprefix $(OUTDIR)/,$(PROGRAM_NAMES))
 
 .PHONY: all clean
@@ -66,6 +66,7 @@ $(OUTDIR)/run_exit_cycle.o: $(OUTDIR)/exit_cycle.o $(OUTDIR)/exit_cycle_ad.o $(O
 $(OUTDIR)/run_pointer_arrays.o: $(OUTDIR)/pointer_arrays.o $(OUTDIR)/pointer_arrays_ad.o $(OUTDIR)/fautodiff_stack.o
 $(OUTDIR)/run_derived_alloc.o: $(OUTDIR)/derived_alloc.o $(OUTDIR)/derived_alloc_ad.o $(OUTDIR)/fautodiff_stack.o
 $(OUTDIR)/run_mpi_example.o: $(OUTDIR)/mpi_example.o $(OUTDIR)/mpi_example_ad.o $(OUTDIR)/mpi_ad.o
+$(OUTDIR)/run_where_forall.o: $(OUTDIR)/where_forall.o $(OUTDIR)/where_forall_ad.o
 
 $(OUTDIR)/run_fautodiff_stack.o: $(OUTDIR)/fautodiff_stack.o
 
@@ -88,6 +89,7 @@ $(OUTDIR)/run_exit_cycle.out: $(OUTDIR)/run_exit_cycle.o $(OUTDIR)/exit_cycle.o 
 $(OUTDIR)/run_pointer_arrays.out: $(OUTDIR)/run_pointer_arrays.o $(OUTDIR)/pointer_arrays.o $(OUTDIR)/pointer_arrays_ad.o $(OUTDIR)/fautodiff_stack.o
 $(OUTDIR)/run_derived_alloc.out: $(OUTDIR)/run_derived_alloc.o $(OUTDIR)/derived_alloc.o $(OUTDIR)/derived_alloc_ad.o $(OUTDIR)/fautodiff_stack.o
 $(OUTDIR)/run_mpi_example.out: $(OUTDIR)/run_mpi_example.o $(OUTDIR)/mpi_example.o $(OUTDIR)/mpi_example_ad.o $(OUTDIR)/mpi_ad.o
+$(OUTDIR)/run_where_forall.out: $(OUTDIR)/run_where_forall.o $(OUTDIR)/where_forall.o $(OUTDIR)/where_forall_ad.o
 
 $(OUTDIR)/run_fautodiff_stack.out: $(OUTDIR)/run_fautodiff_stack.o $(OUTDIR)/fautodiff_stack.o
 

--- a/tests/fortran_runtime/run_where_forall.f90
+++ b/tests/fortran_runtime/run_where_forall.f90
@@ -1,0 +1,112 @@
+program run_where_forall
+  use where_forall
+  use where_forall_ad
+  implicit none
+  real, parameter :: tol = 1.0e-4
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_where_example = 1
+  integer, parameter :: I_forall_example = 2
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("where_example")
+              i_test = I_where_example
+           case ("forall_example")
+              i_test = I_forall_example
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_where_example .or. i_test == I_all) then
+     call test_where_example
+  end if
+  if (i_test == I_forall_example .or. i_test == I_all) then
+     call test_forall_example
+  end if
+  stop
+contains
+
+  subroutine test_where_example
+    integer, parameter :: n = 3
+    real :: a(n), b(n)
+    real :: a0(n), b0(n)
+    real :: a_ad(n), b_ad(n)
+    real :: a_eps(n), b_eps(n), fd(n), eps
+    real :: inner1, inner2
+
+    eps = 1.0e-3
+    a0 = (/ -1.0, 2.0, -3.0 /)
+    b0 = (/ 1.0, 1.0, 1.0 /)
+    a = a0
+    b = b0
+    call where_example(n, a, b)
+    a_eps = a0 + eps
+    b_eps = b0 + eps
+    call where_example(n, a_eps, b_eps)
+    fd(:) = (a_eps(:) - a(:)) / eps
+    a = a0
+    b = b0
+    a_ad(:) = 1.0
+    b_ad(:) = 1.0
+    call where_example_fwd_ad(n, a, a_ad, b, b_ad)
+    if (any(abs((a_ad - fd) / fd) > tol)) then
+       print *, 'test_where_example_fwd failed'
+       error stop 1
+    end if
+
+    inner1 = sum(a_ad(:)**2)
+    a = a0
+    b = b0
+    call where_example_rev_ad(n, a, a_ad, b, b_ad)
+    inner2 = sum(a_ad(:)) + sum(b_ad(:))
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_where_example_rev failed'
+       error stop 1
+    end if
+  end subroutine test_where_example
+
+  subroutine test_forall_example
+    integer, parameter :: n = 3
+    real :: a(n), b(n)
+    real :: a_ad(n), b_ad(n)
+    real :: b_eps(n), fd(n), eps
+    real :: inner1, inner2
+
+    eps = 1.0e-3
+    a = (/1.0, 2.0, 3.0/)
+    call forall_example(n, a, b)
+    call forall_example(n, a + eps, b_eps)
+    fd(:) = (b_eps(:) - b(:)) / eps
+    a_ad(:) = 1.0
+    call forall_example_fwd_ad(n, a, a_ad, b, b_ad)
+    if (any(abs((b_ad - fd) / fd) > tol)) then
+       print *, 'test_forall_example_fwd failed'
+       error stop 1
+    end if
+
+    inner1 = sum(b_ad(:)**2)
+    call forall_example_rev_ad(n, a, a_ad, b_ad)
+    inner2 = sum(a_ad(:))
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_forall_example_rev failed'
+       error stop 1
+    end if
+  end subroutine test_forall_example
+
+end program run_where_forall

--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -129,6 +129,10 @@ class TestFortranADCode(unittest.TestCase):
     def test_mpi_example(self):
         self._run_test('mpi_example', ['sum_reduce'], use_mpi=True)
 
+    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
+    def test_where_forall(self):
+        self._run_test('where_forall', ['where_example', 'forall_example'])
+
 
 
 if __name__ == '__main__':

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -381,6 +381,13 @@ class TestGenerator(unittest.TestCase):
         expected = Path('examples/mpi_example_ad.f90').read_text()
         self.assertEqual(generated, expected)
 
+    def test_where_forall(self):
+        code_tree.Node.reset()
+        src = Path('examples/where_forall.f90')
+        generated = generator.generate_ad(str(src), warn=False)
+        expected = src.with_name('where_forall_ad.f90').read_text()
+        self.assertEqual(generated, expected)
+
 
 def _make_example_test(src: Path):
     def test(self):


### PR DESCRIPTION
## Summary
- parse WHERE and FORALL constructs into dedicated nodes
- generate AD code for WHERE/ELSEWHERE and FORALL blocks
- add examples and runtime tests for WHERE and FORALL

## Testing
- `pytest tests/test_generator.py -q`
- `pytest tests/test_fortran_adcode.py::TestFortranADCode::test_where_forall -q`


------
https://chatgpt.com/codex/tasks/task_b_688d42b1ba98832d85bc13c85c2208e5