### PR TITLE
Use generic real stack push/pop

### DIFF
--- a/examples/derived_alloc_ad.f90
+++ b/examples/derived_alloc_ad.f90
@@ -115,7 +115,7 @@ contains
     real :: obj_arr_save_43_ad(m,n)
 
     do n0_ad = ubound(obj, 1), lbound(obj, 1), - 1
-      call fautodiff_stack_r4%pop(obj(n0_ad)%arr)
+      call fautodiff_stack_pop_r(obj(n0_ad)%arr)
     end do
     do j = 1, m
       obj_arr_save_43_ad(j,1:n) = obj(j)%arr(1:n)
@@ -148,7 +148,7 @@ contains
     integer :: n0_ad
 
     do n0_ad = lbound(obj, 1), ubound(obj, 1)
-      call fautodiff_stack_r4%push(obj(n0_ad)%arr)
+      call fautodiff_stack_push_r(obj(n0_ad)%arr)
     end do
 
     return

--- a/examples/exit_cycle_ad.f90
+++ b/examples/exit_cycle_ad.f90
@@ -71,7 +71,7 @@ contains
     res = x**2
     exit_do_start_32_ad = n
     do i = 1, n
-      call fautodiff_stack_r4%push(res)
+      call fautodiff_stack_push_r(res)
       res = res * x
       if (i == 2) then
         cycle
@@ -102,7 +102,7 @@ contains
     label_32_0_ad: do i = exit_do_start_32_ad, 1, - 1
       cycle_flag_15_ad = .true.
       cycle_flag_24_ad = .true.
-      call fautodiff_stack_r4%pop(res)
+      call fautodiff_stack_pop_r(res)
       if (cycle_flag_15_ad .and. exit_flag_19_ad .and. cycle_flag_24_ad .and. exit_flag_29_ad) then
         res_save_13_ad = res
         res = res * x
@@ -266,7 +266,7 @@ contains
     do while (i <= n)
       call fautodiff_stack_l%push(.true.)
       call fautodiff_stack_i%push(i)
-      call fautodiff_stack_r4%push(res)
+      call fautodiff_stack_push_r(res)
       res = res * x
       if (i == 2) then
         i = i + 1
@@ -298,7 +298,7 @@ contains
     label_69_0_ad: do while (fautodiff_stack_l%get())
       cycle_flag_50_ad = .true.
       cycle_flag_60_ad = .true.
-      call fautodiff_stack_r4%pop(res)
+      call fautodiff_stack_pop_r(res)
       call fautodiff_stack_i%pop(i)
       if (cycle_flag_50_ad .and. exit_flag_54_ad .and. cycle_flag_60_ad .and. exit_flag_65_ad) then
         res_save_47_ad = res
@@ -469,7 +469,7 @@ contains
     call fautodiff_stack_l%push(.false.)
     outer: do while (i <= n)
       call fautodiff_stack_l%push(.true.)
-      call fautodiff_stack_r4%push(res)
+      call fautodiff_stack_push_r(res)
       i = i + 1
       res = res + 1.0
       middle: do j = 1, n
@@ -505,12 +505,12 @@ contains
     exit_flag_94_ad = .true.
     label_112_0_ad: do while (fautodiff_stack_l%get())
       cycle_flag_106_ad = .true.
-      call fautodiff_stack_r4%pop(res)
+      call fautodiff_stack_pop_r(res)
       if (exit_flag_90_ad .and. exit_flag_94_ad .and. cycle_flag_106_ad) then
         res = res + 1.0
         exit_do_start_110_ad = n
         label_110_1_ad: do j = 1, n
-          call fautodiff_stack_r4%push(res)
+          call fautodiff_stack_push_r(res)
           res = res + 10.0
           if (res > 5000.0) then
             exit_do_start_110_ad = j
@@ -551,7 +551,7 @@ contains
       label_110_0_ad: do j = exit_do_start_110_ad, 1, - 1
         cycle_flag_102_ad = .true.
         cycle_flag_106_ad = .true.
-        call fautodiff_stack_r4%pop(res)
+        call fautodiff_stack_pop_r(res)
         if (exit_flag_90_ad .and. exit_flag_94_ad .and. exit_flag_98_ad .and. cycle_flag_102_ad .and. cycle_flag_106_ad) then
           res = res + 10.0
           if (res > 5000.0) then
@@ -562,7 +562,7 @@ contains
           res_save_109_ad = res
           exit_do_start_109_ad = n
           label_109_1_ad: do k = 1, n
-            call fautodiff_stack_r4%push(res)
+            call fautodiff_stack_push_r(res)
             if (res > 4000.0) then
               exit_do_start_109_ad = k
               exit_flag_94_ad = .false.
@@ -593,7 +593,7 @@ contains
           label_109_0_ad: do k = exit_do_start_109_ad, 1, - 1
             cycle_flag_102_ad = .true.
             cycle_flag_106_ad = .true.
