### PR TITLE
Fix derivative intents in MPI reverse wrappers

### DIFF
--- a/examples/mpi_example_ad.f90
+++ b/examples/mpi_example_ad.f90
@@ -29,6 +29,7 @@ contains
     integer :: ierr
 
     tmp_ad = x_ad ! x = tmp
+    x_ad = 0.0 ! x = tmp
     call MPI_Allreduce_rev_ad(x_ad, tmp_ad, 1, MPI_REAL, MPI_SUM, comm, ierr) ! call MPI_Allreduce(x, tmp, 1, MPI_REAL, MPI_SUM, comm, ierr)
 
     return

--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -369,9 +369,12 @@ def parse_src(src, *, search_dirs=None, decl_map=None, type_map=None):
 
 
 def _load_fadmod_decls(mod_name: str, search_dirs: list[str]) -> dict:
-    """Return variable declaration info from ``mod_name`` fadmod file."""
-    if mod_name.lower() in INTRINSIC_MODULES:
-        return {}
+    """Return variable declaration info from ``mod_name`` fadmod file.
+
+    Intrinsic modules normally do not require accompanying ``.fadmod`` files,
+    but if such a file exists we load it automatically.
+    """
+
     for d in search_dirs:
         path = Path(d) / f"{mod_name}.fadmod"
         if path.exists():
@@ -382,7 +385,10 @@ def _load_fadmod_decls(mod_name: str, search_dirs: list[str]) -> dict:
                 raise RuntimeError(
                     f"invalid fadmod file for module {mod_name}: {exc}"
                 ) from exc
-            break
+
+    if mod_name.lower() in INTRINSIC_MODULES:
+        return {}
+
     raise RuntimeError(f"fadmod file not found for module {mod_name}")
 
 
@@ -429,7 +435,7 @@ def _parse_decl_stmt(
         if type_map is not None and name in type_map:
             type_def = type_map[name]
         elif name == "c_ptr": # tentative
-            type_def = TypeDef(name=name, components=[])
+            type_def = TypeDef(name=name, components=[], procs=[])
         else:
             raise RuntimeError(f"type definition not found: {name}")
     else:

--- a/fortran_modules/gen_mpi_fadmod.py
+++ b/fortran_modules/gen_mpi_fadmod.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import sys
 # Ensure the package can be imported when running from the source tree
-PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
@@ -70,7 +70,7 @@ def _collect_routines(mod, routines: Dict[str, dict]) -> Dict[str, dict]:
 
 def _interfaces_to_generics(mod) -> Dict[str, List[str]]:
     generics: Dict[str, List[str]] = {}
-    for node in mod.body.iter_children():
+    for node in mod.decls.iter_children():
         if not isinstance(node, Interface):
             continue
         m = _MODE_RE.match(node.name)
@@ -168,7 +168,9 @@ decl_map = {}
 for name, v in variables.items():
     v.update(common)
     dims = tuple(v.get("dims")) if "dims" in v else None
-    decl_map[name] = Declaration(name=name, typename="integer", dims=dims, parameter=True)
+    decl_map[name] = Declaration(
+        name=name, typename="integer", dims=dims, parameter=True
+    )
 
 def main() -> None:
     here = Path(__file__).resolve().parent

--- a/fortran_modules/mpi.fadmod
+++ b/fortran_modules/mpi.fadmod
@@ -843,7 +843,7 @@
         "ierr"
       ],
       "intents_rev_ad": [
-        "out",
+        "inout",
         "inout",
         "in",
         "in",
@@ -937,7 +937,7 @@
         "ierr"
       ],
       "intents_rev_ad": [
-        "out",
+        "inout",
         "inout",
         "in",
         "in",
@@ -1027,7 +1027,7 @@
         "ierr"
       ],
       "intents_rev_ad": [
-        "out",
+        "inout",
         "inout",
         "in",
         "in",
@@ -1117,7 +1117,7 @@
         "ierr"
       ],
       "intents_rev_ad": [
-        "out",
+        "inout",
         "inout",
         "in",
         "in",
@@ -1992,7 +1992,7 @@
         "in",
         "in",
         "in",
-        "out",
+        "inout",
         "out"
       ]
     },
@@ -2114,7 +2114,7 @@
         "in",
         "in",
         "in",
-        "out",
+        "inout",
         "out"
       ]
     },
@@ -2234,7 +2234,7 @@
         "in",
         "in",
         "in",
-        "out",
+        "inout",
         "out"
       ]
     },
@@ -2354,7 +2354,7 @@
         "in",
         "in",
         "in",
-        "out",
+        "inout",
         "out"
       ]
     },
@@ -2476,7 +2476,7 @@
         "in",
         "in",
         "in",
-        "out",
+        "inout",
         "out"
       ]
     },
@@ -2598,7 +2598,7 @@
         "in",
         "in",
         "in",
-        "out",
+        "inout",
         "out"
       ]
     },
@@ -2718,7 +2718,7 @@
         "in",
         "in",
         "in",
-        "out",
+        "inout",
         "out"
       ]
     },
@@ -2838,7 +2838,7 @@
         "in",
         "in",
         "in",
-        "out",
+        "inout",
         "out"
       ]
     },

--- a/fortran_modules/mpi_ad.f90
+++ b/fortran_modules/mpi_ad.f90
@@ -457,7 +457,7 @@ contains
   end subroutine mpi_allreduce_fwd_ad_r4
 
   subroutine mpi_allreduce_rev_ad_r4(sendbuf_ad, recvbuf_ad, count, datatype, op, comm, ierr)
-    real, intent(out) :: sendbuf_ad(*)
+    real, intent(inout) :: sendbuf_ad(*)
     real, intent(inout) :: recvbuf_ad(*)
     integer, intent(in) :: count, datatype, op, comm
     integer, intent(out), optional :: ierr
