### PR TITLE
Fix array pop across pages

### DIFF
--- a/fortran_modules/fautodiff_stack.f90
+++ b/fortran_modules/fautodiff_stack.f90
@@ -243,12 +243,12 @@ contains
     i1 = len
     do while (len > 0)
       if (self%pos == 1) then
-        self%pos = self%page_size
         self%page_num = self%page_num - 1
         if (self%page_num < 1) then
           print *, 'No stacked data'
           error stop 1
         end if
+        self%pos = self%page_size + 1
       end if
       i0 = i1 - min(len, self%pos - 1) + 1
       j0 = self%pos - int(i1 - i0) - 1
@@ -312,12 +312,12 @@ contains
     i1 = len
     do while (len > 0)
       if (self%pos == 1) then
-        self%pos = self%page_size
         self%page_num = self%page_num - 1
         if (self%page_num < 1) then
           print *, 'No stacked data'
           error stop 1
         end if
+        self%pos = self%page_size + 1
       end if
       i0 = i1 - min(len, self%pos - 1) + 1
       j0 = self%pos - int(i1 - i0) - 1
@@ -381,12 +381,12 @@ contains
     i1 = len
     do while (len > 0)
       if (self%pos == 1) then
-        self%pos = self%page_size
         self%page_num = self%page_num - 1
         if (self%page_num < 1) then
           print *, 'No stacked data'
           error stop 1
         end if
+        self%pos = self%page_size + 1
       end if
       i0 = i1 - min(len, self%pos - 1) + 1
       j0 = self%pos - int(i1 - i0) - 1
@@ -490,12 +490,12 @@ contains
     i1 = len
     do while (len > 0)
       if (self%pos == 1) then
-        self%pos = self%page_size
         self%page_num = self%page_num - 1
         if (self%page_num < 1) then
           print *, 'No stacked data'
           error stop 1
         end if
+        self%pos = self%page_size + 1
       end if
       i0 = i1 - min(len, self%pos - 1) + 1
       j0 = self%pos - int(i1 - i0) - 1
@@ -559,12 +559,12 @@ contains
     i1 = len
     do while (len > 0)
       if (self%pos == 1) then
-        self%pos = self%page_size
         self%page_num = self%page_num - 1
         if (self%page_num < 1) then
           print *, 'No stacked data'
           error stop 1
         end if
+        self%pos = self%page_size + 1
       end if
       i0 = i1 - min(len, self%pos - 1) + 1
       j0 = self%pos - int(i1 - i0) - 1
@@ -628,12 +628,12 @@ contains
     i1 = len
     do while (len > 0)
       if (self%pos == 1) then
-        self%pos = self%page_size
         self%page_num = self%page_num - 1
         if (self%page_num < 1) then
           print *, 'No stacked data'
           error stop 1
         end if
+        self%pos = self%page_size + 1
       end if
       i0 = i1 - min(len, self%pos - 1) + 1
       j0 = self%pos - int(i1 - i0) - 1
@@ -737,12 +737,12 @@ contains
     i1 = len
     do while (len > 0)
       if (self%pos == 1) then
-        self%pos = self%page_size
         self%page_num = self%page_num - 1
         if (self%page_num < 1) then
           print *, 'No stacked data'
           error stop 1
         end if
+        self%pos = self%page_size + 1
       end if
       i0 = i1 - min(len, self%pos - 1) + 1
       j0 = self%pos - int(i1 - i0) - 1
@@ -806,12 +806,12 @@ contains
     i1 = len
     do while (len > 0)
       if (self%pos == 1) then
-        self%pos = self%page_size
         self%page_num = self%page_num - 1
         if (self%page_num < 1) then
           print *, 'No stacked data'
           error stop 1
         end if
+        self%pos = self%page_size + 1
       end if
       i0 = i1 - min(len, self%pos - 1) + 1
       j0 = self%pos - int(i1 - i0) - 1
@@ -875,12 +875,12 @@ contains
     i1 = len
     do while (len > 0)
       if (self%pos == 1) then
-        self%pos = self%page_size
         self%page_num = self%page_num - 1
         if (self%page_num < 1) then
           print *, 'No stacked data'
           error stop 1
         end if
+        self%pos = self%page_size + 1
       end if
       i0 = i1 - min(len, self%pos - 1) + 1
       j0 = self%pos - int(i1 - i0) - 1
@@ -984,12 +984,12 @@ contains
     i1 = len
     do while (len > 0)
       if (self%pos == 1) then
-        self%pos = self%page_size
         self%page_num = self%page_num - 1
         if (self%page_num < 1) then
           print *, 'No stacked data'
           error stop 1
         end if
+        self%pos = self%page_size + 1
       end if
       i0 = i1 - min(len, self%pos - 1) + 1
       j0 = self%pos - int(i1 - i0) - 1
@@ -1053,12 +1053,12 @@ contains
     i1 = len
     do while (len > 0)
       if (self%pos == 1) then
-        self%pos = self%page_size
         self%page_num = self%page_num - 1
         if (self%page_num < 1) then
           print *, 'No stacked data'
           error stop 1
         end if
+        self%pos = self%page_size + 1
       end if
       i0 = i1 - min(len, self%pos - 1) + 1
       j0 = self%pos - int(i1 - i0) - 1
@@ -1122,12 +1122,12 @@ contains
     i1 = len
     do while (len > 0)
       if (self%pos == 1) then
-        self%pos = self%page_size
         self%page_num = self%page_num - 1
         if (self%page_num < 1) then
           print *, 'No stacked data'
           error stop 1
         end if
+        self%pos = self%page_size + 1
       end if
       i0 = i1 - min(len, self%pos - 1) + 1
       j0 = self%pos - int(i1 - i0) - 1

--- a/fortran_modules/gen_fautodiff_stack.py
+++ b/fortran_modules/gen_fautodiff_stack.py
@@ -94,12 +94,12 @@ TEMPLATE_POP_ARRAY = '''
     i1 = len
     do while (len > 0)
       if (self%pos == 1) then
-        self%pos = self%page_size
         self%page_num = self%page_num - 1
         if (self%page_num < 1) then
           print *, 'No stacked data'
           error stop 1
         end if
+        self%pos = self%page_size + 1
       end if
       i0 = i1 - min(len, self%pos - 1) + 1
       j0 = self%pos - int(i1 - i0) - 1

--- a/tests/fortran_runtime/run_fautodiff_stack.f90
+++ b/tests/fortran_runtime/run_fautodiff_stack.f90
@@ -3,7 +3,7 @@ program run_data_storage
   implicit none
 
   integer, parameter :: n = 6
-  real :: val
+  real :: popped(2)
   real :: vals(n)
   integer :: i
   logical :: ok
@@ -24,9 +24,9 @@ program run_data_storage
   call fautodiff_stack_push_r(vals)
 
   ok = .true.
-  do i = 2 * n, 1, -1
-     call fautodiff_stack_pop_r(val)
-     ok = ok .and. abs(val - real(i)) < 1.0e-6
+  do i = 2 * n, 2, -2
+     call fautodiff_stack_pop_r(popped)
+     ok = ok .and. all(abs(popped - real([i - 1, i])) < 1.0e-6)
   end do
 
   if (ok) then


### PR DESCRIPTION
## Summary
- Test popping arrays from stack as two-element blocks
- Handle page boundary when popping arrays in stack implementation

## Testing
- `python tests/test_generator.py`
- `python tests/test_fortran_runtime.py`


------
https://chatgpt.com/codex/tasks/task_b_68901dceb558832d8bccd388290d1da6