### PR TITLE
Handle use of modules defined later in parser

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -509,6 +509,35 @@ class TestParser(unittest.TestCase):
         var_a = routine.get_var("a")
         self.assertEqual(var_a.declared_in, "use")
 
+    def test_use_module_defined_later(self):
+        src = textwrap.dedent(
+            """
+            module modb
+              use moda
+              implicit none
+            contains
+              subroutine foo(x)
+                integer, intent(out) :: x
+                x = K
+              end subroutine foo
+            end module modb
+
+            module moda
+              implicit none
+              integer, parameter :: K = 3
+            contains
+              subroutine dummy()
+              end subroutine dummy
+            end module moda
+            """
+        )
+        modules = parser.parse_src(src)
+        routine = modules[0].routines[0]
+        self.assertTrue(routine.is_declared("K"))
+        decl = routine.decl_map.get("K")
+        self.assertIsNotNone(decl)
+        self.assertTrue(decl.parameter)
+
     def test_parse_pointer_decl(self):
         src = textwrap.dedent(
             """


### PR DESCRIPTION
## Summary
- parse Fortran modules on demand so `use`d variables from later modules are recognized
- add regression test for using variables from modules defined later

## Testing
- `pytest tests/test_parser.py::TestParser::test_use_module_defined_later -q`
- `pytest tests/test_parser.py -q`
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_688ddd031508832daa2c33d17a475a05