### PR TITLE
Handle OpenMP directives without explicit end

### DIFF
--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -3949,6 +3949,29 @@ class OmpDirective(Node):
         body = self.body.deep_clone() if self.body is not None else None
         return OmpDirective(self.directive, list(self.clauses), body)
 
+    def insert_before(self, id: int, node: "Node"):
+        if self.body is None:
+            raise NotImplementedError("OmpDirective has no body")
+        if isinstance(self.body, Block):
+            self.body.insert_before(id, node)
+            return
+        if self.body.get_id() == id:
+            self.body = Block([node, self.body])
+            self.body.set_parent(self)
+            return
+        self.body.insert_before(id, node)
+
+    def insert_begin(self, node: "Node"):
+        if self.body is None:
+            self.body = Block([node])
+            self.body.set_parent(self)
+            return
+        if isinstance(self.body, Block):
+            self.body.insert_begin(node)
+            return
+        self.body = Block([node, self.body])
+        self.body.set_parent(self)
+
     def augment_clauses(self, routine: Routine) -> "OmpDirective":
         """Return a copy with *_ad variables added to relevant clauses.
 

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -1448,6 +1448,8 @@ def generate_ad(
                     reverse=False,
                 )
                 if sub is not None:
+                    if _has_omp(sub.ad_content):
+                        _augment_omp_clauses(sub.ad_content, sub)
                     mod.routines.append(sub)
                 ad_modules_used.update(mods_called)
             if mode in ("reverse", "both"):
@@ -1462,6 +1464,8 @@ def generate_ad(
                     reverse=True,
                 )
                 if sub is not None:
+                    if _has_omp(sub.ad_content):
+                        _augment_omp_clauses(sub.ad_content, sub)
                     mod.routines.append(sub)
                 ad_modules_used.update(mods_called)
                 if used:


### PR DESCRIPTION
## Summary
- allow parsing OpenMP directives that lack matching `end` lines
- support inserting code around directives via `OmpDirective`
- ensure generated AD code augments OpenMP clauses

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_688da3272848832d9d9e9f4888c607fc