### PR TITLE
Fix module variable shadowing

### DIFF
--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -2579,7 +2579,7 @@ class Allocate(Node):
         nodes: List[Node] = []
         mod_var_names = [var.name for var in mod_vars] if mod_vars is not None else []
         for var in self.vars:
-            is_mod_var = var.name in mod_var_names
+            is_mod_var = var.is_module_var(mod_var_names)
             ad_var = var.add_suffix(AD_SUFFIX)
             if reverse:
                 if var.ad_target:
@@ -2616,7 +2616,9 @@ class Allocate(Node):
         mod_var_names = [var.name for var in mod_vars] if mod_vars is not None else []
         vars = []
         for var in self.vars:
-            if not var.name in mod_var_names and (any(var.name == f"{name}{AD_SUFFIX}" for name in mod_var_names) or (decl_map is None or var.name in decl_map)):
+            is_base_mod = var.is_module_var(mod_var_names)
+            is_any_mod = var.is_module_var(mod_var_names, check_ad=True)
+            if not is_base_mod and (is_any_mod or (decl_map is None or var.name in decl_map)):
                 vars.append(var)
         if vars:
             return Allocate(vars, mold=self.mold)
@@ -2691,7 +2693,7 @@ class Deallocate(Node):
         nodes: List[Node] = []
         mod_var_names = [var.name for var in mod_vars] if mod_vars is not None else []
         for var in self.vars:
-            is_mod_var = var.name in mod_var_names
+            is_mod_var = var.is_module_var(mod_var_names)
             ad_var = var.add_suffix(AD_SUFFIX)
             if reverse:
                 if var.ad_target:
@@ -2739,7 +2741,9 @@ class Deallocate(Node):
         mod_var_names = [var.name for var in mod_vars] if mod_vars is not None else []
         vars = []
         for var in self.vars:
-            if not var.name in mod_var_names and (any(var.name == f"{name}{AD_SUFFIX}" for name in mod_var_names) or (decl_map is None or var.name in decl_map)):
+            is_base_mod = var.is_module_var(mod_var_names)
+            is_any_mod = var.is_module_var(mod_var_names, check_ad=True)
+            if not is_base_mod and (is_any_mod or (decl_map is None or var.name in decl_map)):
                 vars.append(var)
         if vars:
             return Deallocate(vars, ad_code=True)

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -1206,11 +1206,8 @@ def _generate_ad_subroutine(
         )
         if reverse and not fw_block.is_effectively_empty():
             vars = fw_block.required_vars(vars)
-        for req_var in vars:
-            name = req_var.name
+        for name in vars.names():
             if not name.endswith(AD_SUFFIX):
-                continue
-            if req_var.is_module_var(mod_var_names, check_ad=True):
                 continue
             if not any(v for v in grad_args if v.name == name):
                 if subroutine.is_declared(name):

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -259,6 +259,37 @@ class TestGenerator(unittest.TestCase):
             generated = generator.generate_ad(str(src), warn=False)
             self.assertNotIn("c_ad", generated)
 
+    def test_local_var_shadows_module_var(self):
+        code_tree.Node.reset()
+        import textwrap
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as tmp:
+            src = Path(tmp) / "shadow.f90"
+            src.write_text(
+                textwrap.dedent(
+                    """
+                    module m
+                      implicit none
+                      real, allocatable :: a(:)
+                    contains
+                      subroutine foo(n, x)
+                        integer, intent(in) :: n
+                        real, intent(inout) :: x
+                        real, allocatable :: a(:)
+                        allocate(a(n))
+                        a = x
+                        x = sum(a)
+                        deallocate(a)
+                      end subroutine foo
+                    end module m
+                    """
+                )
+            )
+            generated = generator.generate_ad(str(src), warn=False)
+            self.assertIn("allocate(a(n))", generated)
+            self.assertIn("deallocate(a)", generated)
+
     def test_fadmod_includes_skip(self):
         code_tree.Node.reset()
         fadmod = Path("directives.fadmod")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -289,6 +289,8 @@ class TestGenerator(unittest.TestCase):
             generated = generator.generate_ad(str(src), warn=False)
             self.assertIn("allocate(a(n))", generated)
             self.assertIn("deallocate(a)", generated)
+            self.assertIn("allocate(a_ad(n))", generated)
+            self.assertIn("deallocate(a_ad)", generated)
 
     def test_fadmod_includes_skip(self):
         code_tree.Node.reset()


### PR DESCRIPTION
## Summary
- avoid treating local variables with same name as module variables as module state
- add regression test for module-variable shadowing
- improve module-variable detection for AD variables and clean up allocation handling

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_6890265bebcc832d9fceb5cb26a5a527