### PR TITLE
Handle Fortran return statements in AD

### DIFF
--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -42,6 +42,7 @@ from .code_tree import (
     PreprocessorLine,
     ExitStmt,
     CycleStmt,
+    ReturnStmt,
     Subroutine,
     Use,
     Allocate,
@@ -1522,7 +1523,7 @@ def _parse_routine(content,
                 return OmpDirective(omp_info[0], omp_info[1], loop)
             return loop
         if isinstance(stmt, Fortran2003.Return_Stmt):
-            return Statement("return")
+            return ReturnStmt()
         if isinstance(stmt, Fortran2003.Exit_Stmt):
             label = stmt.items[1].string if stmt.items[1] is not None else None
             return ExitStmt(label=label)


### PR DESCRIPTION
## Summary
- add a dedicated `ReturnStmt` node that supports flagging and AD generation
- parse `RETURN` statements into the new `ReturnStmt`
- strip empty OpenMP directives and clean forward bodies when building reverse AD

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_6891bfe680ec832d97ff13d48f965598