### PR TITLE
Fix rendering for subtraction of sums

### DIFF
--- a/fautodiff/operators.py
+++ b/fautodiff/operators.py
@@ -1363,8 +1363,10 @@ class OpBinary(Operator):
 
     def __str__(self) -> str:
         a0 = self._paren(self.args[0])
-        eq = isinstance(self.args[1], OpNeg) or (
-            isinstance(self, OpDiv) and isinstance(self.args[1], OpMul)
+        eq = (
+            isinstance(self.args[1], OpNeg)
+            or (isinstance(self, OpDiv) and isinstance(self.args[1], (OpMul, OpDiv)))
+            or (isinstance(self, OpSub) and isinstance(self.args[1], (OpAdd, OpSub)))
         )
         a1 = self._paren(self.args[1], eq=eq)
         return f"{a0} {self.OP} {a1}"

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -79,6 +79,14 @@ class TestOperatorsBasic(unittest.TestCase):
         self.assertEqual(n + (one - n), one)
         self.assertEqual(n + (-one - n), -one)
 
+    def test_sub_with_addition(self):
+        a = OpVar("a")
+        b = OpVar("b")
+        c = OpVar("c")
+        d = OpVar("d")
+        expr = (a + b) - (c + d)
+        self.assertEqual(str(expr), "a + b - (c + d)")
+
     def test_power_special_cases(self):
         x = OpVar("x")
         self.assertEqual(str(x ** OpInt(0)), "1")


### PR DESCRIPTION
## Summary
- ensure subtraction keeps grouped additions by adding parentheses
- add regression test for subtracting sums

## Testing
- `pytest tests/test_operators.py::TestOperatorsBasic::test_sub_with_addition -q`
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_68946e37c41c832dbc7563ec0308af28