### PR TITLE
Add support for main program files

### DIFF
--- a/examples/main_program.f90
+++ b/examples/main_program.f90
@@ -1,0 +1,20 @@
+program main_program
+  implicit none
+  real :: x, y, z
+
+  x = 1.0
+  y = 2.0
+  call simple(x, y, z)
+  print *, "z =", z
+
+contains
+
+  subroutine simple(a, b, c)
+    real, intent(in) :: a, b
+    real, intent(out) :: c
+
+    c = a + b
+
+    return
+  end subroutine simple
+end program main_program

--- a/examples/main_program_ad.f90
+++ b/examples/main_program_ad.f90
@@ -1,0 +1,38 @@
+program main_program_ad
+  implicit none
+
+  real :: x_ad = 0.0
+  real :: y_ad = 0.0
+  real :: z_ad = 0.0
+
+contains
+
+  subroutine simple_fwd_ad(a, a_ad, b, b_ad, c, c_ad)
+    real, intent(in)  :: a
+    real, intent(in)  :: a_ad
+    real, intent(in)  :: b
+    real, intent(in)  :: b_ad
+    real, intent(out) :: c
+    real, intent(out) :: c_ad
+
+    c_ad = a_ad + b_ad ! c = a + b
+    c = a + b
+
+    return
+  end subroutine simple_fwd_ad
+
+  subroutine simple_rev_ad(a, a_ad, b, b_ad, c_ad)
+    real, intent(in)  :: a
+    real, intent(out) :: a_ad
+    real, intent(in)  :: b
+    real, intent(out) :: b_ad
+    real, intent(inout) :: c_ad
+
+    a_ad = c_ad ! c = a + b
+    b_ad = c_ad ! c = a + b
+    c_ad = 0.0 ! c = a + b
+
+    return
+  end subroutine simple_rev_ad
+
+end program main_program_ad

--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -1501,6 +1501,32 @@ class Module(Node):
                     mods.append(child.name)
         return mods
 
+
+@dataclass
+class Program(Module):
+    """Representation of a Fortran main program."""
+
+    def render(self, indent: int = 0) -> List[str]:
+        space = "  " * indent
+        lines = [f"{space}program {self.name}\n"]
+        if self.uses is not None:
+            lines.extend(self.uses.render(indent + 1))
+        lines.extend(f"{space}  implicit none\n")
+        if self.decls is not None:
+            lines.append("\n")
+            lines.extend(self.decls.render(indent + 1))
+        if self.body is not None:
+            lines.append("\n")
+            lines.extend(self.body.render(indent + 1))
+        lines.append("\n")
+        lines.append(f"{space}contains\n")
+        lines.append("\n")
+        for routine in self.routines:
+            lines.extend(routine.render(indent + 1))
+            lines.append("\n")
+        lines.append(f"{space}end program {self.name}\n")
+        return lines
+
 @dataclass
 class Routine(Node):
     """Common functionality for ``subroutine`` and ``function`` blocks."""

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -16,6 +16,7 @@ from . import code_tree as code_tree
 from .code_tree import (
     Node,
     Module,
+    Program,
     Routine,
     Subroutine,
     Function,
@@ -1357,8 +1358,14 @@ def generate_ad(
     generic_routines = {}
     for mod_org in modules_org:
         name = mod_org.name
-        mod = Module(f"{name}{AD_SUFFIX}")
-        mod.uses = Block([Use(name)])
+        mod = type(mod_org)(f"{name}{AD_SUFFIX}")
+        if isinstance(mod_org, Program):
+            if mod_org.uses is not None:
+                mod.uses = mod_org.uses.deep_clone()
+            else:
+                mod.uses = Block([])
+        else:
+            mod.uses = Block([Use(name)])
 
         if mod_org.decls:
             type_map = {}


### PR DESCRIPTION
## Summary
- add `Program` node so AD generator can emit and render Fortran main programs
- extend parser to handle `program` units and return `Program` nodes
- update generator to create AD versions of main programs and include example
- expand main program example with variable declarations, assignments, subroutine call, and print statement
- factor out shared logic for parsing specification and subprogram sections across modules and programs

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_688e2cc30b4c832d987f879ca93bf366