### PR TITLE
Use rank-specific stack procedures in real push/pop wrappers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,12 @@ This file provides guidelines for contributors about the repository and develop 
   ``fautodiff_stack_push``.
 - For AD wrappers of external modules such as MPI, use ``<module>_ad.f90`` as the
   file name and name the module ``<module>_ad``.
+- The files ``fautodiff_stack.f90`` and ``mpi.fadmod`` are generated. Update
+  their respective generator scripts (``gen_fautodiff_stack.py`` and
+  ``gen_mpi_fadmod.py``) and regenerate the sources instead of editing the
+  generated files directly. In general, if a file has a corresponding
+  ``gen_*.py`` script, modify the generator and re-run it rather than editing
+  the generated output.
 
 ## 10. Runtime Verification in `tests/fortran_runtime`
 The programs under `tests/fortran_runtime` check that the generated AD code

--- a/fortran_modules/fautodiff_stack.f90
+++ b/fortran_modules/fautodiff_stack.f90
@@ -1355,16 +1355,16 @@ contains
   end subroutine pop_p_r8_3d
 
   subroutine fautodiff_stack_push_r4(data)
-    real, intent(in) :: data(..)
+    real, intent(in), target :: data(..)
     select rank(data)
     rank(0)
-      call fautodiff_stack_r4%push(data)
+      call fautodiff_stack_r4%push_r4_0d(data)
     rank(1)
-      call fautodiff_stack_r4%push(data)
+      call fautodiff_stack_r4%push_r4_1d(data)
     rank(2)
-      call fautodiff_stack_r4%push(data)
+      call fautodiff_stack_r4%push_r4_2d(data)
     rank(3)
-      call fautodiff_stack_r4%push(data)
+      call fautodiff_stack_r4%push_r4_3d(data)
     rank default
       print *, 'Rank larger than 3 is not supported'
       error stop 1
@@ -1372,16 +1372,16 @@ contains
   end subroutine fautodiff_stack_push_r4
 
   subroutine fautodiff_stack_pop_r4(data)
-    real, intent(out) :: data(..)
+    real, intent(out), target :: data(..)
     select rank(data)
     rank(0)
-      call fautodiff_stack_r4%pop(data)
+      call fautodiff_stack_r4%pop_r4_0d(data)
     rank(1)
-      call fautodiff_stack_r4%pop(data)
+      call fautodiff_stack_r4%pop_r4_1d(data)
     rank(2)
-      call fautodiff_stack_r4%pop(data)
+      call fautodiff_stack_r4%pop_r4_2d(data)
     rank(3)
-      call fautodiff_stack_r4%pop(data)
+      call fautodiff_stack_r4%pop_r4_3d(data)
     rank default
       print *, 'Rank larger than 3 is not supported'
       error stop 1
@@ -1389,16 +1389,16 @@ contains
   end subroutine fautodiff_stack_pop_r4
 
   subroutine fautodiff_stack_push_r8(data)
-    real(8), intent(in) :: data(..)
+    real(8), intent(in), target :: data(..)
     select rank(data)
     rank(0)
-      call fautodiff_stack_r8%push(data)
+      call fautodiff_stack_r8%push_r8_0d(data)
     rank(1)
-      call fautodiff_stack_r8%push(data)
+      call fautodiff_stack_r8%push_r8_1d(data)
     rank(2)
-      call fautodiff_stack_r8%push(data)
+      call fautodiff_stack_r8%push_r8_2d(data)
     rank(3)
-      call fautodiff_stack_r8%push(data)
+      call fautodiff_stack_r8%push_r8_3d(data)
     rank default
       print *, 'Rank larger than 3 is not supported'
       error stop 1
@@ -1406,16 +1406,16 @@ contains
   end subroutine fautodiff_stack_push_r8
 
   subroutine fautodiff_stack_pop_r8(data)
-    real(8), intent(out) :: data(..)
+    real(8), intent(out), target :: data(..)
     select rank(data)
     rank(0)
-      call fautodiff_stack_r8%pop(data)
+      call fautodiff_stack_r8%pop_r8_0d(data)
     rank(1)
-      call fautodiff_stack_r8%pop(data)
+      call fautodiff_stack_r8%pop_r8_1d(data)
     rank(2)
