### PR TITLE
Fix reverse-mode slice assignment gradient propagation

### DIFF
--- a/examples/array_slice.f90
+++ b/examples/array_slice.f90
@@ -1,25 +1,47 @@
 
 module array_slice
+
 contains
   subroutine slice_copy(u, n, m, i, j)
     integer, intent(in) :: n, m, i, j
-    real :: u(:)
+    real, intent(inout) :: u(:)
+
     u(n:m) = u(i:j)
+
+    return
   end subroutine slice_copy
 
-  subroutine slice_copy_ptr(u, n, m, i, j)
+  subroutine slice_copy_ptr(u, v, n, m, i, j)
     integer, intent(in) :: n, m, i, j
-    real, target :: u(:)
-    real, pointer :: p(:)
+    real, intent(inout), target :: u(:), v(:)
+    real, pointer :: p(:), q(:)
+    integer :: k
+
     p => u
-    u(n:m) = p(i:j)
+    q => v
+    do k = n, m
+      u(k) = p(i+k-n)
+    end do
+    v(n:m) = p(i:j) + q(i:j)
+    u(n:m) = u(n:m) + q(i:j)
+
+    return
   end subroutine slice_copy_ptr
 
-  subroutine slice_copy_expr(u, v, w, n, m, i, j)
-    integer, intent(in) :: n, m, i, j
-    real :: u(:)
-    real :: v(:)
-    real :: w(:)
-    u(n:m) = v(i:j) + w(i:j)
+  subroutine slice_copy_expr(u, v, w, n, m, i, j, l1, l2)
+    integer, intent(in) :: n, m, i, j, l1, l2
+    real, intent(inout) :: u(:,:)
+    real, intent(in) :: v(:,:)
+    real, intent(inout) :: w(:,:)
+    integer :: k1, k2
+
+    u(n:n+l1-1,m:m+l2-1) = v(i:i+l1-1,j:j+l2-1) * u(i:i+l1-1,j:j+l2-1)
+    do k2 = 1, l2
+      do k1 = 1, l1
+        w(n+k1-1,m+k2-1) = w(i+k1-1,j+k2-1) * v(i+k1-1,j+k2-1)
+      end do
+    end do
+
+    return
   end subroutine slice_copy_expr
 end module array_slice

--- a/examples/array_slice.f90
+++ b/examples/array_slice.f90
@@ -1,0 +1,25 @@
+
+module array_slice
+contains
+  subroutine slice_copy(u, n, m, i, j)
+    integer, intent(in) :: n, m, i, j
+    real :: u(:)
+    u(n:m) = u(i:j)
+  end subroutine slice_copy
+
+  subroutine slice_copy_ptr(u, n, m, i, j)
+    integer, intent(in) :: n, m, i, j
+    real, target :: u(:)
+    real, pointer :: p(:)
+    p => u
+    u(n:m) = p(i:j)
+  end subroutine slice_copy_ptr
+
+  subroutine slice_copy_expr(u, v, w, n, m, i, j)
+    integer, intent(in) :: n, m, i, j
+    real :: u(:)
+    real :: v(:)
+    real :: w(:)
+    u(n:m) = v(i:j) + w(i:j)
+  end subroutine slice_copy_expr
+end module array_slice

--- a/examples/array_slice_ad.f90
+++ b/examples/array_slice_ad.f90
@@ -5,8 +5,8 @@ module array_slice_ad
 contains
 
   subroutine slice_copy_fwd_ad(u, u_ad, n, m, i, j)
-    real :: u(:)
-    real :: u_ad(:)
+    real, intent(inout) :: u(:)
+    real, intent(inout) :: u_ad(:)
     integer, intent(in)  :: n
     integer, intent(in)  :: m
     integer, intent(in)  :: i
@@ -19,94 +19,155 @@ contains
   end subroutine slice_copy_fwd_ad
 
   subroutine slice_copy_rev_ad(u, u_ad, n, m, i, j)
+    real, intent(inout) :: u(:)
     real, intent(inout) :: u_ad(:)
     integer, intent(in)  :: n
     integer, intent(in)  :: m
     integer, intent(in)  :: i
     integer, intent(in)  :: j
-    integer :: i0_12
+    integer :: n1_12_ad
     real :: tmp_save_12_ad
 
-    do i0_12 = 1, m - n + 1
-      tmp_save_12_ad = u_ad(n + i0_12 - 1) ! u(n:m) = u(i:j)
-      u_ad(n + i0_12 - 1) = 0.0 ! u(n:m) = u(i:j)
-      u_ad(i + i0_12 - 1) = tmp_save_12_ad + u_ad(i + i0_12 - 1) ! u(n:m) = u(i:j)
+    do n1_12_ad = n, m
+      tmp_save_12_ad = u_ad(n1_12_ad) ! u(n:m) = u(i:j)
+      u_ad(n1_12_ad) = 0.0 ! u(n:m) = u(i:j)
+      u_ad(i + n1_12_ad - n) = tmp_save_12_ad + u_ad(i + n1_12_ad - n) ! u(n:m) = u(i:j)
     end do
 
     return
   end subroutine slice_copy_rev_ad
 