-            call fautodiff_stack_r4%pop(res)
+            call fautodiff_stack_pop_r(res)
             if (exit_flag_94_ad .and. exit_flag_98_ad .and. cycle_flag_102_ad .and. cycle_flag_106_ad) then
               if (res > 4000.0) then
                 exit_flag_94_ad = .false.

--- a/examples/module_vars_ad.f90
+++ b/examples/module_vars_ad.f90
@@ -30,7 +30,7 @@ contains
     real :: y
     real :: a_save_13_ad
 
-    call fautodiff_stack_r4%pop(a)
+    call fautodiff_stack_pop_r(a)
     y = (c + x) * a
     a_save_13_ad = a
     a = a + x
@@ -48,7 +48,7 @@ contains
 
   subroutine inc_and_use_fwd_rev_ad()
 
-    call fautodiff_stack_r4%push(a)
+    call fautodiff_stack_push_r(a)
 
     return
   end subroutine inc_and_use_fwd_rev_ad

--- a/examples/store_vars_ad.f90
+++ b/examples/store_vars_ad.f90
@@ -47,14 +47,14 @@ contains
     work = x(1) * work
     work_save_18_ad = work
     do i = 1, n
-      call fautodiff_stack_r4%push(work)
+      call fautodiff_stack_push_r(work)
       work = x(i) * work
     end do
 
     work_ad = 0.0
 
     do i = n, 1, - 1
-      call fautodiff_stack_r4%pop(work)
+      call fautodiff_stack_pop_r(work)
       work_save_16_ad = work
       work = x(i) * work
       work_ad = z_ad(i) * 2.0 * work + work_ad ! z(i) = work**2 + z(i)
@@ -121,8 +121,8 @@ contains
     y_save_37_ad = y
     do while (y < 10.0)
       call fautodiff_stack_l%push(.true.)
-      call fautodiff_stack_r4%push(z)
-      call fautodiff_stack_r4%push(a)
+      call fautodiff_stack_push_r(z)
+      call fautodiff_stack_push_r(a)
       a = a + x
       y = y + a
       a = a + 1.0
@@ -135,8 +135,8 @@ contains
     z_ad = y_ad * y + z_ad ! y = z * y
     y_ad = y_ad * z ! y = z * y
     do while (fautodiff_stack_l%get())
-      call fautodiff_stack_r4%pop(a)
-      call fautodiff_stack_r4%pop(z)
+      call fautodiff_stack_pop_r(a)
+      call fautodiff_stack_pop_r(z)
       a = a + x
       a = a + 1.0
       a_ad = z_ad * z + a_ad ! z = z * a

--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -2393,11 +2393,14 @@ class PushPop(SaveAssignment):
 
     def render(self, indent: int = 0) -> List[str]:
         space = "  " * indent
-        op = "pop" if self.load else "push"
         stack = self._stack_name()
         var = self.var
         if self.pointer:
             var = var.change_index(None)
+        if stack == "fautodiff_stack_r":
+            op = "fautodiff_stack_pop_r" if self.load else "fautodiff_stack_push_r"
+            return [f"{space}call {op}({var})\n"]
+        op = "pop" if self.load else "push"
         return [f"{space}call {stack}%{op}({var})\n"]
 
     def _stack_name(self) -> str:
@@ -2420,10 +2423,8 @@ class PushPop(SaveAssignment):
         if typ.startswith("integer"):
             return "fautodiff_stack_i"
         if typ.startswith("real") or typ.startswith("double"):
-            if kind == "8" or "(8" in typ or "double" in typ:
-                return "fautodiff_stack_r8"
-            return "fautodiff_stack_r4"
-        return "fautodiff_stack_r4"
+            return "fautodiff_stack_r"
+        return "fautodiff_stack_r"
 
     def to_load(self) -> "PushPop":
         return PushPop(self.var, id=self.id, tmpvar=self.tmpvar, pointer=self.pointer, load=True)

--- a/fortran_modules/fautodiff_stack.f90
+++ b/fortran_modules/fautodiff_stack.f90
@@ -13,6 +13,8 @@ module fautodiff_stack
   public :: fautodiff_stack_i
   public :: fautodiff_stack_l
   public :: fautodiff_stack_p
+  public :: fautodiff_stack_push_r
+  public :: fautodiff_stack_pop_r
 
   integer, parameter :: DEFAULT_PAGE_SIZE = 1024 * 1024
   integer, parameter :: MAX_PAGE_NUM_LARGE = 1024 * 1024
@@ -141,6 +143,13 @@ module fautodiff_stack
   type(fautodiff_stack_i_t), save :: fautodiff_stack_i
   type(fautodiff_stack_l_t), save :: fautodiff_stack_l
   type(fautodiff_stack_p_t), save :: fautodiff_stack_p
+
+  interface fautodiff_stack_push_r
+    module procedure fautodiff_stack_push_r4, fautodiff_stack_push_r8
+  end interface
+  interface fautodiff_stack_pop_r
+    module procedure fautodiff_stack_pop_r4, fautodiff_stack_pop_r8
+  end interface
 
 contains
 