-      call fautodiff_stack_r8%pop(data)
+      call fautodiff_stack_r8%pop_r8_2d(data)
     rank(3)
-      call fautodiff_stack_r8%pop(data)
+      call fautodiff_stack_r8%pop_r8_3d(data)
     rank default
       print *, 'Rank larger than 3 is not supported'
       error stop 1

--- a/fortran_modules/gen_fautodiff_stack.py
+++ b/fortran_modules/gen_fautodiff_stack.py
@@ -209,45 +209,47 @@ def gen_get_function(tname):
 
 def gen_wrapper_push(tname):
     ftype = tmap[tname]
-    return (
-        f"  subroutine fautodiff_stack_push_{tname}(data)\n"
-        f"    {ftype}, intent(in) :: data(..)\n"
-        f"    select rank(data)\n"
-        f"    rank(0)\n"
-        f"      call fautodiff_stack_{tname}%push(data)\n"
-        f"    rank(1)\n"
-        f"      call fautodiff_stack_{tname}%push(data)\n"
-        f"    rank(2)\n"
-        f"      call fautodiff_stack_{tname}%push(data)\n"
-        f"    rank(3)\n"
-        f"      call fautodiff_stack_{tname}%push(data)\n"
-        f"    rank default\n"
-        f"      print *, 'Rank larger than 3 is not supported'\n"
-        f"      error stop 1\n"
-        f"    end select\n"
-        f"  end subroutine fautodiff_stack_push_{tname}\n"
+    lines = [
+        f"  subroutine fautodiff_stack_push_{tname}(data)",
+        f"    {ftype}, intent(in), target :: data(..)",
+        f"    select rank(data)",
+    ]
+    for r in ranks:
+        lines.append(f"    rank({r})")
+        lines.append(f"      call fautodiff_stack_{tname}%push_{tname}_{r}d(data)")
+    lines.extend(
+        [
+            "    rank default",
+            "      print *, 'Rank larger than 3 is not supported'",
+            "      error stop 1",
+            "    end select",
+            f"  end subroutine fautodiff_stack_push_{tname}",
+            "",
+        ]
     )
+    return "\n".join(lines)
 
 def gen_wrapper_pop(tname):
     ftype = tmap[tname]
-    return (
-        f"  subroutine fautodiff_stack_pop_{tname}(data)\n"
-        f"    {ftype}, intent(out) :: data(..)\n"
-        f"    select rank(data)\n"
-        f"    rank(0)\n"
-        f"      call fautodiff_stack_{tname}%pop(data)\n"
-        f"    rank(1)\n"
-        f"      call fautodiff_stack_{tname}%pop(data)\n"
-        f"    rank(2)\n"
-        f"      call fautodiff_stack_{tname}%pop(data)\n"
-        f"    rank(3)\n"
-        f"      call fautodiff_stack_{tname}%pop(data)\n"
-        f"    rank default\n"
-        f"      print *, 'Rank larger than 3 is not supported'\n"
-        f"      error stop 1\n"
-        f"    end select\n"
-        f"  end subroutine fautodiff_stack_pop_{tname}\n"
+    lines = [
+        f"  subroutine fautodiff_stack_pop_{tname}(data)",
+        f"    {ftype}, intent(out), target :: data(..)",
+        f"    select rank(data)",
+    ]
+    for r in ranks:
+        lines.append(f"    rank({r})")
+        lines.append(f"      call fautodiff_stack_{tname}%pop_{tname}_{r}d(data)")
+    lines.extend(
+        [
+            "    rank default",
+            "      print *, 'Rank larger than 3 is not supported'",
+            "      error stop 1",
+            "    end select",
+            f"  end subroutine fautodiff_stack_pop_{tname}",
+            "",
+        ]
     )
+    return "\n".join(lines)
 
 def gen_module():
     lines = [


### PR DESCRIPTION
## Summary
- Generate real*4 and real*8 stack wrappers that dispatch to rank-specific push/pop routines
- Document that generated Fortran sources (e.g., fautodiff_stack.f90 and mpi.fadmod) must be updated via their gen_* scripts

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_68900be7a484832dac145ef744209a6b