-  subroutine slice_copy_ptr_fwd_ad(u, u_ad, n, m, i, j)
-    real, target :: u(:)
-    real, target :: u_ad(:)
+  subroutine slice_copy_ptr_fwd_ad(u, u_ad, v, v_ad, n, m, i, j)
+    real, intent(inout), target :: u(:)
+    real, intent(inout), target :: u_ad(:)
+    real, intent(inout), target :: v(:)
+    real, intent(inout), target :: v_ad(:)
     integer, intent(in)  :: n
     integer, intent(in)  :: m
     integer, intent(in)  :: i
     integer, intent(in)  :: j
     real, pointer :: p_ad(:)
+    real, pointer :: q_ad(:)
     real, pointer :: p(:)
+    real, pointer :: q(:)
+    integer :: k
 
     p_ad => u_ad ! p => u
     p => u
-    u_ad(n:m) = p_ad(i:j) ! u(n:m) = p(i:j)
-    u(n:m) = p(i:j)
-    p_ad => null()
-    p => null()
+    q_ad => v_ad ! q => v
+    q => v
+    do k = n, m
+      u_ad(k) = p_ad(i + k - n) ! u(k) = p(i+k-n)
+      u(k) = p(i + k - n)
+    end do
+    v_ad(n:m) = p_ad(i:j) + q_ad(i:j) ! v(n:m) = p(i:j) + q(i:j)
+    v(n:m) = p(i:j) + q(i:j)
+    u_ad(n:m) = u_ad(n:m) + q_ad(i:j) ! u(n:m) = u(n:m) + q(i:j)
+    u(n:m) = u(n:m) + q(i:j)
 
     return
   end subroutine slice_copy_ptr_fwd_ad
 
-  subroutine slice_copy_ptr_rev_ad(u, u_ad, n, m, i, j)
+  subroutine slice_copy_ptr_rev_ad(u, u_ad, v, v_ad, n, m, i, j)
+    real, intent(inout), target :: u(:)
     real, intent(inout), target :: u_ad(:)
+    real, intent(inout), target :: v(:)
+    real, intent(inout), target :: v_ad(:)
     integer, intent(in)  :: n
     integer, intent(in)  :: m
     integer, intent(in)  :: i
     integer, intent(in)  :: j
     real, pointer :: p_ad(:)
-    integer :: i0_25
-    real :: tmp_save_25_ad
+    real, pointer :: q_ad(:)
+    integer :: k
+    real :: tmp_save_31_ad
+    integer :: n1_33_ad
+    real :: tmp_save_33_ad
 
+    q_ad => v_ad
     p_ad => u_ad
-    do i0_25 = 1, m - n + 1
-      tmp_save_25_ad = u_ad(n + i0_25 - 1) ! u(n:m) = p(i:j)
-      u_ad(n + i0_25 - 1) = 0.0 ! u(n:m) = p(i:j)
-      p_ad(i + i0_25 - 1) = tmp_save_25_ad + p_ad(i + i0_25 - 1) ! u(n:m) = p(i:j)
+    q_ad(i:j) = u_ad(n:m) + q_ad(i:j) ! u(n:m) = u(n:m) + q(i:j)
+    do n1_33_ad = n, m
+      tmp_save_33_ad = v_ad(n1_33_ad) ! v(n:m) = p(i:j) + q(i:j)
+      v_ad(n1_33_ad) = 0.0 ! v(n:m) = p(i:j) + q(i:j)
+      p_ad(i + n1_33_ad - n) = tmp_save_33_ad + p_ad(i + n1_33_ad - n) ! v(n:m) = p(i:j) + q(i:j)
+      q_ad(i + n1_33_ad - n) = tmp_save_33_ad + q_ad(i + n1_33_ad - n) ! v(n:m) = p(i:j) + q(i:j)
     end do
+    do k = m, n, - 1
+      tmp_save_31_ad = u_ad(k) ! u(k) = p(i+k-n)
+      u_ad(k) = 0.0 ! u(k) = p(i+k-n)
+      p_ad(i + k - n) = tmp_save_31_ad + p_ad(i + k - n) ! u(k) = p(i+k-n)
+    end do
+    q_ad => null() ! q => v
     p_ad => null() ! p => u
 
     return
   end subroutine slice_copy_ptr_rev_ad
 
