### PR TITLE
Refactor VarDict typing for mypy

### DIFF
--- a/fautodiff/__init__.py
+++ b/fautodiff/__init__.py
@@ -1,12 +1,22 @@
 """Public API for fautodiff."""
 
-import fparser
+import importlib
+from typing import Any
+
+import fparser  # type: ignore[import-untyped]
 from packaging.version import Version, parse
 
 if parse(getattr(fparser, "__version__", "0")) < Version("0.2.0"):
     raise RuntimeError("fautodiff requires fparser version 0.2.0 or later")
 
-from . import parser
-from .generator import generate_ad
-
 __all__ = ["parser", "generate_ad"]
+
+
+def __getattr__(name: str) -> Any:
+    """Dynamically import exported members."""
+
+    if name == "parser":
+        return importlib.import_module(".parser", __name__)
+    if name == "generate_ad":
+        return importlib.import_module(".generator", __name__).generate_ad
+    raise AttributeError(name)

--- a/fautodiff/var_dict.py
+++ b/fautodiff/var_dict.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Dict, Generic, Iterable, Iterator, List, Tuple, TypeVar
 
-class VarDict:
+KT = TypeVar("KT")
+VT = TypeVar("VT")
+
+
+class VarDict(Generic[KT, VT]):
     """Ordered dictionary with a minimal API.
 
     This class mimics part of :class:`dict` while preserving insertion order.
@@ -13,43 +18,43 @@ class VarDict:
     """
 
     def __init__(self) -> None:
-        self._data: dict = {}
+        self._data: Dict[KT, VT] = {}
 
-    def __setitem__(self, key, value) -> None:
+    def __setitem__(self, key: KT, value: VT) -> None:
         """Set ``key`` to ``value`` preserving insertion order."""
         self._data[key] = value
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: KT) -> VT:
         return self._data[key]
 
-    def __contains__(self, key) -> bool:
+    def __contains__(self, key: object) -> bool:
         return key in self._data
 
-    def __delitem__(self, key) -> None:
+    def __delitem__(self, key: KT) -> None:
         del self._data[key]
 
-    def keys(self):
+    def keys(self) -> List[KT]:
         return list(self._data.keys())
 
-    def values(self):
+    def values(self) -> List[VT]:
         return list(self._data.values())
 
-    def items(self):
+    def items(self) -> List[Tuple[KT, VT]]:
         return list(self._data.items())
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._data)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[KT]:
         return iter(self._data)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return ", ".join(f"{k}=>{v}" for k, v in self._data.items())
 
-    def remove(self, key) -> None:
+    def remove(self, key: KT) -> None:
         self._data.pop(key)
 
-    def copy(self) -> "VarDict":
+    def copy(self) -> "VarDict[KT, VT]":
         obj = type(self)()
         obj._data = self._data.copy()
         return obj

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+files = fautodiff
+
+[mypy-fautodiff.*]
+ignore_errors = True
+
+[mypy-fautodiff.var_dict]
+ignore_errors = False
+
+[mypy-fautodiff.__init__]
+ignore_errors = False


### PR DESCRIPTION
## Summary
- add generic type annotations to VarDict
- lazily import heavy modules in __init__
- configure mypy to scan entire package while only enforcing checks in typed modules

## Testing
- `python tests/test_generator.py`
- `mypy`


------
https://chatgpt.com/codex/tasks/task_b_6893121d4964832db1ea5af711aa425e