### PR TITLE
Ensure current directory is included in search paths

### DIFF
--- a/fautodiff/cli.py
+++ b/fautodiff/cli.py
@@ -24,7 +24,7 @@ def main():
         dest="search_dirs",
         action="append",
         default=[],
-        help="add directory to .fadmod search path (may be repeated)",
+        help="add directory to .fadmod search path before the current directory (may be repeated)",
     )
     parser_arg.add_argument(
         "-M",
@@ -45,12 +45,16 @@ def main():
     )
     args = parser_arg.parse_args()
 
+    search_dirs = args.search_dirs if args.search_dirs else []
+    if "." not in search_dirs:
+        search_dirs.append(".")
+
     try:
         code = generator.generate_ad(
             args.input,
             args.output,
             warn=not args.no_warn,
-            search_dirs=args.search_dirs,
+            search_dirs=search_dirs,
             write_fadmod=not args.no_fadmod,
             fadmod_dir=args.fadmod_dir,
             mode=args.mode,

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -1332,15 +1332,16 @@ def generate_ad(
     ``fadmod_dir`` selects where ``<module>.fadmod`` files are written (defaults
     to the current working directory).
     """
-    modules_org = parser.parse_file(in_file, search_dirs=search_dirs)
     modules = []
     warnings = []
 
     if search_dirs is None:
         search_dirs = []
     cwd = "."
-    if not cwd in search_dirs:
+    if cwd not in search_dirs:
         search_dirs.append(cwd)
+
+    modules_org = parser.parse_file(in_file, search_dirs=search_dirs)
     if fadmod_dir is None:
         fadmod_dir = Path.cwd()
     else:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -40,7 +40,6 @@ class TestGenerator(unittest.TestCase):
         generated = generator.generate_ad(
             "examples/cross_mod_b.f90",
             warn=False,
-            search_dirs=["."],
         )
         expected = Path("examples/cross_mod_b_ad.f90").read_text()
         self.assertEqual(generated, expected)
@@ -51,7 +50,6 @@ class TestGenerator(unittest.TestCase):
         generated = generator.generate_ad(
             "examples/call_module_vars.f90",
             warn=False,
-            search_dirs=["."],
         )
         expected = Path("examples/call_module_vars_ad.f90").read_text()
         self.assertEqual(generated, expected)


### PR DESCRIPTION
## Summary
- default search_dirs now include '.' so modules in current directory are found
- CLI appends current directory after any -I paths to maintain priority
- tests adjusted for new default behavior

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_688de144e99c832da654996460c95ac0