-  subroutine slice_copy_expr_fwd_ad(u, u_ad, v, v_ad, w, w_ad, n, m, i, j)
-    real :: u(:)
-    real :: u_ad(:)
-    real :: v(:)
-    real :: v_ad(:)
-    real :: w(:)
-    real :: w_ad(:)
+  subroutine slice_copy_expr_fwd_ad(u, u_ad, v, v_ad, w, w_ad, n, m, i, j, l1, l2)
+    real, intent(inout) :: u(:,:)
+    real, intent(inout) :: u_ad(:,:)
+    real, intent(in)  :: v(:,:)
+    real, intent(in)  :: v_ad(:,:)
+    real, intent(inout) :: w(:,:)
+    real, intent(inout) :: w_ad(:,:)
     integer, intent(in)  :: n
     integer, intent(in)  :: m
     integer, intent(in)  :: i
     integer, intent(in)  :: j
+    integer, intent(in)  :: l1
+    integer, intent(in)  :: l2
+    integer :: k1
+    integer :: k2
 
-    u_ad(n:m) = v_ad(i:j) + w_ad(i:j) ! u(n:m) = v(i:j) + w(i:j)
-    u(n:m) = v(i:j) + w(i:j)
+    u_ad(n:n + l1 - 1,m:m + l2 - 1) = v_ad(i:i + l1 - 1,j:j + l2 - 1) * u(i:i + l1 - 1,j:j + l2 - 1) + u_ad(i:i + l1 - 1,j:j + l2 - 1) * v(i:i + l1 - 1,j:j + l2 - 1) ! u(n:n+l1-1,m:m+l2-1) = v(i:i+l1-1,j:j+l2-1) * u(i:i+l1-1,j:j+l2-1)
+    u(n:n + l1 - 1,m:m + l2 - 1) = v(i:i + l1 - 1,j:j + l2 - 1) * u(i:i + l1 - 1,j:j + l2 - 1)
+    do k2 = 1, l2
+      do k1 = 1, l1
+        w_ad(n + k1 - 1,m + k2 - 1) = w_ad(i + k1 - 1,j + k2 - 1) * v(i + k1 - 1,j + k2 - 1) + v_ad(i + k1 - 1,j + k2 - 1) * w(i + k1 - 1,j + k2 - 1) ! w(n+k1-1,m+k2-1) = w(i+k1-1,j+k2-1) * v(i+k1-1,j+k2-1)
+        w(n + k1 - 1,m + k2 - 1) = w(i + k1 - 1,j + k2 - 1) * v(i + k1 - 1,j + k2 - 1)
+      end do
+    end do
 
     return
   end subroutine slice_copy_expr_fwd_ad
 
-  subroutine slice_copy_expr_rev_ad(u, u_ad, v, v_ad, w, w_ad, n, m, i, j)
-    real, intent(inout) :: u_ad(:)
-    real, intent(inout) :: v_ad(:)
-    real, intent(inout) :: w_ad(:)
+  subroutine slice_copy_expr_rev_ad(u, u_ad, v, v_ad, w, w_ad, n, m, i, j, l1, l2)
+    real, intent(inout) :: u(:,:)
+    real, intent(inout) :: u_ad(:,:)
+    real, intent(in)  :: v(:,:)
+    real, intent(inout) :: v_ad(:,:)
+    real, intent(inout) :: w(:,:)
+    real, intent(inout) :: w_ad(:,:)
     integer, intent(in)  :: n
     integer, intent(in)  :: m
     integer, intent(in)  :: i
     integer, intent(in)  :: j
+    integer, intent(in)  :: l1
+    integer, intent(in)  :: l2
+    integer :: k1
+    integer :: k2
+    integer :: n2_52_ad
+    integer :: n1_52_ad
+    real :: tmp_save_52_ad
+    real :: tmp_save_55_ad
 
