### PR TITLE
Add OpenMP loop runtime tests

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -3,7 +3,7 @@ OUTDIR ?= $(shell pwd)
 FC = gfortran
 MPIFC ?= mpifort
 FFLAGS = -O2 -ffree-line-length-none \
-         -ffpe-trap=invalid,zero,overflow,underflow -fbounds-check -finit-real=nan -g -fbacktrace
+         -ffpe-trap=invalid,zero,overflow,underflow -fbounds-check -finit-real=nan -g -fbacktrace -fopenmp
 
 SRCS := $(wildcard *.f90)
 OBJS := $(addprefix $(OUTDIR)/,$(SRCS:.f90=.o))

--- a/tests/fortran_runtime/Makefile
+++ b/tests/fortran_runtime/Makefile
@@ -3,7 +3,7 @@ OUTDIR ?= $(shell pwd)
 FC = gfortran
 MPIFC ?= mpifort
 FFLAGS = -O2 -ffree-line-length-none \
-         -ffpe-trap=invalid,zero,overflow,underflow -fbounds-check -finit-real=nan -g -fbacktrace
+         -ffpe-trap=invalid,zero,overflow,underflow -fbounds-check -finit-real=nan -g -fbacktrace -fopenmp
 
 HELPER_DIR = ../../fortran_modules
 MOD_DIR = ../../examples
@@ -18,7 +18,7 @@ PROGRAM_NAMES = run_simple_math.out run_arrays.out run_call_example.out run_cont
            run_intrinsic_func.out run_real_kind.out run_save_vars.out run_store_vars.out \
            run_directives.out run_parameter_var.out run_module_vars.out run_call_module_vars.out run_allocate_vars.out \
            run_exit_cycle.out run_pointer_arrays.out run_derived_alloc.out run_mpi_example.out \
-                   run_stack.out run_where_forall.out
+                   run_stack.out run_where_forall.out run_omp_loops.out
 PROGRAMS = $(addprefix $(OUTDIR)/,$(PROGRAM_NAMES))
 
 .PHONY: all clean
@@ -27,10 +27,10 @@ all: $(PROGRAMS)
 
 
 $(OUTDIR)/run_%.out: $(OUTDIR)/run_%.o
-	$(FC) -o $@ $^
+	$(FC) $(FFLAGS) -o $@ $^
 
 $(OUTDIR)/run_mpi_example.out: $(OUTDIR)/run_mpi_example.o
-	$(MPIFC) -o $@ $^
+	$(MPIFC) $(FFLAGS) -o $@ $^
 
 $(OUTDIR)/run_%.o: run_%.f90
 	$(FC) $(FFLAGS) -c $< -J $(OUTDIR) -o $@
@@ -68,6 +68,8 @@ $(OUTDIR)/run_derived_alloc.o: $(OUTDIR)/derived_alloc.o $(OUTDIR)/derived_alloc
 $(OUTDIR)/run_mpi_example.o: $(OUTDIR)/mpi_example.o $(OUTDIR)/mpi_example_ad.o $(OUTDIR)/mpi_ad.o
 $(OUTDIR)/run_where_forall.o: $(OUTDIR)/where_forall.o $(OUTDIR)/where_forall_ad.o
 
+$(OUTDIR)/run_omp_loops.o: $(OUTDIR)/omp_loops.o $(OUTDIR)/omp_loops_ad.o
+
 $(OUTDIR)/run_fautodiff_stack.o: $(OUTDIR)/fautodiff_stack.o
 
 
@@ -90,6 +92,8 @@ $(OUTDIR)/run_pointer_arrays.out: $(OUTDIR)/run_pointer_arrays.o $(OUTDIR)/point
 $(OUTDIR)/run_derived_alloc.out: $(OUTDIR)/run_derived_alloc.o $(OUTDIR)/derived_alloc.o $(OUTDIR)/derived_alloc_ad.o $(OUTDIR)/fautodiff_stack.o
 $(OUTDIR)/run_mpi_example.out: $(OUTDIR)/run_mpi_example.o $(OUTDIR)/mpi_example.o $(OUTDIR)/mpi_example_ad.o $(OUTDIR)/mpi_ad.o
 $(OUTDIR)/run_where_forall.out: $(OUTDIR)/run_where_forall.o $(OUTDIR)/where_forall.o $(OUTDIR)/where_forall_ad.o