@@ -1344,5 +1353,73 @@ contains
     call c_f_pointer(self%ary(self%pos), data, [self%dims(1, self%pos), self%dims(2, self%pos), self%dims(3, self%pos)])
     return
   end subroutine pop_p_r8_3d
+
+  subroutine fautodiff_stack_push_r4(data)
+    real, intent(in) :: data(..)
+    select rank(data)
+    rank(0)
+      call fautodiff_stack_r4%push(data)
+    rank(1)
+      call fautodiff_stack_r4%push(data)
+    rank(2)
+      call fautodiff_stack_r4%push(data)
+    rank(3)
+      call fautodiff_stack_r4%push(data)
+    rank default
+      print *, 'Rank larger than 3 is not supported'
+      error stop 1
+    end select
+  end subroutine fautodiff_stack_push_r4
+
+  subroutine fautodiff_stack_pop_r4(data)
+    real, intent(out) :: data(..)
+    select rank(data)
+    rank(0)
+      call fautodiff_stack_r4%pop(data)
+    rank(1)
+      call fautodiff_stack_r4%pop(data)
+    rank(2)
+      call fautodiff_stack_r4%pop(data)
+    rank(3)
+      call fautodiff_stack_r4%pop(data)
+    rank default
+      print *, 'Rank larger than 3 is not supported'
+      error stop 1
+    end select
+  end subroutine fautodiff_stack_pop_r4
+
+  subroutine fautodiff_stack_push_r8(data)
+    real(8), intent(in) :: data(..)
+    select rank(data)
+    rank(0)
+      call fautodiff_stack_r8%push(data)
+    rank(1)
+      call fautodiff_stack_r8%push(data)
+    rank(2)
+      call fautodiff_stack_r8%push(data)
+    rank(3)
+      call fautodiff_stack_r8%push(data)
+    rank default
+      print *, 'Rank larger than 3 is not supported'
+      error stop 1
+    end select
+  end subroutine fautodiff_stack_push_r8
+
+  subroutine fautodiff_stack_pop_r8(data)
+    real(8), intent(out) :: data(..)
+    select rank(data)
+    rank(0)
+      call fautodiff_stack_r8%pop(data)
+    rank(1)
+      call fautodiff_stack_r8%pop(data)
+    rank(2)
+      call fautodiff_stack_r8%pop(data)
+    rank(3)
+      call fautodiff_stack_r8%pop(data)
+    rank default
+      print *, 'Rank larger than 3 is not supported'
+      error stop 1
+    end select
+  end subroutine fautodiff_stack_pop_r8
 
 end module fautodiff_stack

--- a/tests/fortran_runtime/run_fautodiff_stack.f90
+++ b/tests/fortran_runtime/run_fautodiff_stack.f90
@@ -9,15 +9,15 @@ program run_data_storage
 
   arr = (/10.0, 20.0, 30.0/)
 
-  call fautodiff_stack_r4%push(1.0)
-  call fautodiff_stack_r4%push(2.0)
-  call fautodiff_stack_r4%push(3.0)
-  call fautodiff_stack_r4%push(arr)
+  call fautodiff_stack_push_r(1.0)
+  call fautodiff_stack_push_r(2.0)
+  call fautodiff_stack_push_r(3.0)
+  call fautodiff_stack_push_r(arr)
 
-  call fautodiff_stack_r4%pop(out)
-  call fautodiff_stack_r4%pop(x3)
-  call fautodiff_stack_r4%pop(x2)
-  call fautodiff_stack_r4%pop(x1)
+  call fautodiff_stack_pop_r(out)
+  call fautodiff_stack_pop_r(x3)
+  call fautodiff_stack_pop_r(x2)
+  call fautodiff_stack_pop_r(x1)
 
   ok = .true.
   ok = ok .and. abs(x1 - 1.0) < 1.0e-6

--- a/tests/test_code_tree.py
+++ b/tests/test_code_tree.py
@@ -583,13 +583,13 @@ class TestPushPop(unittest.TestCase):
     def test_push(self):
         var = OpVar("a")
         node = PushPop(var, 100)
-        self.assertEqual(render_program(Block([node])), "call fautodiff_stack_r4%push(a)\n")
+        self.assertEqual(render_program(Block([node])), "call fautodiff_stack_push_r(a)\n")
         self.assertEqual({str(v) for v in node.iter_ref_vars()}, {"a"})
 
     def test_pop(self):
         var = OpVar("a")
         node = PushPop(var, 100).to_load()
-        self.assertEqual(render_program(Block([node])), "call fautodiff_stack_r4%pop(a)\n")
+        self.assertEqual(render_program(Block([node])), "call fautodiff_stack_pop_r(a)\n")
         self.assertEqual({str(v) for v in node.iter_assign_vars()}, {"a"})
 
 


### PR DESCRIPTION
## Summary
- add generic `fautodiff_stack_push_r`/`fautodiff_stack_pop_r` wrappers
- route real variable saves/loads through the new generic stack helpers
- adjust tests and example AD outputs for generic stack usage

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_688dc2d30ce8832d9760c6d795cc78fc