-    v_ad(i:j) = u_ad(n:m) + v_ad(i:j) ! u(n:m) = v(i:j) + w(i:j)
-    w_ad(i:j) = u_ad(n:m) + w_ad(i:j) ! u(n:m) = v(i:j) + w(i:j)
-    u_ad(n:m) = 0.0 ! u(n:m) = v(i:j) + w(i:j)
+    do k2 = l2, 1, - 1
+      do k1 = l1, 1, - 1
+        tmp_save_55_ad = w_ad(n + k1 - 1,m + k2 - 1) ! w(n+k1-1,m+k2-1) = w(i+k1-1,j+k2-1) * v(i+k1-1,j+k2-1)
+        w_ad(n + k1 - 1,m + k2 - 1) = 0.0 ! w(n+k1-1,m+k2-1) = w(i+k1-1,j+k2-1) * v(i+k1-1,j+k2-1)
+        w_ad(i + k1 - 1,j + k2 - 1) = tmp_save_55_ad * v(i + k1 - 1,j + k2 - 1) + w_ad(i + k1 - 1,j + k2 - 1) ! w(n+k1-1,m+k2-1) = w(i+k1-1,j+k2-1) * v(i+k1-1,j+k2-1)
+        v_ad(i + k1 - 1,j + k2 - 1) = tmp_save_55_ad * w(i + k1 - 1,j + k2 - 1) + v_ad(i + k1 - 1,j + k2 - 1) ! w(n+k1-1,m+k2-1) = w(i+k1-1,j+k2-1) * v(i+k1-1,j+k2-1)
+      end do
+    end do
+    do n2_52_ad = m, m + l2 - 1
+      do n1_52_ad = n, n + l1 - 1
+        tmp_save_52_ad = u_ad(n1_52_ad,n2_52_ad) ! u(n:n+l1-1,m:m+l2-1) = v(i:i+l1-1,j:j+l2-1) * u(i:i+l1-1,j:j+l2-1)
+        u_ad(n1_52_ad,n2_52_ad) = 0.0 ! u(n:n+l1-1,m:m+l2-1) = v(i:i+l1-1,j:j+l2-1) * u(i:i+l1-1,j:j+l2-1)
+        v_ad(i + n1_52_ad - n,j + n2_52_ad - m) = tmp_save_52_ad * u(i + n1_52_ad - n,j + n2_52_ad - m) + v_ad(i + n1_52_ad - n,j + n2_52_ad - m) ! u(n:n+l1-1,m:m+l2-1) = v(i:i+l1-1,j:j+l2-1) * u(i:i+l1-1,j:j+l2-1)
+        u_ad(i + n1_52_ad - n,j + n2_52_ad - m) = tmp_save_52_ad * v(i + n1_52_ad - n,j + n2_52_ad - m) + u_ad(i + n1_52_ad - n,j + n2_52_ad - m) ! u(n:n+l1-1,m:m+l2-1) = v(i:i+l1-1,j:j+l2-1) * u(i:i+l1-1,j:j+l2-1)
+      end do
+    end do
 
     return
   end subroutine slice_copy_expr_rev_ad

--- a/examples/array_slice_ad.f90
+++ b/examples/array_slice_ad.f90
@@ -1,0 +1,114 @@
+module array_slice_ad
+  use array_slice
+  implicit none
+
+contains
+
+  subroutine slice_copy_fwd_ad(u, u_ad, n, m, i, j)
+    real :: u(:)
+    real :: u_ad(:)
+    integer, intent(in)  :: n
+    integer, intent(in)  :: m
+    integer, intent(in)  :: i
+    integer, intent(in)  :: j
+
+    u_ad(n:m) = u_ad(i:j) ! u(n:m) = u(i:j)
+    u(n:m) = u(i:j)
+
+    return
+  end subroutine slice_copy_fwd_ad
+
+  subroutine slice_copy_rev_ad(u, u_ad, n, m, i, j)
+    real, intent(inout) :: u_ad(:)
+    integer, intent(in)  :: n
+    integer, intent(in)  :: m
+    integer, intent(in)  :: i
+    integer, intent(in)  :: j
+    integer :: i0_12
+    real :: tmp_save_12_ad
+
+    do i0_12 = 1, m - n + 1
+      tmp_save_12_ad = u_ad(n + i0_12 - 1) ! u(n:m) = u(i:j)
+      u_ad(n + i0_12 - 1) = 0.0 ! u(n:m) = u(i:j)
+      u_ad(i + i0_12 - 1) = tmp_save_12_ad + u_ad(i + i0_12 - 1) ! u(n:m) = u(i:j)
+    end do
+
+    return
+  end subroutine slice_copy_rev_ad
+
+  subroutine slice_copy_ptr_fwd_ad(u, u_ad, n, m, i, j)
+    real, target :: u(:)
+    real, target :: u_ad(:)
+    integer, intent(in)  :: n
+    integer, intent(in)  :: m
+    integer, intent(in)  :: i
+    integer, intent(in)  :: j
+    real, pointer :: p_ad(:)
+    real, pointer :: p(:)
+
+    p_ad => u_ad ! p => u
+    p => u
+    u_ad(n:m) = p_ad(i:j) ! u(n:m) = p(i:j)
+    u(n:m) = p(i:j)
+    p_ad => null()
+    p => null()
+
+    return
+  end subroutine slice_copy_ptr_fwd_ad
+
+  subroutine slice_copy_ptr_rev_ad(u, u_ad, n, m, i, j)
+    real, intent(inout), target :: u_ad(:)
+    integer, intent(in)  :: n
+    integer, intent(in)  :: m
+    integer, intent(in)  :: i
+    integer, intent(in)  :: j
+    real, pointer :: p_ad(:)
+    integer :: i0_25
+    real :: tmp_save_25_ad
+
+    p_ad => u_ad
+    do i0_25 = 1, m - n + 1
+      tmp_save_25_ad = u_ad(n + i0_25 - 1) ! u(n:m) = p(i:j)
+      u_ad(n + i0_25 - 1) = 0.0 ! u(n:m) = p(i:j)
+      p_ad(i + i0_25 - 1) = tmp_save_25_ad + p_ad(i + i0_25 - 1) ! u(n:m) = p(i:j)
+    end do
+    p_ad => null() ! p => u
+
+    return
+  end subroutine slice_copy_ptr_rev_ad
+
+  subroutine slice_copy_expr_fwd_ad(u, u_ad, v, v_ad, w, w_ad, n, m, i, j)
+    real :: u(:)
+    real :: u_ad(:)
+    real :: v(:)
+    real :: v_ad(:)
+    real :: w(:)
+    real :: w_ad(:)
+    integer, intent(in)  :: n
+    integer, intent(in)  :: m
+    integer, intent(in)  :: i
+    integer, intent(in)  :: j
+
+    u_ad(n:m) = v_ad(i:j) + w_ad(i:j) ! u(n:m) = v(i:j) + w(i:j)
+    u(n:m) = v(i:j) + w(i:j)
+
+    return
+  end subroutine slice_copy_expr_fwd_ad
+
+  subroutine slice_copy_expr_rev_ad(u, u_ad, v, v_ad, w, w_ad, n, m, i, j)
+    real, intent(inout) :: u_ad(:)
+    real, intent(inout) :: v_ad(:)
+    real, intent(inout) :: w_ad(:)
+    integer, intent(in)  :: n
+    integer, intent(in)  :: m
+    integer, intent(in)  :: i
+    integer, intent(in)  :: j
+
+    v_ad(i:j) = u_ad(n:m) + v_ad(i:j) ! u(n:m) = v(i:j) + w(i:j)
+    w_ad(i:j) = u_ad(n:m) + w_ad(i:j) ! u(n:m) = v(i:j) + w(i:j)
+    u_ad(n:m) = 0.0 ! u(n:m) = v(i:j) + w(i:j)
+
+    return
+  end subroutine slice_copy_expr_rev_ad
+
+end module array_slice_ad

