### PR TITLE
Treat reverse-mode gradients as inout

### DIFF
--- a/examples/allocate_vars_ad.f90
+++ b/examples/allocate_vars_ad.f90
@@ -37,7 +37,7 @@ contains
   subroutine allocate_and_sum_rev_ad(n, x, x_ad, res_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(inout) :: res_ad
     real, allocatable :: arr_ad(:)
     integer :: i
@@ -47,8 +47,6 @@ contains
     do i = 1, n
       arr(i) = i * x
     end do
-
-    x_ad = 0.0
 
     allocate(arr_ad(n))
     do i = n, 1, - 1
@@ -86,10 +84,8 @@ contains
   subroutine module_vars_init_rev_ad(n, x, x_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     integer :: i
-
-    x_ad = 0.0
 
     do i = n, 1, - 1
       x_ad = mod_arr_diff_ad(i) * i + x_ad ! mod_arr_diff(i) = i * x

--- a/examples/arrays_ad.f90
+++ b/examples/arrays_ad.f90
@@ -24,13 +24,13 @@ contains
   subroutine elementwise_add_rev_ad(n, a, a_ad, b, b_ad, c_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: a(n)
-    real, intent(out) :: a_ad(n)
+    real, intent(inout) :: a_ad(n)
     real, intent(in)  :: b(n)
-    real, intent(out) :: b_ad(n)
+    real, intent(inout) :: b_ad(n)
     real, intent(inout) :: c_ad(n)
 
-    b_ad(:n:1) = c_ad ! c = c(:) + b(:n:1)
-    a_ad = c_ad(:) ! c(:) = a + b
+    b_ad(:n:1) = c_ad + b_ad(:n:1) ! c = c(:) + b(:n:1)
+    a_ad = c_ad(:) + a_ad ! c(:) = a + b
     b_ad = c_ad(:) + b_ad ! c(:) = a + b
     c_ad(:) = 0.0 ! c(:) = a + b
 
@@ -92,21 +92,19 @@ contains
     integer, intent(in)  :: n
     integer, intent(in)  :: m
     real, intent(in)  :: a(n,m)
-    real, intent(out) :: a_ad(n,m)
+    real, intent(inout) :: a_ad(n,m)
     real, intent(in)  :: b(n,m)
-    real, intent(out) :: b_ad(n,m)
+    real, intent(inout) :: b_ad(n,m)
     real, intent(in)  :: c
-    real, intent(out) :: c_ad
+    real, intent(inout) :: c_ad
     real, intent(inout) :: d_ad(n,m)
     integer :: i
     integer :: j
 
-    c_ad = 0.0
-
     do j = m, 1, - 1
       do i = n, 1, - 1
-        a_ad(i,j) = d_ad(i,j) ! d(i,j) = a(i,j) + b(i,j) * c
-        b_ad(i,j) = d_ad(i,j) * c ! d(i,j) = a(i,j) + b(i,j) * c
+        a_ad(i,j) = d_ad(i,j) + a_ad(i,j) ! d(i,j) = a(i,j) + b(i,j) * c
+        b_ad(i,j) = d_ad(i,j) * c + b_ad(i,j) ! d(i,j) = a(i,j) + b(i,j) * c
         c_ad = d_ad(i,j) * b(i,j) + c_ad ! d(i,j) = a(i,j) + b(i,j) * c
         d_ad(i,j) = 0.0 ! d(i,j) = a(i,j) + b(i,j) * c
       end do
@@ -138,15 +136,15 @@ contains
   subroutine dot_product_rev_ad(n, a, a_ad, b, b_ad, res_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: a(n)
-    real, intent(out) :: a_ad(n)
+    real, intent(inout) :: a_ad(n)
     real, intent(in)  :: b(n)
-    real, intent(out) :: b_ad(n)
+    real, intent(inout) :: b_ad(n)
     real, intent(inout) :: res_ad
     integer :: i
 
     do i = n, 1, - 1
-      a_ad(i) = res_ad * b(i) ! res = res + a(i) * b(i)
-      b_ad(i) = res_ad * a(i) ! res = res + a(i) * b(i)
+      a_ad(i) = res_ad * b(i) + a_ad(i) ! res = res + a(i) * b(i)
+      b_ad(i) = res_ad * a(i) + b_ad(i) ! res = res + a(i) * b(i)
     end do
     res_ad = 0.0 ! res = 0.0
 
@@ -179,13 +177,11 @@ contains
   subroutine indirect_rev_ad(n, a, a_ad, b_ad, c_ad, idx)
     integer, intent(in)  :: n
     real, intent(in)  :: a(n)
-    real, intent(out) :: a_ad(n)
+    real, intent(inout) :: a_ad(n)
     real, intent(inout) :: b_ad(n)
     real, intent(inout) :: c_ad(n)
     integer, intent(in)  :: idx(n)
     integer :: i
-
-    a_ad(:) = 0.0
 
     do i = n, 1, - 1
       a_ad(idx(i)) = c_ad(idx(i)) * 2.0 * a(idx(i)) + a_ad(idx(i)) ! c(idx(i)) = a(idx(i))**2
@@ -225,13 +221,11 @@ contains
   subroutine stencil_rev_ad(n, a, a_ad, b_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: a(n)
-    real, intent(out) :: a_ad(n)
+    real, intent(inout) :: a_ad(n)
     real, intent(inout) :: b_ad(n)
     integer :: i
     integer :: in
     integer :: ip
-
-    a_ad(:) = 0.0
 
     do i = n, 1, - 1
       in = i - 1

--- a/examples/block_construct_ad.f90
+++ b/examples/block_construct_ad.f90
@@ -18,9 +18,9 @@ contains
 
   subroutine compute_module_rev_ad(val, val_ad)
     real, intent(in)  :: val
-    real, intent(out) :: val_ad
+    real, intent(inout) :: val_ad
 
-    val_ad = z_ad ! z = val + 1.0
+    val_ad = z_ad + val_ad ! z = val + 1.0
     z_ad = 0.0 ! z = val + 1.0
 
     return
@@ -53,7 +53,7 @@ contains
 
   subroutine use_block_rev_ad(x, x_ad, y_ad)
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(inout) :: y_ad
     real :: z_ad
 
@@ -63,7 +63,7 @@ contains
 
       z_ad = y_ad ! y = z + 1.0
       y_ad = 0.0 ! y = z + 1.0
-      x_ad = z_ad ! z = x + 2.0
+      x_ad = z_ad + x_ad ! z = x + 2.0
     end block
     x_ad = z_ad + x_ad ! z = x + 1.0
     z_ad = 0.0 ! z = x + 1.0

--- a/examples/call_example_ad.f90
+++ b/examples/call_example_ad.f90
@@ -20,9 +20,9 @@ contains
     real, intent(inout) :: a
     real, intent(inout) :: a_ad
     real, intent(in)  :: b
-    real, intent(out) :: b_ad
+    real, intent(inout) :: b_ad
 
-    b_ad = a_ad ! a = a * 2.0 + b
+    b_ad = a_ad + b_ad ! a = a * 2.0 + b
     a_ad = a_ad * 2.0 ! a = a * 2.0 + b
 
     return
@@ -42,10 +42,10 @@ contains
 
   subroutine bar_rev_ad(a, a_ad, b_ad)
     real, intent(in)  :: a
-    real, intent(out) :: a_ad
+    real, intent(inout) :: a_ad
     real, intent(inout) :: b_ad
 
-    a_ad = b_ad * 2.0 * a ! b = a**2
+    a_ad = b_ad * 2.0 * a + a_ad ! b = a**2
     b_ad = 0.0 ! b = a**2
 
     return
@@ -66,7 +66,7 @@ contains
     real, intent(inout) :: x
     real, intent(inout) :: x_ad
     real, intent(in)  :: y
-    real, intent(out) :: y_ad
+    real, intent(inout) :: y_ad
 
     call foo_rev_ad(x, x_ad, y, y_ad) ! call foo(x, y)
 
@@ -87,7 +87,7 @@ contains
   subroutine call_fucntion_rev_ad(x_ad, y, y_ad)
     real, intent(inout) :: x_ad
     real, intent(in)  :: y
-    real, intent(out) :: y_ad
+    real, intent(inout) :: y_ad
 
     call bar_rev_ad(y, y_ad, x_ad) ! x = bar(y)
 
@@ -111,11 +111,11 @@ contains
     real, intent(inout) :: x
     real, intent(inout) :: x_ad
     real, intent(in)  :: y
-    real, intent(out) :: y_ad
+    real, intent(inout) :: y_ad
     real :: foo_arg1_save_45_ad
 
     call foo_rev_ad(x, x_ad, y * 2.0, foo_arg1_save_45_ad) ! call foo(x, y * 2.0)
-    y_ad = foo_arg1_save_45_ad * 2.0 ! call foo(x, y * 2.0)
+    y_ad = foo_arg1_save_45_ad * 2.0 + y_ad ! call foo(x, y * 2.0)
 
     return
   end subroutine arg_operation_rev_ad
@@ -138,7 +138,7 @@ contains
     real, intent(inout) :: x
     real, intent(inout) :: x_ad
     real, intent(in)  :: y
-    real, intent(out) :: y_ad
+    real, intent(inout) :: y_ad
     real :: foo_arg1_save_54_ad
 
     call foo_rev_ad(x, x_ad, bar(y), foo_arg1_save_54_ad) ! call foo(x, bar(y))

--- a/examples/call_module_vars_ad.f90
+++ b/examples/call_module_vars_ad.f90
@@ -25,7 +25,7 @@ contains
 
   subroutine call_inc_and_use_rev_ad(x, x_ad, y_ad)
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(inout) :: y_ad
     real :: z_ad
     real :: z

--- a/examples/cross_mod_a_ad.f90
+++ b/examples/cross_mod_a_ad.f90
@@ -20,9 +20,9 @@ contains
     real, intent(inout) :: a
     real, intent(inout) :: a_ad
     real, intent(in)  :: inc
-    real, intent(out) :: inc_ad
+    real, intent(inout) :: inc_ad
 
-    inc_ad = a_ad ! a = a + inc
+    inc_ad = a_ad + inc_ad ! a = a + inc
 
     return
   end subroutine incval_rev_ad

--- a/examples/cross_mod_b_ad.f90
+++ b/examples/cross_mod_b_ad.f90
@@ -27,6 +27,8 @@ contains
 
     inc = 1.0
 
+    inc_ad = 0.0
+
     call incval_rev_ad(b, b_ad, inc, inc_ad) ! call incval(b, inc)
 
     return
@@ -52,6 +54,8 @@ contains
     real :: inc
 
     inc = 1.0
+
+    inc_ad = 0.0
 
     call incval_rev_ad(b, b_ad, inc, inc_ad) ! call incval(inc=inc, a=b)
 

--- a/examples/derived_alloc_ad.f90
+++ b/examples/derived_alloc_ad.f90
@@ -107,7 +107,7 @@ contains
     integer, intent(in)  :: n
     integer, intent(in)  :: m
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(inout) :: res_ad
     integer :: n0_ad
     integer :: i
@@ -123,8 +123,6 @@ contains
         obj(j)%arr(i) = obj(j)%arr(i) * x + j
       end do
     end do
-
-    x_ad = 0.0
 
     do j = m, 1, - 1
       do i = n, 1, - 1

--- a/examples/directives_ad.f90
+++ b/examples/directives_ad.f90
@@ -19,11 +19,11 @@ contains
 
   subroutine add_const_rev_ad(x, x_ad, y_ad, z)
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(inout) :: y_ad
     real, intent(in)  :: z
 
-    x_ad = y_ad ! y = x + z
+    x_ad = y_ad + x_ad ! y = x + z
     y_ad = 0.0 ! y = x + z
 
     return
@@ -47,13 +47,13 @@ contains
 
   subroutine worker_rev_ad(x, x_ad, z_ad)
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(inout) :: z_ad
     real :: y_ad
 
     y_ad = z_ad ! z = y
     z_ad = 0.0 ! z = y
-    x_ad = y_ad ! y = x + 1.0
+    x_ad = y_ad + x_ad ! y = x + 1.0
 
     return
   end subroutine worker_rev_ad

--- a/examples/exit_cycle_ad.f90
+++ b/examples/exit_cycle_ad.f90
@@ -52,7 +52,7 @@ contains
   subroutine do_exit_cycle_rev_ad(n, x, x_ad, res_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(inout) :: res_ad
     real :: res
     integer :: exit_do_start_32_ad
@@ -95,7 +95,7 @@ contains
       res = res * x
     end do
 
-    x_ad = res_ad * res ! res = res * x
+    x_ad = res_ad * res + x_ad ! res = res * x
     res_ad = res_ad * x ! res = res * x
     exit_flag_19_ad = .true.
     exit_flag_29_ad = .true.
@@ -243,7 +243,7 @@ contains
   subroutine while_exit_cycle_rev_ad(n, x, x_ad, res_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(inout) :: res_ad
     real :: res
     integer :: i
@@ -291,7 +291,7 @@ contains
       i = i + 1
     end do
 
-    x_ad = res_ad * res ! res = res * x
+    x_ad = res_ad * res + x_ad ! res = res * x
     res_ad = res_ad * x ! res = res * x
     exit_flag_54_ad = .true.
     exit_flag_65_ad = .true.
@@ -446,7 +446,7 @@ contains
   subroutine exit_cycle_with_labels_rev_ad(n, x, x_ad, res_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(inout) :: res_ad
     real :: res
     integer :: i
@@ -498,8 +498,6 @@ contains
       end do middle
       res = res * x
     end do outer
-
-    x_ad = 0.0
 
     exit_flag_90_ad = .true.
     exit_flag_94_ad = .true.

--- a/examples/intrinsic_func_ad.f90
+++ b/examples/intrinsic_func_ad.f90
@@ -66,7 +66,7 @@ contains
 
   subroutine math_intrinsics_rev_ad(x, x_ad, y, y_ad, z_ad)
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(inout) :: y
     real, intent(inout) :: y_ad
     real, intent(inout) :: z_ad
@@ -97,7 +97,7 @@ contains
     p_ad = z_ad ! z = a + b + c + d + e + f + g + h + o + p + q
     q_ad = z_ad ! z = a + b + c + d + e + f + g + h + o + p + q
     z_ad = 0.0 ! z = a + b + c + d + e + f + g + h + o + p + q
-    x_ad = q_ad ! q = mod(x, y)
+    x_ad = q_ad + x_ad ! q = mod(x, y)
     y_ad = - q_ad * real(int(x / y), kind(x)) + y_ad ! q = mod(x, y)
     x_ad = p_ad * 2.0 / sqrt(acos(- 1.0)) * exp(- x**2) + x_ad ! p = erf(x) + erfc(y)
     y_ad = - p_ad * 2.0 / sqrt(acos(- 1.0)) * exp(- y**2) + y_ad ! p = erf(x) + erfc(y)
@@ -147,13 +147,13 @@ contains
 
   subroutine reduction_rev_ad(x, x_ad, a_ad, b_ad, c_ad, d_ad)
     real, intent(in)  :: x(:)
-    real, intent(out) :: x_ad(:)
+    real, intent(inout) :: x_ad(:)
     real, intent(inout) :: a_ad
     real, intent(inout) :: b_ad
     real, intent(inout) :: c_ad
     real, intent(inout) :: d_ad
 
-    x_ad = d_ad * merge(1.0, 0.0, x == maxval(x)) ! d = maxval(x)
+    x_ad = d_ad * merge(1.0, 0.0, x == maxval(x)) + x_ad ! d = maxval(x)
     d_ad = 0.0 ! d = maxval(x)
     x_ad = c_ad * merge(1.0, 0.0, x == minval(x)) + x_ad ! c = minval(x)
     c_ad = 0.0 ! c = minval(x)
@@ -201,15 +201,12 @@ contains
   subroutine non_differentiable_intrinsics_rev_ad(str, arr, arr_ad, x, x_ad, y_ad)
     character(len=*), intent(in)  :: str
     real, intent(in)  :: arr(:)
-    real, intent(out) :: arr_ad(:)
+    real, intent(inout) :: arr_ad(:)
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(inout) :: y_ad
 
-    arr_ad(:) = 0.0
-
     y_ad = 0.0 ! y = a + b + c
-    x_ad = 0.0 ! c = tiny(x)
 
     return
   end subroutine non_differentiable_intrinsics_rev_ad
@@ -230,11 +227,11 @@ contains
 
   subroutine special_intrinsics_rev_ad(mat_in, mat_in_ad, mat_out_ad)
     real, intent(in)  :: mat_in(:,:)
-    real, intent(out) :: mat_in_ad(:,:)
+    real, intent(inout) :: mat_in_ad(:,:)
     real, intent(inout) :: mat_out_ad(:,:)
 
     mat_out_ad = cshift(mat_out_ad, - 1, 2) ! mat_out = cshift(mat_out, 1, 2)
-    mat_in_ad = transpose(mat_out_ad) ! mat_out = transpose(mat_in)
+    mat_in_ad = transpose(mat_out_ad) + mat_in_ad ! mat_out = transpose(mat_in)
 
     return
   end subroutine special_intrinsics_rev_ad
@@ -261,11 +258,11 @@ contains
   subroutine casting_intrinsics_rev_ad(i, r, r_ad, d_ad, c)
     integer, intent(in)  :: i
     real, intent(in)  :: r
-    real, intent(out) :: r_ad
+    real, intent(inout) :: r_ad
     double precision, intent(inout) :: d_ad
     character(len=1), intent(inout) :: c
 
-    r_ad = d_ad ! d = dble(r) + dble(i2)
+    r_ad = d_ad + r_ad ! d = dble(r) + dble(i2)
     d_ad = 0.0d0 ! d = dble(r) + dble(i2)
 
     return

--- a/examples/keyword_args_ad.f90
+++ b/examples/keyword_args_ad.f90
@@ -20,9 +20,9 @@ contains
     real, intent(inout) :: a
     real, intent(inout) :: a_ad
     real, intent(in)  :: b
-    real, intent(out) :: b_ad
+    real, intent(inout) :: b_ad
 
-    b_ad = a_ad ! a = a + b
+    b_ad = a_ad + b_ad ! a = a + b
 
     return
   end subroutine inc_rev_ad
@@ -42,7 +42,7 @@ contains
     real, intent(inout) :: x
     real, intent(inout) :: x_ad
     real, intent(in)  :: y
-    real, intent(out) :: y_ad
+    real, intent(inout) :: y_ad
 
     call inc_rev_ad(x, x_ad, y, y_ad) ! call inc(a=x, b=y)
 

--- a/examples/main_program_ad.f90
+++ b/examples/main_program_ad.f90
@@ -23,13 +23,13 @@ contains
 
   subroutine simple_rev_ad(a, a_ad, b, b_ad, c_ad)
     real, intent(in)  :: a
-    real, intent(out) :: a_ad
+    real, intent(inout) :: a_ad
     real, intent(in)  :: b
-    real, intent(out) :: b_ad
+    real, intent(inout) :: b_ad
     real, intent(inout) :: c_ad
 
-    a_ad = c_ad ! c = a + b
-    b_ad = c_ad ! c = a + b
+    a_ad = c_ad + a_ad ! c = a + b
+    b_ad = c_ad + b_ad ! c = a + b
     c_ad = 0.0 ! c = a + b
 
     return

--- a/examples/module_vars_ad.f90
+++ b/examples/module_vars_ad.f90
@@ -25,7 +25,7 @@ contains
 
   subroutine inc_and_use_rev_ad(x, x_ad, y_ad)
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(inout) :: y_ad
     real :: y
     real :: a_save_13_ad
@@ -38,7 +38,7 @@ contains
     a_ad = y_ad * y + a_ad ! y = y * a
     y_ad = y_ad * a ! y = y * a
     a = a_save_13_ad
-    x_ad = a_ad ! a = a + x
+    x_ad = a_ad + x_ad ! a = a + x
     x_ad = y_ad * a + x_ad ! y = (c + x) * a
     a_ad = y_ad * (c + x) + a_ad ! y = (c + x) * a
     y_ad = 0.0 ! y = (c + x) * a

--- a/examples/omp_loops_ad.f90
+++ b/examples/omp_loops_ad.f90
@@ -31,7 +31,7 @@ contains
   subroutine sum_loop_rev_ad(n, x, x_ad, y_ad, s_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: x(n)
-    real, intent(out) :: x_ad(n)
+    real, intent(inout) :: x_ad(n)
     real, intent(inout) :: y_ad(n)
     real, intent(inout) :: s_ad
     integer :: i
@@ -39,7 +39,7 @@ contains
     !$omp parallel do
     do i = n, 1, - 1
       y_ad(i) = s_ad + y_ad(i) ! s = s + y(i)
-      x_ad(i) = y_ad(i) ! y(i) = x(i)
+      x_ad(i) = y_ad(i) + x_ad(i) ! y(i) = x(i)
     end do
     !$omp end parallel do
     s_ad = 0.0 ! s = 0.0
@@ -78,13 +78,11 @@ contains
   subroutine stencil_loop_rev_ad(n, x, x_ad, y_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: x(n)
-    real, intent(out) :: x_ad(n)
+    real, intent(inout) :: x_ad(n)
     real, intent(inout) :: y_ad(n)
     integer :: i
     integer :: in
     integer :: ip
-
-    x_ad(:) = 0.0
 
     do i = n, 1, - 1
       in = i - 1

--- a/examples/parameter_var_ad.f90
+++ b/examples/parameter_var_ad.f90
@@ -19,11 +19,11 @@ contains
 
   subroutine compute_area_rev_ad(r, r_ad, area_ad)
     real, intent(in)  :: r
-    real, intent(out) :: r_ad
+    real, intent(inout) :: r_ad
     real, intent(inout) :: area_ad
     real, parameter :: pi = 3.14159
 
-    r_ad = area_ad * (pi * r + pi * r) ! area = pi * r * r
+    r_ad = area_ad * (pi * r + pi * r) + r_ad ! area = pi * r * r
     area_ad = 0.0 ! area = pi * r * r
 
     return

--- a/examples/pointer_arrays_ad.f90
+++ b/examples/pointer_arrays_ad.f90
@@ -47,12 +47,10 @@ contains
   subroutine pointer_allocate_rev_ad(n, x, x_ad, res_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(inout) :: res_ad
     real, pointer :: p_ad(:)
     integer :: i
-
-    x_ad = 0.0
 
     if (.not. associated(mod_p_ad)) then
       allocate(mod_p_ad, mold=mod_p)
@@ -109,12 +107,10 @@ contains
   subroutine pointer_subarray_rev_ad(n, x, x_ad, res_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(inout) :: res_ad
     real, pointer :: p_ad(:)
     integer :: i
-
-    x_ad = 0.0
 
     if (.not. associated(mod_p_ad)) then
       allocate(mod_p_ad, mold=mod_p)
@@ -206,7 +202,7 @@ contains
   subroutine pointer_allsub_main_rev_ad(n, x, x_ad, res_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: x(n)
-    real, intent(out) :: x_ad(n)
+    real, intent(inout) :: x_ad(n)
     real, intent(inout) :: res_ad
     integer :: i
 
@@ -223,7 +219,7 @@ contains
     end do
     res_ad = 0.0 ! res = 0.0
     do i = n, 1, - 1
-      x_ad(i) = sub1_p_ad(i) ! sub1_p(i) = sub1_p(i) + x(i)
+      x_ad(i) = sub1_p_ad(i) + x_ad(i) ! sub1_p(i) = sub1_p(i) + x(i)
     end do
 
     return
@@ -279,9 +275,9 @@ contains
   subroutine pointer_swap_rev_ad(n, x, x_ad, y, y_ad, res_ad)
     integer, intent(in)  :: n
     real, intent(in), target  :: x(n)
-    real, intent(out), target :: x_ad(n)
+    real, intent(inout), target :: x_ad(n)
     real, intent(in), target  :: y(n)
-    real, intent(out), target :: y_ad(n)
+    real, intent(inout), target :: y_ad(n)
     real, intent(inout) :: res_ad
     real, pointer :: swap_ad(:)
     real, pointer :: work1_ad(:)
@@ -297,9 +293,6 @@ contains
       work1_ad => work2_ad ! work1 => work2
       work2_ad => swap_ad ! work2 => swap
     end do
-
-    x_ad(:) = 0.0
-    y_ad(:) = 0.0
 
     do j = 3, 1, - 1
       call fautodiff_stack_p%pop(work1_ad)

--- a/examples/save_vars_ad.f90
+++ b/examples/save_vars_ad.f90
@@ -32,9 +32,9 @@ contains
 
   subroutine simple_rev_ad(x, x_ad, y, y_ad, z_ad)
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(in)  :: y
-    real, intent(out) :: y_ad
+    real, intent(inout) :: y_ad
     real, intent(inout) :: z_ad
     real :: work_ad
     real :: work
@@ -48,7 +48,7 @@ contains
     work = x**2
 
     work_ad = z_ad * x ! z = work * x + z
-    x_ad = z_ad * work ! z = work * x + z
+    x_ad = z_ad * work + x_ad ! z = work * x + z
     work = work_save_15_ad
     x_ad = work_ad * 2.0 * x + x_ad ! work = x**2
     work_ad = z_ad * x ! z = work * x + z
@@ -56,7 +56,7 @@ contains
     work = work_save_13_ad
     work_ad = work_ad * 2.0 * work ! work = work**2
     work_ad = z_ad + work_ad ! z = work + y
-    y_ad = z_ad ! z = work + y
+    y_ad = z_ad + y_ad ! z = work + y
     z_ad = 0.0 ! z = work + y
     x_ad = work_ad + x_ad ! work = x + 1.0
 
@@ -103,9 +103,9 @@ contains
 
   subroutine if_example_rev_ad(x, x_ad, y, y_ad, z_ad)
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(in)  :: y
-    real, intent(out) :: y_ad
+    real, intent(inout) :: y_ad
     real, intent(inout) :: z_ad
     real :: work_ad
     real :: work
@@ -124,10 +124,8 @@ contains
     work_save_39_ad = work
     work = work * x
 
-    y_ad = 0.0
-
     work_ad = z_ad * x ! z = work * x + z
-    x_ad = z_ad * work ! z = work * x + z
+    x_ad = z_ad * work + x_ad ! z = work * x + z
     work = work_save_39_ad
     x_ad = work_ad * work + x_ad ! work = work * x
     work_ad = work_ad * x ! work = work * x
@@ -144,7 +142,7 @@ contains
       x_ad = work_ad * work + x_ad ! work = work * x
       work_ad = work_ad * x ! work = work * x
       work_ad = z_ad * y + work_ad ! z = work * y
-      y_ad = z_ad * work ! z = work * y
+      y_ad = z_ad * work + y_ad ! z = work * y
       z_ad = 0.0 ! z = work * y
       x_ad = work_ad + x_ad ! work = x
       work_ad = 0.0 ! work = x
@@ -206,9 +204,9 @@ contains
     integer, intent(in)  :: n
     integer, intent(in)  :: m
     real, intent(in)  :: x(n,m)
-    real, intent(out) :: x_ad(n,m)
+    real, intent(inout) :: x_ad(n,m)
     real, intent(in)  :: y(n,m)
-    real, intent(out) :: y_ad(n,m)
+    real, intent(inout) :: y_ad(n,m)
     real, intent(inout) :: z_ad(n,m)
     real :: ary_ad(n,m)
     real :: scalar_ad
@@ -238,11 +236,11 @@ contains
         z_ad(i,j) = z_ad(i,j) * scalar ! z(i,j) = z(i,j) * scalar
         scalar = scalar_save_64_ad
         z_ad(i,j) = scalar_ad * y(i,j) + z_ad(i,j) ! scalar = z(i,j) * y(i,j)
-        y_ad(i,j) = scalar_ad * z(i,j) ! scalar = z(i,j) * y(i,j)
+        y_ad(i,j) = scalar_ad * z(i,j) + y_ad(i,j) ! scalar = z(i,j) * y(i,j)
         y_ad(i,j) = z_ad(i,j) * scalar + y_ad(i,j) ! z(i,j) = y(i,j) * scalar + z(i,j)
         scalar_ad = z_ad(i,j) * y(i,j) ! z(i,j) = y(i,j) * scalar + z(i,j)
         z(i,j) = z_save_62_ad
-        x_ad(i,j) = z_ad(i,j) ! z(i,j) = x(i,j) + scalar
+        x_ad(i,j) = z_ad(i,j) + x_ad(i,j) ! z(i,j) = x(i,j) + scalar
         scalar_ad = z_ad(i,j) + scalar_ad ! z(i,j) = x(i,j) + scalar
         ary_ad(i,j) = scalar_ad * z(i,j) ! scalar = ary(i,j) * z(i,j)
         z_ad(i,j) = scalar_ad * ary(i,j) ! scalar = ary(i,j) * z(i,j)
@@ -306,9 +304,9 @@ contains
     integer, intent(in)  :: n
     integer, intent(in)  :: m
     real, intent(in)  :: x(n,m)
-    real, intent(out) :: x_ad(n,m)
+    real, intent(inout) :: x_ad(n,m)
     real, intent(in)  :: y(n,m)
-    real, intent(out) :: y_ad(n,m)
+    real, intent(inout) :: y_ad(n,m)
     real, intent(inout) :: z_ad(n,m)
     real :: ary_ad(n,m)
     integer :: i
@@ -333,9 +331,9 @@ contains
     do j = m, 1, - 1
       do i = n, 1, - 1
         ary_ad(i,j) = z_ad(i,j) ! z(i,j) = z(i,j) + ary(i,j)
-        y_ad(i,j) = ary_ad(i,j) * ary(i,j) ! ary(i,j) = y(i,j) * ary(i,j)
+        y_ad(i,j) = ary_ad(i,j) * ary(i,j) + y_ad(i,j) ! ary(i,j) = y(i,j) * ary(i,j)
         ary_ad(i,j) = ary_ad(i,j) * y(i,j) ! ary(i,j) = y(i,j) * ary(i,j)
-        x_ad(i,j) = z_ad(i,j) * z(i,j) ! z(i,j) = z(i,j) * x(i,j) + ary(i,j)
+        x_ad(i,j) = z_ad(i,j) * z(i,j) + x_ad(i,j) ! z(i,j) = z(i,j) * x(i,j) + ary(i,j)
         ary_ad(i,j) = z_ad(i,j) + ary_ad(i,j) ! z(i,j) = z(i,j) * x(i,j) + ary(i,j)
         z_ad(i,j) = z_ad(i,j) * x(i,j) ! z(i,j) = z(i,j) * x(i,j) + ary(i,j)
       end do
@@ -419,9 +417,9 @@ contains
     integer, intent(in)  :: n
     integer, intent(in)  :: m
     real, intent(in)  :: x(n,m)
-    real, intent(out) :: x_ad(n,m)
+    real, intent(inout) :: x_ad(n,m)
     real, intent(in)  :: y(n,m)
-    real, intent(out) :: y_ad(n,m)
+    real, intent(inout) :: y_ad(n,m)
     real, intent(inout) :: z_ad(n,m)
     real :: work1_ad(2,n,m)
     real :: work2_ad(2,m)
@@ -462,9 +460,9 @@ contains
         work3_ad(1) = z_ad(i,j) * z(i,j) + work3_ad(1) ! z(i,j) = z(i,j) * (work3(1) + work3(2)) + work1(1,i,j) * y(i,j) + work1(2,i,j) * x(i,j)
         work3_ad(2) = z_ad(i,j) * z(i,j) + work3_ad(2) ! z(i,j) = z(i,j) * (work3(1) + work3(2)) + work1(1,i,j) * y(i,j) + work1(2,i,j) * x(i,j)
         work1_ad(1,i,j) = z_ad(i,j) * y(i,j) ! z(i,j) = z(i,j) * (work3(1) + work3(2)) + work1(1,i,j) * y(i,j) + work1(2,i,j) * x(i,j)
-        y_ad(i,j) = z_ad(i,j) * work1(1,i,j) ! z(i,j) = z(i,j) * (work3(1) + work3(2)) + work1(1,i,j) * y(i,j) + work1(2,i,j) * x(i,j)
+        y_ad(i,j) = z_ad(i,j) * work1(1,i,j) + y_ad(i,j) ! z(i,j) = z(i,j) * (work3(1) + work3(2)) + work1(1,i,j) * y(i,j) + work1(2,i,j) * x(i,j)
         work1_ad(2,i,j) = z_ad(i,j) * x(i,j) ! z(i,j) = z(i,j) * (work3(1) + work3(2)) + work1(1,i,j) * y(i,j) + work1(2,i,j) * x(i,j)
-        x_ad(i,j) = z_ad(i,j) * work1(2,i,j) ! z(i,j) = z(i,j) * (work3(1) + work3(2)) + work1(1,i,j) * y(i,j) + work1(2,i,j) * x(i,j)
+        x_ad(i,j) = z_ad(i,j) * work1(2,i,j) + x_ad(i,j) ! z(i,j) = z(i,j) * (work3(1) + work3(2)) + work1(1,i,j) * y(i,j) + work1(2,i,j) * x(i,j)
         z_ad(i,j) = z_ad(i,j) * (work3(1) + work3(2)) ! z(i,j) = z(i,j) * (work3(1) + work3(2)) + work1(1,i,j) * y(i,j) + work1(2,i,j) * x(i,j)
         do k = 2, 1, - 1
           work1(k,i,j) = work1_save_132_ad(k)

--- a/examples/simple_math_ad.f90
+++ b/examples/simple_math_ad.f90
@@ -26,17 +26,17 @@ contains
 
   subroutine add_numbers_rev_ad(a, a_ad, b, b_ad, c_ad)
     real, intent(in)  :: a
-    real, intent(out) :: a_ad
+    real, intent(inout) :: a_ad
     real, intent(in)  :: b
-    real, intent(out) :: b_ad
+    real, intent(inout) :: b_ad
     real, intent(inout) :: c_ad
     real :: work_ad
 
     work_ad = c_ad ! c = c + 2.0 + work
-    a_ad = c_ad ! c = a + 1.0
+    a_ad = c_ad + a_ad ! c = a + 1.0
     c_ad = 0.0 ! c = a + 1.0
     a_ad = work_ad + a_ad ! work = a + b
-    b_ad = work_ad ! work = a + b
+    b_ad = work_ad + b_ad ! work = a + b
 
     return
   end subroutine add_numbers_rev_ad
@@ -59,14 +59,14 @@ contains
 
   subroutine subtract_numbers_rev_ad(a, a_ad, b, b_ad, c_ad)
     real, intent(in)  :: a
-    real, intent(out) :: a_ad
+    real, intent(inout) :: a_ad
     real, intent(in)  :: b
-    real, intent(out) :: b_ad
+    real, intent(inout) :: b_ad
     real, intent(inout) :: c_ad
 
-    b_ad = c_ad ! c = - c + b
+    b_ad = c_ad + b_ad ! c = - c + b
     c_ad = - c_ad ! c = - c + b
-    a_ad = c_ad ! c = a - b
+    a_ad = c_ad + a_ad ! c = a - b
     b_ad = - c_ad + b_ad ! c = a - b
     c_ad = 0.0 ! c = a - b
 
@@ -91,15 +91,15 @@ contains
 
   subroutine multiply_numbers_rev_ad(a, a_ad, b, b_ad, c_ad)
     real, intent(in)  :: a
-    real, intent(out) :: a_ad
+    real, intent(inout) :: a_ad
     real, intent(in)  :: b
-    real, intent(out) :: b_ad
+    real, intent(inout) :: b_ad
     real, intent(inout) :: c_ad
 
-    a_ad = c_ad ! c = c * 3.0 + a
+    a_ad = c_ad + a_ad ! c = c * 3.0 + a
     c_ad = c_ad * 3.0 ! c = c * 3.0 + a
     a_ad = c_ad * (b + 1.0) + a_ad ! c = a * b + a
-    b_ad = c_ad * a ! c = a * b + a
+    b_ad = c_ad * a + b_ad ! c = a * b + a
     c_ad = 0.0 ! c = a * b + a
 
     return
@@ -123,15 +123,15 @@ contains
 
   subroutine divide_numbers_rev_ad(a, a_ad, b, b_ad, c_ad)
     real, intent(in)  :: a
-    real, intent(out) :: a_ad
+    real, intent(inout) :: a_ad
     real, intent(in)  :: b
-    real, intent(out) :: b_ad
+    real, intent(inout) :: b_ad
     real, intent(inout) :: c_ad
 
-    a_ad = c_ad ! c = c / 2.0 + a
+    a_ad = c_ad + a_ad ! c = c / 2.0 + a
     c_ad = c_ad / 2.0 ! c = c / 2.0 + a
     a_ad = c_ad / (b + 1.5) + a_ad ! c = a / (b + 1.5)
-    b_ad = - c_ad * a / (b + 1.5)**2 ! c = a / (b + 1.5)
+    b_ad = - c_ad * a / (b + 1.5)**2 + b_ad ! c = a / (b + 1.5)
     c_ad = 0.0 ! c = a / (b + 1.5)
 
     return
@@ -155,13 +155,13 @@ contains
 
   subroutine power_numbers_rev_ad(a, a_ad, b, b_ad, c_ad)
     real, intent(in)  :: a
-    real, intent(out) :: a_ad
+    real, intent(inout) :: a_ad
     real, intent(in)  :: b
-    real, intent(out) :: b_ad
+    real, intent(inout) :: b_ad
     real, intent(inout) :: c_ad
 
-    a_ad = c_ad * (b * a**(b - 1.0) + b * (4.0 * a + 2.0)**(b - 1.0) * 4.0 + (b * 5.0 + 3.0) * a**(b * 5.0 + 2.0)) ! c = c + a**b + (4.0 * a + 2.0)**b + a**(b * 5.0 + 3.0)
-    b_ad = c_ad * (a**b * log(a) + (4.0 * a + 2.0)**b * log(4.0 * a + 2.0) + a**(b * 5.0 + 3.0) * log(a) * 5.0) ! c = c + a**b + (4.0 * a + 2.0)**b + a**(b * 5.0 + 3.0)
+    a_ad = c_ad * (b * a**(b - 1.0) + b * (4.0 * a + 2.0)**(b - 1.0) * 4.0 + (b * 5.0 + 3.0) * a**(b * 5.0 + 2.0)) + a_ad ! c = c + a**b + (4.0 * a + 2.0)**b + a**(b * 5.0 + 3.0)
+    b_ad = c_ad * (a**b * log(a) + (4.0 * a + 2.0)**b * log(4.0 * a + 2.0) + a**(b * 5.0 + 3.0) * log(a) * 5.0) + b_ad ! c = c + a**b + (4.0 * a + 2.0)**b + a**(b * 5.0 + 3.0)
     a_ad = c_ad * 3.0 * a**2 + a_ad ! c = a**3 + b**5.5
     b_ad = c_ad * 5.5 * b**4.5 + b_ad ! c = a**3 + b**5.5
     c_ad = 0.0 ! c = a**3 + b**5.5

--- a/examples/store_vars_ad.f90
+++ b/examples/store_vars_ad.f90
@@ -33,7 +33,7 @@ contains
   subroutine do_with_recurrent_scalar_rev_ad(n, x, x_ad, z_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: x(n)
-    real, intent(out) :: x_ad(n)
+    real, intent(inout) :: x_ad(n)
     real, intent(inout) :: z_ad(n)
     real :: work_ad
     real :: work
@@ -59,7 +59,7 @@ contains
       work = x(i) * work
       work_ad = z_ad(i) * 2.0 * work + work_ad ! z(i) = work**2 + z(i)
       work = work_save_16_ad
-      x_ad(i) = work_ad * work ! work = x(i) * work
+      x_ad(i) = work_ad * work + x_ad(i) ! work = x(i) * work
       work_ad = work_ad * x(i) ! work = x(i) * work
     end do
     work = work_save_18_ad
@@ -105,7 +105,7 @@ contains
 
   subroutine do_while_rev_ad(x, x_ad, y_ad, z_ad)
     real, intent(in)  :: x
-    real, intent(out) :: x_ad
+    real, intent(inout) :: x_ad
     real, intent(inout) :: y_ad
     real, intent(inout) :: z_ad
     real :: a_ad
@@ -130,7 +130,6 @@ contains
     end do
 
     a_ad = 0.0
-    x_ad = 0.0
 
     z_ad = y_ad * y + z_ad ! y = z * y
     y_ad = y_ad * z ! y = z * y

--- a/examples/where_forall_ad.f90
+++ b/examples/where_forall_ad.f90
@@ -27,12 +27,10 @@ contains
     real, intent(inout) :: a(n)
     real, intent(inout) :: a_ad(n)
     real, intent(in)  :: b(n)
-    real, intent(out) :: b_ad(n)
-
-    b_ad(:) = 0.0
+    real, intent(inout) :: b_ad(n)
 
     where (a > 0.0)
-      b_ad = a_ad ! a = a + b
+      b_ad = a_ad + b_ad ! a = a + b
     elsewhere
       a_ad = - a_ad ! a = -a
     end where
@@ -61,14 +59,12 @@ contains
   subroutine forall_example_rev_ad(n, a, a_ad, b_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: a(n)
-    real, intent(out) :: a_ad(n)
+    real, intent(inout) :: a_ad(n)
     real, intent(inout) :: b_ad(n)
     integer :: i
 
-    a_ad(:) = 0.0
-
     forall (i=1:n)
-      a_ad(i) = b_ad(i) * 2.0 ! b(i) = 2.0 * a(i)
+      a_ad(i) = b_ad(i) * 2.0 + a_ad(i) ! b(i) = 2.0 * a(i)
       b_ad(i) = 0.0 ! b(i) = 2.0 * a(i)
     end forall
 


### PR DESCRIPTION
## Summary
- Preserve incoming values by marking reverse-mode gradient arguments as `intent(inout)` and checking them during pruning
- Clean up reverse OpenMP example by removing unnecessary reduction clauses and sequential directives

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_68904b2e826c832d83a9ebc94f42c54a