### PR TITLE
Include function result intents in fadmod

### DIFF
--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -474,6 +474,8 @@ class Node:
             intents = ufunc.intents
             if intents is None and ufunc.name in routine_map:
                 intents = routine_map[ufunc.name]["intents"]
+                if len(intents) > len(ufunc.args):
+                    intents = intents[:-1]
             # Recursively generate AD code for the function call
             callstmt = CallStatement(
                 name=ufunc.name,

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -651,9 +651,6 @@ def _prepare_fwd_ad_header(routine_org, has_mod_grad_var):
             if intent in ("out", "inout"):
                 out_grad_args.append(var)
 
-    if routine_org.result is not None:
-        arg_info["intents"] = arg_info["intents"][:-1]
-
     ad_name = f"{routine_org.name}{FWD_SUFFIX}"
     subroutine = Subroutine(ad_name, [v.name for v in args])
     arg_info["name_fwd_ad"] = ad_name
@@ -782,8 +779,6 @@ def _prepare_rev_ad_header(routine_org, has_mod_grad_var):
                 if grad_intent == "inout":
                     in_grad_args.append(var)
                     has_grad_input = True
-    if routine_org.result is not None:
-        arg_info["intents"] = arg_info["intents"][:-1]
 
     ad_name = f"{routine_org.name}{REV_SUFFIX}"
     subroutine = Subroutine(ad_name, [v.name for v in args])

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -55,6 +55,18 @@ class TestGenerator(unittest.TestCase):
                 warn=False,
             )
 
+    def test_fadmod_function_intents_length(self):
+        code_tree.Node.reset()
+        fadmod = Path("simple_math.fadmod")
+        if fadmod.exists():
+            fadmod.unlink()
+        generator.generate_ad("examples/simple_math.f90", warn=False)
+        routines, _, _ = generator._load_fadmods(["simple_math"], ["."])
+        info = routines.get("add_numbers")
+        self.assertIsNotNone(info)
+        self.assertEqual(len(info["args"]), len(info["intents"]))
+        self.assertEqual(info["intents"][-1], "out")
+
     def test_call_module_vars(self):
         code_tree.Node.reset()
         generator.generate_ad("examples/module_vars.f90", warn=False)


### PR DESCRIPTION
## Summary
- keep function return intents in fadmod metadata
- adjust call handling to drop the result intent only when creating call statements
- test fadmod generation for functions

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_688e2ec051f0832d8c060741bc467bae