--- a/examples/arrays_ad.f90
+++ b/examples/arrays_ad.f90
@@ -162,8 +162,6 @@ contains
     integer, intent(in)  :: idx(n)
     integer :: i
 
-    c_ad(:) = 0.0
-
     do i = 1, n
       b_ad(i) = a_ad(idx(i)) ! b(i) = a(idx(i)) + 1.0
       b(i) = a(idx(i)) + 1.0

--- a/examples/where_forall_ad.f90
+++ b/examples/where_forall_ad.f90
@@ -46,8 +46,6 @@ contains
     real, intent(out) :: b_ad(n)
     integer :: i
 
-    b_ad(:) = 0.0
-
     forall (i=1:n)
       b_ad(i) = a_ad(i) * 2.0 ! b(i) = 2.0 * a(i)
       b(i) = 2.0 * a(i)

--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -93,17 +93,17 @@ class Node:
 
     def has_reference_to(self, var: str) -> bool:
         """Return ``True`` if ``var`` is refered within this node."""
-        if any(var == v.name for v in self.iter_ref_vars()):
+        if any(var.is_same_var(v) for v in self.iter_ref_vars()):
             return True
         return any(child.has_reference_to(var) for child in self.iter_children())
 
-    def has_assignment_to(self, var: str) -> bool:
+    def has_assignment_to(self, var: OpVar) -> bool:
         """Return ``True`` if ``var`` is assigned within this node."""
-        if any(var == v.name for v in self.iter_assign_vars()):
+        if any(var.is_same_var(v) for v in self.iter_assign_vars()):
             return True
         return any(child.has_assignment_to(var) for child in self.iter_children())
 
-    def has_access_to(self, var: str) -> bool:
+    def has_access_to(self, var: OpVar) -> bool:
         """Return ``True`` if ``var`` is accessed within this node."""
         if self.has_assignment_to(var):
             return True
@@ -652,59 +652,6 @@ class Node:
         rhs = rhs.deep_clone()
         extras: List[Node] = []
 