+
+$(OUTDIR)/run_omp_loops.out: $(OUTDIR)/run_omp_loops.o $(OUTDIR)/omp_loops.o $(OUTDIR)/omp_loops_ad.o
 
 $(OUTDIR)/run_fautodiff_stack.out: $(OUTDIR)/run_fautodiff_stack.o $(OUTDIR)/fautodiff_stack.o
 

--- a/tests/fortran_runtime/run_omp_loops.f90
+++ b/tests/fortran_runtime/run_omp_loops.f90
@@ -1,0 +1,108 @@
+program run_omp_loops
+  use omp_loops
+  use omp_loops_ad
+  implicit none
+  real, parameter :: tol = 1.0e-4
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_sum_loop = 1
+  integer, parameter :: I_stencil_loop = 2
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("sum_loop")
+              i_test = I_sum_loop
+           case ("stencil_loop")
+              i_test = I_stencil_loop
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_sum_loop .or. i_test == I_all) then
+     call test_sum_loop
+  end if
+  if (i_test == I_stencil_loop .or. i_test == I_all) then
+     call test_stencil_loop
+  end if
+
+  stop
+contains
+
+  subroutine test_sum_loop
+    integer, parameter :: n = 3
+    real :: x(n), y(n), s
+    real :: x_ad(n), y_ad(n), s_ad
+    real :: y_eps(n), s_eps, fd_y(n), fd_s, eps
+    real :: inner1, inner2
+
+    eps = 1.0e-3
+    x = (/1.0, 2.0, 3.0/)
+    call sum_loop(n, x, y, s)
+    call sum_loop(n, x + eps, y_eps, s_eps)
+    fd_y(:) = (y_eps(:) - y(:)) / eps
+    fd_s = (s_eps - s) / eps
+    x_ad(:) = 1.0
+    call sum_loop_fwd_ad(n, x, x_ad, y, y_ad, s, s_ad)
+    if (any(abs((y_ad(:) - fd_y(:)) / fd_y(:)) > tol) .or. abs((s_ad - fd_s) / fd_s) > tol) then
+       print *, 'test_sum_loop_fwd failed'
+       error stop 1
+    end if
+
+    inner1 = sum(y_ad(:)**2) + s_ad**2
+    call sum_loop_rev_ad(n, x, x_ad, y_ad, s_ad)
+    inner2 = sum(x_ad(:))
+    if (abs((inner2 - inner1) / inner1) > tol) then
+      print *, 'test_sum_loop_rev failed', inner1, inner2
+      error stop 1
+    end if
+
+    return
+  end subroutine test_sum_loop
+
+  subroutine test_stencil_loop
+    real, parameter :: tol_stencil = 2.0e-4
+    integer, parameter :: n = 3
+    real :: x(n), y(n)
+    real :: x_ad(n), y_ad(n)
+    real :: y_eps(n), fd_y(n), eps
+    real :: inner1, inner2
+
+    eps = 1.0e-3
+    x = (/1.0, 2.0, 3.0/)
+    call stencil_loop(n, x, y)
+    call stencil_loop(n, x + eps, y_eps)
+    fd_y(:) = (y_eps(:) - y(:)) / eps
+    x_ad(:) = 1.0
+    call stencil_loop_fwd_ad(n, x, x_ad, y, y_ad)
+    if (any(abs((y_ad(:) - fd_y(:)) / fd_y(:)) > tol_stencil)) then
+       print *, 'test_stencil_loop_fwd failed'
+       error stop 1
+    end if
+
+    inner1 = sum(y_ad(:)**2)
+    call stencil_loop_rev_ad(n, x, x_ad, y_ad)
+    inner2 = sum(x_ad(:))
+    if (abs((inner2 - inner1) / inner1) > tol_stencil) then
+       print *, 'test_stencil_loop_rev failed', inner1, inner2
+       error stop 1
+    end if
+
+    return
+  end subroutine test_stencil_loop
+
+end program run_omp_loops

--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -133,6 +133,10 @@ class TestFortranADCode(unittest.TestCase):
     def test_where_forall(self):
         self._run_test('where_forall', ['where_example', 'forall_example'])
 
+    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
+    def test_omp_loops(self):
+        self._run_test('omp_loops', ['sum_loop', 'stencil_loop'])
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- test OpenMP parallel loops with forward and reverse AD drivers
- enable OpenMP compilation across example and runtime Makefiles

## Testing
- `python tests/test_generator.py`
- `pytest tests/test_fortran_adcode.py::TestFortranADCode::test_omp_loops -q`


------
https://chatgpt.com/codex/tasks/task_b_688dbdac3c64832dac41be5c75ca8f5e