### PR TITLE
Handle intrinsic modules through fadmod files

### DIFF
--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -63,7 +63,6 @@ code_tree.REV_SUFFIX = REV_SUFFIX
 operators.AD_SUFFIX = AD_SUFFIX
 
 from . import parser
-from .parser import INTRINSIC_MODULES
 from .var_list import VarList
 
 
@@ -588,8 +587,6 @@ def _load_fadmods(mod_names: list[str], search_dirs: list[str]) -> tuple[dict, d
     variables = {}
     generics = {}
     for mod in mod_names:
-        if mod.lower() in INTRINSIC_MODULES:
-            continue
         found = False
         for d in search_dirs:
             path = Path(d) / f"{mod}.fadmod"

--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -74,18 +74,6 @@ from .operators import (
 
 _KIND_RE = re.compile(r"([\+\-])?([\d\.]+)([edED][\+\-]?\d+)?(?:_(.*))?$")
 
-# Modules provided by the Fortran standard or compiler that do not require
-# corresponding ``.fadmod`` files when ``use``d.
-INTRINSIC_MODULES = {
-    "iso_c_binding",
-    "iso_fortran_env",
-    "ieee_arithmetic",
-    "ieee_exceptions",
-    "ieee_features",
-    "omp_lib",
-}
-
-
 if parse(getattr(fparser, "__version__", "0")) < Version("0.2.0"):
     raise RuntimeError("fautodiff requires fparser version 0.2.0 or later")
 
@@ -369,11 +357,7 @@ def parse_src(src, *, search_dirs=None, decl_map=None, type_map=None):
 
 
 def _load_fadmod_decls(mod_name: str, search_dirs: list[str]) -> dict:
-    """Return variable declaration info from ``mod_name`` fadmod file.
-
-    Intrinsic modules normally do not require accompanying ``.fadmod`` files,
-    but if such a file exists we load it automatically.
-    """
+    """Return variable declaration info from ``mod_name`` fadmod file."""
 
     for d in search_dirs:
         path = Path(d) / f"{mod_name}.fadmod"
@@ -385,9 +369,6 @@ def _load_fadmod_decls(mod_name: str, search_dirs: list[str]) -> dict:
                 raise RuntimeError(
                     f"invalid fadmod file for module {mod_name}: {exc}"
                 ) from exc
-
-    if mod_name.lower() in INTRINSIC_MODULES:
-        return {}
 
     raise RuntimeError(f"fadmod file not found for module {mod_name}")
 

--- a/fortran_modules/ieee_arithmetic.fadmod
+++ b/fortran_modules/ieee_arithmetic.fadmod
@@ -1,0 +1,18 @@
+{
+  "routines": {
+    "ieee_is_nan": {
+      "module": "ieee_arithmetic",
+      "args": ["x", "result"],
+      "intents": ["in", "out"],
+      "dims": [null, null],
+      "type": ["real", "logical"],
+      "kind": [null, null]
+    }
+  },
+  "variables": {
+    "ieee_positive_inf": {"typename": "real", "parameter": true},
+    "ieee_negative_inf": {"typename": "real", "parameter": true},
+    "ieee_signaling_nan": {"typename": "real", "parameter": true},
+    "ieee_quiet_nan": {"typename": "real", "parameter": true}
+  }
+}

--- a/fortran_modules/ieee_exceptions.fadmod
+++ b/fortran_modules/ieee_exceptions.fadmod
@@ -1,0 +1,20 @@
+{
+  "routines": {
+    "ieee_get_flag": {
+      "module": "ieee_exceptions",
+      "args": ["flag", "value"],
+      "intents": ["in", "out"],
+      "dims": [null, null],
+      "type": ["integer", "logical"],
+      "kind": [null, null]
+    }
+  },
+  "variables": {
+    "ieee_all": {"typename": "integer", "parameter": true},
+    "ieee_invalid": {"typename": "integer", "parameter": true},
+    "ieee_overflow": {"typename": "integer", "parameter": true},
+    "ieee_divide_by_zero": {"typename": "integer", "parameter": true},
+    "ieee_underflow": {"typename": "integer", "parameter": true},
+    "ieee_inexact": {"typename": "integer", "parameter": true}
+  }
+}

--- a/fortran_modules/ieee_features.fadmod
+++ b/fortran_modules/ieee_features.fadmod
@@ -1,0 +1,16 @@
+{
+  "routines": {
+    "ieee_get_underflow_mode": {
+      "module": "ieee_features",
+      "args": ["mode"],
+      "intents": ["out"],
+      "dims": [null],
+      "type": ["integer"],
+      "kind": [null]
+    }
+  },
+  "variables": {
+    "ieee_denorm": {"typename": "integer", "parameter": true},
+    "ieee_rounding": {"typename": "integer", "parameter": true}
+  }
+}

--- a/fortran_modules/iso_fortran_env.fadmod
+++ b/fortran_modules/iso_fortran_env.fadmod
@@ -1,0 +1,13 @@
+{
+  "variables": {
+    "int8": {"typename": "integer", "parameter": true},
+    "int16": {"typename": "integer", "parameter": true},
+    "int32": {"typename": "integer", "parameter": true},
+    "int64": {"typename": "integer", "parameter": true},
+    "real32": {"typename": "real", "parameter": true},
+    "real64": {"typename": "real", "parameter": true},
+    "stdin": {"typename": "integer", "parameter": true},
+    "stdout": {"typename": "integer", "parameter": true},
+    "stderr": {"typename": "integer", "parameter": true}
+  }
+}

--- a/fortran_modules/omp_lib.fadmod
+++ b/fortran_modules/omp_lib.fadmod
@@ -1,0 +1,20 @@
+{
+  "routines": {
+    "omp_get_num_threads": {
+      "module": "omp_lib",
+      "args": ["result"],
+      "intents": ["out"],
+      "dims": [null],
+      "type": ["integer"],
+      "kind": [null]
+    },
+    "omp_get_thread_num": {
+      "module": "omp_lib",
+      "args": ["result"],
+      "intents": ["out"],
+      "dims": [null],
+      "type": ["integer"],
+      "kind": [null]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- remove intrinsic module whitelist and require fadmod descriptors
- add fadmod specs for ISO and IEEE standard modules and OpenMP

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_6890851c0904832d8ebd092602533745