-        # Special handling for assignments between slices of the same array or
-        # potentially aliased arrays (e.g., pointer associations).  Copy each
-        # element of the adjoint of the left-hand slice to a temporary scalar,
-        # clear the source element, and accumulate it into the destination
-        # element inside explicit loops.
-        if (
-            isinstance(rhs, OpVar)
-            and isinstance(lhs, OpVar)
-            and self._may_alias(lhs, rhs)
-            and lhs.index is not None
-            and rhs.index is not None
-        ):
-            grad_lhs = lhs.add_suffix(AD_SUFFIX)
-            grad_rhs = rhs.add_suffix(AD_SUFFIX)
-            ad_info = self.info.get("code") if self.info is not None else None
-            tmp = OpVar(
-                self._save_var_name("tmp", self.get_id()),
-                typename=grad_lhs.typename,
-                kind=grad_lhs.kind,
-            )
-            saved_vars.append(tmp)
-
-            lhs_idx = lhs.index.deep_clone()
-            rhs_idx = rhs.index.deep_clone()
-            gl = grad_lhs.deep_clone()
-            gr = grad_rhs.deep_clone()
-            gl.index = lhs_idx
-            gr.index = rhs_idx
-
-            body: Block = Block(
-                [
-                    Assignment(tmp, gl, ad_info=ad_info),
-                    ClearAssignment(gl, ad_info=ad_info),
-                    Assignment(gr, tmp + gr, ad_info=ad_info),
-                ]
-            )
-
-            for dim in reversed(range(len(lhs_idx))):
-                ldim = lhs_idx[dim]
-                rdim = rhs_idx[dim]
-                if not isinstance(ldim, OpRange) or not isinstance(rdim, OpRange):
-                    break
-                idx_var = OpVar(f"i{dim}_{self.get_id()}", typename="integer")
-                saved_vars.append(idx_var)
-                length = ldim[1] - ldim[0] + OpInt(1)
-                lhs_idx[dim] = ldim[0] + idx_var - OpInt(1)
-                rhs_idx[dim] = rdim[0] + idx_var - OpInt(1)
-                rng = OpRange([OpInt(1), length])
-                body = Block([DoLoop(body, idx_var, rng)])
-
-            assigns = list(body.iter_children())
-            assigns.extend(extras)
-            return assigns
         # Handle user defined functions appearing in the expression first
         funcs = rhs.find_userfunc()
         for n, ufunc in enumerate(funcs):
@@ -775,25 +722,121 @@ class Node:
                     assigns.extend(extras)
                     return assigns
 
-            vars = rhs.collect_vars(without_index=True, without_refvar=True)
-            if lhs in vars:
+            rhs_vars = rhs.collect_vars(without_index=True, without_refvar=True)
+
+            # Special handling for assignments between slices of the same array or
+            # potentially aliased arrays (e.g., pointer associations).  Copy each
+            # element of the adjoint of the left-hand slice to a temporary scalar,
+            # clear the source element, and accumulate it into the destination
+            # element inside explicit loops.
+            flag = False
+            if lhs.index is not None:
+                for var in rhs_vars:
+                    if not var.ad_target:
+                        continue
+                    if (
+                        isinstance(var, OpVar)
+                        and self._may_alias(lhs, var)
+                        and var.index is not None
+                        and not lhs == var
+                    ):
+                        if lhs.name == var.name:
+                            for dim in range(len(lhs.index)):
+                                idx1 = lhs.index[dim]
+                                idx2 = var.index[dim]
+                                if isinstance(idx1, OpRange) or isinstance(idx2, OpRange):
+                                    flag = True
+                                    break
+                                diff = idx1 - idx2
+                                if not (isinstance(diff, OpInt) or (isinstance(diff, OpNeg) and isinstance(diff.args[0], OpInt))):
+                                    flag = True
+                                    break
+                            break
+                        flag = True
+                        break
+            if flag:
+                tmp_var = OpVar(
+                    self._save_var_name("tmp", self.get_id()),
+                    typename=grad_lhs.typename,
+                    kind=grad_lhs.kind,
+                )
+                saved_vars.append(tmp_var)
+                lhs_index: List[Operator] = []
+                index_vars: List[Tuple[OpVar, OpRange]] = []
+                for dim in range(len(lhs.index)):
+                    ldim = lhs.index[dim]
+                    if not isinstance(ldim, OpRange):
+                        lhs_index.append(ldim)
+                        continue
+                    if ldim[2] is not None and ldim[2] != OpInt(1):
+                        raise NotImplementedError(f"stride access is not supported: {lhs}")
+                    idx_var = OpVar(f"n{dim+1}_{self.get_id()}_ad", typename="integer")
+                    saved_vars.append(idx_var)
+                    index_vars.append((idx_var, ldim))
+                    lhs_index.append(idx_var)
+                gl = grad_lhs.change_index(lhs_index)
+                body: Block = Block(
+                    [
+                        Assignment(tmp_var, gl, ad_info=ad_info),
+                        ClearAssignment(gl, ad_info=ad_info),
+                    ]
+                )
+                for var in rhs_vars:
+                    if not var.ad_target:
+                        continue
+                    rhs_index: List[Operator] = []
+                    idx = 0
+                    for dim in range(len(var.index)):
+                        rdim = var.index[dim]
+                        if not isinstance(rdim, OpRange):
+                            rhs_index.append(rdim)
+                            continue
+                        if rdim[2] is not None and rdim[2] != OpInt(1):
+                            raise NotImplementedError(f"stride access is not supported: {var}")
+                        idx_var, ldim = index_vars[idx]
+                        idx += 1
+                        rhs_index.append(rdim[0] + idx_var - ldim[0])
+                    if idx != len(index_vars):
+                        raise RuntimeError(f"The number of range index is different: {lhs} {var} {len(index_vars)} {idx}")
+                    var.index = AryIndex(rhs_index) # override variables in rhs
+                for var in rhs_vars:
+                    grad_rhs = var.add_suffix(AD_SUFFIX)
+                    dev = rhs.derivative(
+                       var, target=grad_lhs, info=self.info, warnings=warnings
+                    )
+                    assig = Assignment(grad_rhs, tmp_var * dev, accumulate=(grad_rhs != grad_lhs), ad_info=ad_info)
+                    body.append(assig)
+
+                for idx_var, ldim in index_vars:
+                    rng = OpRange([ldim[0], ldim[1]])
+                    body = Block([DoLoop(body, idx_var, rng)])
+
+                assigns = list(body.iter_children())
+                assigns.extend(extras)
+                return assigns
+
+            # not the special case
+            grad_lhs = lhs.add_suffix(AD_SUFFIX)
+            ad_info = self.info.get("code") if self.info is not None else None
+
+            if lhs in rhs_vars:
                 # Ensure the derivative for lhs is computed last