@@ -479,7 +479,7 @@ contains
   end subroutine mpi_allreduce_fwd_ad_r8
 
   subroutine mpi_allreduce_rev_ad_r8(sendbuf_ad, recvbuf_ad, count, datatype, op, comm, ierr)
-    real(8), intent(out) :: sendbuf_ad(*)
+    real(8), intent(inout) :: sendbuf_ad(*)
     real(8), intent(inout) :: recvbuf_ad(*)
     integer, intent(in) :: count, datatype, op, comm
     integer, intent(out), optional :: ierr
@@ -505,7 +505,7 @@ contains
   end subroutine mpi_allreduce_fwd_ad_scalar_r4
 
   subroutine mpi_allreduce_rev_ad_scalar_r4(sendbuf_ad, recvbuf_ad, count, datatype, op, comm, ierr)
-    real, intent(out), target :: sendbuf_ad
+    real, intent(inout), target :: sendbuf_ad
     real, intent(inout), target :: recvbuf_ad
     integer, intent(in) :: count, datatype, op, comm
     integer, intent(out), optional :: ierr
@@ -533,7 +533,7 @@ contains
   end subroutine mpi_allreduce_fwd_ad_scalar_r8
 
   subroutine mpi_allreduce_rev_ad_scalar_r8(sendbuf_ad, recvbuf_ad, count, datatype, op, comm, ierr)
-    real(8), intent(out), target :: sendbuf_ad
+    real(8), intent(inout), target :: sendbuf_ad
     real(8), intent(inout), target :: recvbuf_ad
     integer, intent(in) :: count, datatype, op, comm
     integer, intent(out), optional :: ierr
@@ -754,7 +754,7 @@ contains
   subroutine mpi_isend_rev_ad_r4(buf_ad, count, datatype, dest, tag, comm, request_ad, ierr)
     real, intent(inout) :: buf_ad(*)
     integer, intent(in) :: count, datatype, dest, tag, comm
-    integer, intent(out) :: request_ad
+    integer, intent(inout) :: request_ad
     integer, intent(out), optional :: ierr
     integer :: idx
 
@@ -813,7 +813,7 @@ contains
   subroutine mpi_isend_rev_ad_r8(buf_ad, count, datatype, dest, tag, comm, request_ad, ierr)
     real(8), intent(inout) :: buf_ad(*)
     integer, intent(in) :: count, datatype, dest, tag, comm
-    integer, intent(out) :: request_ad
+    integer, intent(inout) :: request_ad
     integer, intent(out), optional :: ierr
     integer :: idx
 
@@ -855,7 +855,7 @@ contains
   subroutine mpi_isend_rev_ad_scalar_r4(buf_ad, count, datatype, dest, tag, comm, request_ad, ierr)
     real, intent(inout), target :: buf_ad
     integer, intent(in) :: count, datatype, dest, tag, comm
-    integer, intent(out) :: request_ad
+    integer, intent(inout) :: request_ad
     integer, intent(out), optional :: ierr
     real, pointer :: b_ad(:)
 
@@ -890,7 +890,7 @@ contains
   subroutine mpi_isend_rev_ad_scalar_r8(buf_ad, count, datatype, dest, tag, comm, request_ad, ierr)
     real(8), intent(inout), target :: buf_ad
     integer, intent(in) :: count, datatype, dest, tag, comm
-    integer, intent(out) :: request_ad
+    integer, intent(inout) :: request_ad
     integer, intent(out), optional :: ierr
     real(8), pointer :: b_ad(:)
 
@@ -939,7 +939,7 @@ contains
   subroutine mpi_irecv_rev_ad_r4(buf_ad, count, datatype, source, tag, comm, request_ad, ierr)
     real, intent(inout), target :: buf_ad(*)
     integer, intent(in) :: count, datatype, source, tag, comm
-    integer, intent(out) :: request_ad
+    integer, intent(inout) :: request_ad
     integer, intent(out), optional :: ierr
     integer :: idx
 
@@ -996,7 +996,7 @@ contains
   subroutine mpi_irecv_rev_ad_r8(buf_ad, count, datatype, source, tag, comm, request_ad, ierr)
     real(8), intent(inout), target :: buf_ad(*)
     integer, intent(in) :: count, datatype, source, tag, comm
-    integer, intent(out) :: request_ad
+    integer, intent(inout) :: request_ad
     integer, intent(out), optional :: ierr
     integer :: idx
 
@@ -1041,7 +1041,7 @@ contains
   subroutine mpi_irecv_rev_ad_scalar_r4(buf_ad, count, datatype, source, tag, comm, request_ad, ierr)
     real, intent(inout), target :: buf_ad
     integer, intent(in) :: count, datatype, source, tag, comm
-    integer, intent(out) :: request_ad
+    integer, intent(inout) :: request_ad
     integer, intent(out), optional :: ierr
     real, pointer :: b_ad(:)
 
@@ -1076,7 +1076,7 @@ contains
   subroutine mpi_irecv_rev_ad_scalar_r8(buf_ad, count, datatype, source, tag, comm, request_ad, ierr)
     real(8), intent(inout), target :: buf_ad
     integer, intent(in) :: count, datatype, source, tag, comm
-    integer, intent(out) :: request_ad
+    integer, intent(inout) :: request_ad
     integer, intent(out), optional :: ierr
     real(8), pointer :: b_ad(:)
 


### PR DESCRIPTION
## Summary
- ensure MPI FAD module generator loads repository parser and scans interface declarations so generic mappings are retained
- regenerate `mpi.fadmod` with full generic metadata and update MPI example AD output
- let parser auto-load `iso_c_binding` constants so the generator no longer reads its fadmod directly

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_689077db9280832d99aa0c2a24019898