### PR TITLE
Add support for Fortran block construct

### DIFF
--- a/doc/fortran_support.md
+++ b/doc/fortran_support.md
@@ -13,6 +13,7 @@ This document summarizes the Fortran constructs handled by the AD code generator
 - `select case`
 - `do` and `do while` loops
 - `exit` and `cycle` statements inside `do` loops
+- `block` constructs providing local scoping
 
 ## Array operations
 - Array assignments and loops over arrays are supported.

--- a/examples/block_construct.f90
+++ b/examples/block_construct.f90
@@ -1,0 +1,22 @@
+module block_construct
+  implicit none
+  real :: z
+contains
+  subroutine compute_module(val)
+    real, intent(in) :: val
+    z = val + 1.0
+  end subroutine compute_module
+
+  subroutine use_block(x, y)
+    real, intent(in) :: x
+    real, intent(out) :: y
+    real :: z
+    z = x + 1.0
+    block
+      real :: z
+      z = x + 2.0
+      y = z + 1.0
+    end block
+    y = y + z
+  end subroutine use_block
+end module block_construct

--- a/examples/block_construct_ad.f90
+++ b/examples/block_construct_ad.f90
@@ -1,0 +1,74 @@
+module block_construct_ad
+  use block_construct
+  implicit none
+
+  real :: z_ad = 0.0
+
+contains
+
+  subroutine compute_module_fwd_ad(val, val_ad)
+    real, intent(in)  :: val
+    real, intent(in)  :: val_ad
+
+    z_ad = val_ad ! z = val + 1.0
+    z = val + 1.0
+
+    return
+  end subroutine compute_module_fwd_ad
+
+  subroutine compute_module_rev_ad(val, val_ad)
+    real, intent(in)  :: val
+    real, intent(out) :: val_ad
+
+    val_ad = z_ad ! z = val + 1.0
+    z_ad = 0.0 ! z = val + 1.0
+
+    return
+  end subroutine compute_module_rev_ad
+
+  subroutine use_block_fwd_ad(x, x_ad, y, y_ad)
+    real, intent(in)  :: x
+    real, intent(in)  :: x_ad
+    real, intent(out) :: y
+    real, intent(out) :: y_ad
+    real :: z_ad
+    real :: z
+
+    z_ad = x_ad ! z = x + 1.0
+    z = x + 1.0
+    block
+      real :: z
+      real :: z_ad = 0.0
+
+      z_ad = x_ad ! z = x + 2.0
+      z = x + 2.0
+      y_ad = z_ad ! y = z + 1.0
+      y = z + 1.0
+    end block
+    y_ad = y_ad + z_ad ! y = y + z
+    y = y + z
+
+    return
+  end subroutine use_block_fwd_ad
+
+  subroutine use_block_rev_ad(x, x_ad, y_ad)
+    real, intent(in)  :: x
+    real, intent(out) :: x_ad
+    real, intent(inout) :: y_ad
+    real :: z_ad
+
+    z_ad = y_ad + z_ad ! y = y + z
+    block
+      real :: z_ad = 0.0
+
+      z_ad = y_ad ! y = z + 1.0
+      y_ad = 0.0 ! y = z + 1.0
+      x_ad = z_ad ! z = x + 2.0
+    end block
+    x_ad = z_ad + x_ad ! z = x + 1.0
+    z_ad = 0.0 ! z = x + 1.0
+
+    return
+  end subroutine use_block_rev_ad
+
+end module block_construct_ad

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -37,6 +37,7 @@ from .code_tree import (
     SelectBlock,
     WhereBlock,
     ForallBlock,
+    BlockConstruct,
     Allocate,
     Deallocate,
     Statement,

--- a/tests/test_code_tree.py
+++ b/tests/test_code_tree.py
@@ -18,6 +18,7 @@ from fautodiff.code_tree import (
     DoLoop,
     DoWhile,
     IfBlock,
+    BlockConstruct,
     render_program
 )
 from fautodiff.operators import (
@@ -198,6 +199,27 @@ class TestNodeMethods(unittest.TestCase):
         )
         self.assertEqual({str(v) for v in sub.assigned_vars()}, {"a", "b"})
         self.assertEqual({str(v) for v in sub.required_vars()}, set())
+
+    def test_block_scope(self):
+        decls = Block([Declaration(name="a", typename="real")])
+        body = Block([Assignment(OpVar("b"), OpVar("a"))])
+        blk = BlockConstruct(decls, body)
+        self.assertFalse(blk.has_reference_to("a"))
+        self.assertFalse(blk.has_assignment_to("a"))
+        self.assertTrue(blk.has_assignment_to("b"))
+        vars = VarList([OpVar("a")])
+        vars = blk.required_vars(vars)
+        self.assertEqual({str(v) for v in vars}, {"a"})
+        vars = VarList([OpVar("a")])
+        vars = blk.assigned_vars(vars)
+        self.assertEqual({str(v) for v in vars}, {"a", "b"})
+
+    def test_block_unrefered_advars(self):
+        decls = Block([Declaration(name="a_ad", typename="real")])
+        blk = BlockConstruct(decls, Block([]))
+        vars = VarList([OpVar("b_ad")])
+        vars = blk.unrefered_advars(vars)
+        self.assertEqual({str(v) for v in vars}, {"b_ad"})
 
     def test_do_loop_list(self):
         a = Assignment(OpVar("a"), OpInt(0))

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -151,6 +151,12 @@ class TestGenerator(unittest.TestCase):
         variables = data.get("variables", {})
         self.assertIn("c", variables)
 
+    def test_block_construct(self):
+        code_tree.Node.reset()
+        generated = generator.generate_ad("examples/block_construct.f90", warn=False)
+        expected = Path("examples/block_construct_ad.f90").read_text()
+        self.assertEqual(generated, expected)
+
     def test_fadmod_variable_defaults(self):
         code_tree.Node.reset()
         fadmod = Path("module_vars.fadmod")


### PR DESCRIPTION
## Summary
- track block-local variable names and exclude them when computing required and assigned variables
- honor block scoping in reference/assignment queries and pruning logic
- test block construct handling and verify local variable isolation
- strip block-local names from unreferenced variable analysis and cover with unit tests
- expand block example to reuse the same variable name at module, routine, and block scope

## Testing
- `python tests/test_generator.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688d533dd848832d9d6e5ee4dc4864c9