-                vars.remove(lhs)
-                vars.append(lhs)
-            for var in vars:
+                rhs_vars.remove(lhs)
+                rhs_vars.append(lhs)
+            for var in rhs_vars:
                 if not var.ad_target:
                     continue
                 dev = rhs.derivative(
                     var, target=grad_lhs, info=self.info, warnings=warnings
                 )
-                v = var.add_suffix(AD_SUFFIX)
+                grad_rhs = var.add_suffix(AD_SUFFIX)
                 res = grad_lhs * dev
-                if not v.is_array() and res.is_array():
+                if not grad_rhs.is_array() and res.is_array():
                     res = OpFunc("sum", args=[res])
                 assigns.append(
-                    Assignment(v, res, accumulate=(v != grad_lhs), ad_info=ad_info)
+                    Assignment(grad_rhs, res, accumulate=(grad_rhs != grad_lhs), ad_info=ad_info)
                 )
-            if lhs not in vars:
+            if lhs not in rhs_vars:
                 # If lhs does not appear in rhs, its gradient is cleared
                 assigns.append(ClearAssignment(grad_lhs, ad_info=ad_info))
         assigns.extend(extras)
@@ -5023,22 +5066,34 @@ class BlockConstruct(Node):
     def iter_ref_vars(self) -> Iterator[OpVar]:
         local_names = self._local_names()
         for var in self.decls.iter_ref_vars():
-            if var.name not in local_names:
+            v = var
+            while v.ref_var:
+                v = v.ref_var
+            if v.name not in local_names:
                 yield var
 
     def iter_assign_vars(self, without_savevar: bool = False) -> Iterator[OpVar]:
         local_names = self._local_names()
         for var in self.decls.iter_assign_vars(without_savevar=without_savevar):
-            if var.name not in local_names:
+            v = var
+            while v.ref_var:
+                v = v.ref_var
+            if v.name not in local_names:
                 yield var
 
-    def has_reference_to(self, var: str) -> bool:
-        if var in self._local_names():
+    def has_reference_to(self, var: OpVar) -> bool:
+        v = var
+        while v.ref_var:
+            v = v.ref_var
+        if v.name in self._local_names():
             return False
         return self.decls.has_reference_to(var) or self.body.has_reference_to(var)
 
