### PR TITLE
Remove test skips and run all examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ This file provides guidelines for contributors about the repository and develop 
   Use ``python tests/test_generator.py`` to run the unit tests.
 - Messages such as commits and PRs should be in English.
 - Branch names **must** be in English (ASCII only) to avoid issues with non-English characters.
+- Do not disable or skip tests to work around failures. Ensure all tests run.
 
 ## 5. Tests and Examples
 - Place the original Fortran code samples under “examples” and the test scripts under “tests.”

--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -1358,7 +1358,7 @@ class CallStatement(Node):
             if reverse:
                 for lhs, rhs in tmp_vars:
                     init_nodes.append(
-                        Assignment(lhs, OpReal("0.0", kind=lhs.kind))
+                        Assignment(lhs.add_suffix(AD_SUFFIX), OpReal("0.0", kind=lhs.kind))
                     )
                     ad_nodes.extend(
                         self._generate_ad_reverse(
@@ -4136,6 +4136,8 @@ class OmpDirective(Node):
                 new_clauses.append({key: vars})
                 continue
             if low_key == "reduction":
+                if reverse:
+                    continue
                 op, vars = values[0], list(values[1])
                 for v in list(vars):
                     ad = f"{v}{AD_SUFFIX}"

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -101,12 +101,17 @@ def _strip_sequential_omp(node: Node, warnings: Optional[List[str]], *, reverse:
         body = node.body
         if body is not None:
             body = _strip_sequential_omp(body, warnings, reverse=reverse)
-            if reverse and isinstance(body, DoLoop) and body.has_modified_indices():
+            check_body = body
+            if isinstance(body, Block):
+                children = list(body.iter_children())
+                if len(children) == 1 and isinstance(children[0], DoLoop):
+                    check_body = children[0]
+            if reverse and isinstance(check_body, DoLoop) and check_body.has_modified_indices():
                 if warnings is not None:
                     warnings.append(
                         "Dropped OpenMP directive: loop runs sequentially in reverse mode due to index dependency"
                     )
-                return body
+                return check_body
             node.body = body
         return node
 

--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -50,90 +50,69 @@ class TestFortranADCode(unittest.TestCase):
                 subprocess.run(cmd, check=True)
 
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_simple_math(self):
         self._run_test('simple_math', ['add_numbers', 'multiply_numbers', 'subtract_numbers', 'divide_numbers', 'power_numbers'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_arrays(self):
         self._run_test('arrays', ['elementwise_add', 'dot_product', 'multidimension',
                                   'scale_array', 'indirect', 'stencil'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_control_flow(self):
         self._run_test('control_flow', ['if_example', 'do_example', 'select_example',
                                        'do_while_example'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_intrinsic_func(self):
         self._run_test('intrinsic_func', ['casting', 'math', 'non_diff', 'special'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_save_vars(self):
         self._run_test('save_vars', ['simple', 'if_example', 'array_private',
                                      'array', 'local_array', 'stencil_array'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_cross_mod_call_inc(self):
         self._run_test('cross_mod', ['call_inc', 'incval', 'call_inc_kw'], deps=['cross_mod_a', 'cross_mod_b'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_call_example(self):
         self._run_test('call_example', ['call_subroutine', 'call_fucntion', 'arg_operation', 'arg_function',
                                        'foo', 'bar'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_real_kind(self):
         self._run_test('real_kind', ['scale_8', 'scale_rp', 'scale_dp'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_store_vars(self):
         self._run_test('store_vars', ['do_with_recurrent_scalar'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_directives(self):
         self._run_test('directives', ['add_const', 'worker'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_parameter_var(self):
         self._run_test('parameter_var', ['compute_area'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_module_vars(self):
         self._run_test('module_vars', ['inc_and_use'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_call_module_vars(self):
         self._run_test('call_module_vars', ['call_inc_and_use'], deps=['module_vars', 'call_module_vars'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_allocate(self):
         self._run_test('allocate_vars', ['allocate_and_sum', 'module_vars'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_exit_cycle(self):
         self._run_test('exit_cycle', ['do_exit_cycle', 'while_exit_cycle'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_pointer_arrays(self):
         self._run_test('pointer_arrays', ['pointer_allocate', 'pointer_subarray', 'pointer_allsub', 'pointer_swap'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_derived_alloc(self):
         self._run_test('derived_alloc', ['derived_alloc'])
 
     mpifort = shutil.which('mpifort')
 
-    @unittest.skipIf(compiler is None or mpirun is None or mpifort is None,
-                     'MPI compiler not available')
     def test_mpi_example(self):
         self._run_test('mpi_example', ['sum_reduce'], use_mpi=True)
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_where_forall(self):
         self._run_test('where_forall', ['where_example', 'forall_example'])
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_omp_loops(self):
         self._run_test('omp_loops', ['sum_loop', 'stencil_loop'])
 

--- a/tests/test_fortran_runtime.py
+++ b/tests/test_fortran_runtime.py
@@ -30,7 +30,6 @@ class TestFortranRuntime(unittest.TestCase):
         exe = tmp / target_out
         return exe
 
-    @unittest.skipIf(compiler is None, 'gfortran compiler not available')
     def test_stack_push_pop(self):
         base = Path(__file__).resolve().parents[1]
         src = base / 'fortran_modules' / 'fautodiff_stack.f90'

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -592,7 +592,9 @@ class TestGenerator(unittest.TestCase):
 def _make_example_test(src: Path):
     def test(self):
         code_tree.Node.reset()
-        generated = generator.generate_ad(str(src), warn=False)
+        generated = generator.generate_ad(
+            str(src), warn=False, search_dirs=[".", "examples", "fortran_modules"]
+        )
         expected = src.with_name(src.stem + "_ad.f90").read_text()
         self.assertEqual(generated, expected, msg=f"Mismatch for {src.name}")
 
@@ -601,18 +603,12 @@ def _make_example_test(src: Path):
 
 examples_dir = Path("examples")
 for _src in sorted(examples_dir.glob("*.f90")):
-    if _src.name.endswith("_ad.f90") or _src.stem in {"cross_mod_a", "cross_mod_b", "call_module_vars", "pointer_arrays", "mpi_example", "omp_loops", "call_example"}:
+    if _src.name.endswith("_ad.f90"):
         continue
     test_name = f"test_{_src.stem}"
+    if hasattr(TestGenerator, test_name):
+        continue
     setattr(TestGenerator, test_name, _make_example_test(_src))
-
-class TestPointerArrays(unittest.TestCase):
-    def test_pointer_arrays(self):
-        code_tree.Node.reset()
-        src = Path("examples/pointer_arrays.f90")
-        generated = generator.generate_ad(str(src), warn=False)
-        expected = src.with_name("pointer_arrays_ad.f90").read_text()
-        self.assertEqual(generated, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Initialize temporary adjoint variables before reverse-mode calls and regenerate example outputs
- Drop unnecessary OpenMP reduction and sequentialize reverse stencil loop
- Record module_vars metadata so generator can resolve module variables
- Ensure example test generation doesn't override explicit tests and remove stray generated `.fadmod`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689074d94504832da2b5d85f1ed37a58