-    def has_assignment_to(self, var: str) -> bool:
-        if var in self._local_names():
+    def has_assignment_to(self, var: OpVar) -> bool:
+        v = var
+        while v.ref_var:
+            v = v.ref_var
+        if v.name in self._local_names():
             return False
         return self.decls.has_assignment_to(var) or self.body.has_assignment_to(var)
 

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -1335,15 +1335,39 @@ def _generate_ad_subroutine(
                     ad_block.remove_child(first)
                 continue
             flag = False
+        fw_nodes = [n for n in fw_block.iter_children()]
+        for i, node_fw in enumerate(fw_nodes):
+            if isinstance(node_fw, SaveAssignment) and not node_fw.pushpop:
+                var = node_fw.var
+                if i < len(fw_nodes)-1:
+                    flag = False
+                    for node in fw_nodes[i+1:]:
+                        if node.has_assignment_to(var):
+                            flag = True
+                            break
+                    if flag:
+                        break
+                for node_ad in ad_block.iter_children():
+                    if (
+                        isinstance(node_ad, SaveAssignment)
+                        and node_ad.load
+                        and node_fw.id == node_ad.id
+                    ):
+                        fw_block.remove_child(node_fw)
+                        ad_block.remove_child(node_ad)
+                        break
+                    if node_ad.has_assignment_to(var):
+                        break
+
         if not fw_block.is_effectively_empty():
             subroutine.content.extend(fw_block)
 
-    if (ad_block is not None) and (not ad_block.is_effectively_empty()):
+    if reverse and (ad_block is not None) and (not ad_block.is_effectively_empty()):
         # initialize ad_var if necessary
         vars = ad_block.required_vars(
             VarList(out_grad_args + save_ad_vars), without_savevar=True
         )
-        if reverse and not fw_block.is_effectively_empty():
+        if not fw_block.is_effectively_empty():
             vars = fw_block.required_vars(vars)
         for name in vars.names():
             if not name.endswith(AD_SUFFIX):
@@ -1357,7 +1381,7 @@ def _generate_ad_subroutine(
                 if any(v for v in in_grad_args if v.name == name):
                     continue
                 var = next(v for v in out_grad_args if v.name == name)
-            if var is not None and not var.save:
+            if var is not None and not var.save and not var.pointer:
                 if var.dims is not None and len(var.dims) > 0:
                     index = AryIndex((None,) * len(var.dims))
                 else:

--- a/fautodiff/operators.py
+++ b/fautodiff/operators.py
@@ -1040,6 +1040,15 @@ class OpVar(OpLeaf):
             name = f"{self.ref_var.name_ext()}%{name}"
         return name
 
+    def is_same_var(self, other: OpVar) -> bool:
+        if self.name != other.name:
+            return False
+        if self.ref_var is not None:
+            if other.ref_var is None:
+                return False
+            return self.ref_var.is_save_var(other.ref_var)
+        return True
+
     def get_dims(self) -> Optional[List[str]]:
         if self.index is None and self.dims is None:
             return None
@@ -1306,7 +1315,8 @@ class OpVar(OpLeaf):
             return NotImplemented
         if self.name == other.name:
             if self.index == other.index:
-                return True
+                if self.ref_var == other.ref_var:
+                    return True
         return False
 
 

--- a/tests/test_code_tree.py
+++ b/tests/test_code_tree.py
@@ -102,8 +102,8 @@ class TestNodeMethods(unittest.TestCase):
                 Assignment(OpVar("a"), OpInt(1)),
             ]
         )
-        self.assertTrue(blk.has_assignment_to("a"))
-        self.assertFalse(blk.has_assignment_to("b"))
+        self.assertTrue(blk.has_assignment_to(OpVar("a")))
+        self.assertFalse(blk.has_assignment_to(OpVar("b")))
 
         inner = DoLoop(
             Block(
@@ -120,9 +120,9 @@ class TestNodeMethods(unittest.TestCase):
         outer = DoLoop(
             Block([inner]), index=OpVar("j"), range=OpRange([OpInt(1), OpVar("m")])
         )
-        self.assertTrue(outer.has_assignment_to("a"))
-        self.assertFalse(outer.has_assignment_to("b"))
-        self.assertFalse(outer.has_assignment_to("c"))
+        self.assertTrue(outer.has_assignment_to(OpVar("a")))
+        self.assertFalse(outer.has_assignment_to(OpVar("b")))
+        self.assertFalse(outer.has_assignment_to(OpVar("c")))
 
     def test_has_reference_to(self):
         inner = Block(
@@ -132,9 +132,9 @@ class TestNodeMethods(unittest.TestCase):
         )
         loop = DoLoop(inner, index=OpVar("i"), range=OpRange([OpInt(1), OpInt(10)]))
         outer = Block([loop])
-        self.assertTrue(outer.has_reference_to("a"))
-        self.assertFalse(outer.has_reference_to("c"))
-        self.assertFalse(outer.has_reference_to("b"))
+        self.assertTrue(outer.has_reference_to(OpVar("a")))
+        self.assertFalse(outer.has_reference_to(OpVar("c")))
+        self.assertFalse(outer.has_reference_to(OpVar("b")))
 
     def test_ids_and_clone(self):
         blk = Block([Assignment(OpVar("a"), OpInt(1))])
@@ -198,9 +198,9 @@ class TestNodeMethods(unittest.TestCase):
         decls = Block([Declaration(name="a", typename="real")])
         body = Block([Assignment(OpVar("b"), OpVar("a"))])
         blk = BlockConstruct(decls, body)
-        self.assertFalse(blk.has_reference_to("a"))
-        self.assertFalse(blk.has_assignment_to("a"))
-        self.assertTrue(blk.has_assignment_to("b"))
+        self.assertFalse(blk.has_reference_to(OpVar("a")))
+        self.assertFalse(blk.has_assignment_to(OpVar("a")))
+        self.assertTrue(blk.has_assignment_to(OpVar("b")))
         vars = VarList([OpVar("a")])
         vars = blk.required_vars(vars)
         self.assertEqual({str(v) for v in vars}, {"a"})


### PR DESCRIPTION
## Summary
- loop over slice assignments with scalar temporaries to avoid losing gradients when arrays alias
- detect potential self-referential assignments by pre-scanning pointer associations
- update array slice example to demonstrate elementwise reverse accumulation, including pointer aliasing and multi-term expressions

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_6894ba701988832d8ce5fd57cfdbcefa