### PR TITLE
Rename array slice example to self reference and add runtime tests

### DIFF
--- a/examples/self_reference.f90
+++ b/examples/self_reference.f90
@@ -1,17 +1,17 @@
 
-module array_slice
+module self_reference
 
 contains
-  subroutine slice_copy(u, n, m, i, j)
+  subroutine self_ref_slice(u, n, m, i, j)
     integer, intent(in) :: n, m, i, j
     real, intent(inout) :: u(:)
 
     u(n:m) = u(i:j)
 
     return
-  end subroutine slice_copy
+  end subroutine self_ref_slice
 
-  subroutine slice_copy_ptr(u, v, n, m, i, j)
+  subroutine self_ref_slice_ptr(u, v, n, m, i, j)
     integer, intent(in) :: n, m, i, j
     real, intent(inout), target :: u(:), v(:)
     real, pointer :: p(:), q(:)
@@ -26,9 +26,9 @@ contains
     u(n:m) = u(n:m) + q(i:j)
 
     return
-  end subroutine slice_copy_ptr
+  end subroutine self_ref_slice_ptr
 
-  subroutine slice_copy_expr(u, v, w, n, m, i, j, l1, l2)
+  subroutine self_ref_slice_expr(u, v, w, n, m, i, j, l1, l2)
     integer, intent(in) :: n, m, i, j, l1, l2
     real, intent(inout) :: u(:,:)
     real, intent(in) :: v(:,:)
@@ -43,5 +43,5 @@ contains
     end do
 
     return
-  end subroutine slice_copy_expr
-end module array_slice
+  end subroutine self_ref_slice_expr
+end module self_reference

--- a/examples/self_reference_ad.f90
+++ b/examples/self_reference_ad.f90
@@ -1,10 +1,10 @@
-module array_slice_ad
-  use array_slice
+module self_reference_ad
+  use self_reference
   implicit none
 
 contains
 
-  subroutine slice_copy_fwd_ad(u, u_ad, n, m, i, j)
+  subroutine self_ref_slice_fwd_ad(u, u_ad, n, m, i, j)
     real, intent(inout) :: u(:)
     real, intent(inout) :: u_ad(:)
     integer, intent(in)  :: n
@@ -16,9 +16,9 @@ contains
     u(n:m) = u(i:j)
 
     return
-  end subroutine slice_copy_fwd_ad
+  end subroutine self_ref_slice_fwd_ad
 
-  subroutine slice_copy_rev_ad(u, u_ad, n, m, i, j)
+  subroutine self_ref_slice_rev_ad(u, u_ad, n, m, i, j)
     real, intent(inout) :: u(:)
     real, intent(inout) :: u_ad(:)
     integer, intent(in)  :: n
@@ -35,9 +35,9 @@ contains
     end do
 
     return
-  end subroutine slice_copy_rev_ad
+  end subroutine self_ref_slice_rev_ad
 
-  subroutine slice_copy_ptr_fwd_ad(u, u_ad, v, v_ad, n, m, i, j)
+  subroutine self_ref_slice_ptr_fwd_ad(u, u_ad, v, v_ad, n, m, i, j)
     real, intent(inout), target :: u(:)
     real, intent(inout), target :: u_ad(:)
     real, intent(inout), target :: v(:)
@@ -66,9 +66,9 @@ contains
     u(n:m) = u(n:m) + q(i:j)
 
     return
-  end subroutine slice_copy_ptr_fwd_ad
+  end subroutine self_ref_slice_ptr_fwd_ad
 
-  subroutine slice_copy_ptr_rev_ad(u, u_ad, v, v_ad, n, m, i, j)
+  subroutine self_ref_slice_ptr_rev_ad(u, u_ad, v, v_ad, n, m, i, j)
     real, intent(inout), target :: u(:)
     real, intent(inout), target :: u_ad(:)
     real, intent(inout), target :: v(:)
@@ -102,9 +102,9 @@ contains
     p_ad => null() ! p => u
 
     return
-  end subroutine slice_copy_ptr_rev_ad
+  end subroutine self_ref_slice_ptr_rev_ad
 
-  subroutine slice_copy_expr_fwd_ad(u, u_ad, v, v_ad, w, w_ad, n, m, i, j, l1, l2)
+  subroutine self_ref_slice_expr_fwd_ad(u, u_ad, v, v_ad, w, w_ad, n, m, i, j, l1, l2)
     real, intent(inout) :: u(:,:)
     real, intent(inout) :: u_ad(:,:)
     real, intent(in)  :: v(:,:)
@@ -130,9 +130,9 @@ contains
     end do
 
     return
-  end subroutine slice_copy_expr_fwd_ad
+  end subroutine self_ref_slice_expr_fwd_ad
 
-  subroutine slice_copy_expr_rev_ad(u, u_ad, v, v_ad, w, w_ad, n, m, i, j, l1, l2)
+  subroutine self_ref_slice_expr_rev_ad(u, u_ad, v, v_ad, w, w_ad, n, m, i, j, l1, l2)
     real, intent(inout) :: u(:,:)
     real, intent(inout) :: u_ad(:,:)
     real, intent(in)  :: v(:,:)
@@ -170,6 +170,6 @@ contains
     end do
 
     return
-  end subroutine slice_copy_expr_rev_ad
+  end subroutine self_ref_slice_expr_rev_ad
 
-end module array_slice_ad
+end module self_reference_ad

--- a/tests/fortran_runtime/Makefile
+++ b/tests/fortran_runtime/Makefile
@@ -18,7 +18,7 @@ PROGRAM_NAMES = run_simple_math.out run_arrays.out run_call_example.out run_cont
            run_intrinsic_func.out run_real_kind.out run_save_vars.out run_store_vars.out \
            run_directives.out run_parameter_var.out run_module_vars.out run_call_module_vars.out run_allocate_vars.out \
            run_exit_cycle.out run_pointer_arrays.out run_derived_alloc.out run_mpi_example.out \
-                   run_stack.out run_where_forall.out run_omp_loops.out run_return_example.out
+                   run_stack.out run_where_forall.out run_omp_loops.out run_return_example.out run_self_reference.out
 PROGRAMS = $(addprefix $(OUTDIR)/,$(PROGRAM_NAMES))
 
 .PHONY: all clean
@@ -74,6 +74,8 @@ $(OUTDIR)/run_omp_loops.o: $(OUTDIR)/omp_loops.o $(OUTDIR)/omp_loops_ad.o
 
 $(OUTDIR)/run_fautodiff_stack.o: $(OUTDIR)/fautodiff_stack.o
 
+$(OUTDIR)/run_self_reference.o: $(OUTDIR)/self_reference.o $(OUTDIR)/self_reference_ad.o
+
 
 $(OUTDIR)/run_simple_math.out: $(OUTDIR)/run_simple_math.o $(OUTDIR)/simple_math.o $(OUTDIR)/simple_math_ad.o
 $(OUTDIR)/run_arrays.out: $(OUTDIR)/run_arrays.o $(OUTDIR)/arrays.o $(OUTDIR)/arrays_ad.o
@@ -100,6 +102,8 @@ $(OUTDIR)/run_return_example.out: $(OUTDIR)/run_return_example.o $(OUTDIR)/retur
 $(OUTDIR)/run_omp_loops.out: $(OUTDIR)/run_omp_loops.o $(OUTDIR)/omp_loops.o $(OUTDIR)/omp_loops_ad.o
 
 $(OUTDIR)/run_fautodiff_stack.out: $(OUTDIR)/run_fautodiff_stack.o $(OUTDIR)/fautodiff_stack.o
+
+$(OUTDIR)/run_self_reference.out: $(OUTDIR)/run_self_reference.o $(OUTDIR)/self_reference.o $(OUTDIR)/self_reference_ad.o
 
 clean:
 	rm -f $(OUTDIR)/*.o $(OUTDIR)/*.mod

--- a/tests/fortran_runtime/run_self_reference.f90
+++ b/tests/fortran_runtime/run_self_reference.f90
@@ -1,0 +1,169 @@
+program run_self_reference
+  use self_reference
+  use self_reference_ad
+  implicit none
+  real, parameter :: tol = 1.0e-4
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_slice = 1
+  integer, parameter :: I_slice_ptr = 2
+  integer, parameter :: I_slice_expr = 3
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("slice")
+              i_test = I_slice
+           case ("slice_ptr")
+              i_test = I_slice_ptr
+           case ("slice_expr")
+              i_test = I_slice_expr
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_slice .or. i_test == I_all) then
+     call test_slice
+  end if
+  if (i_test == I_slice_ptr .or. i_test == I_all) then
+     call test_slice_ptr
+  end if
+  if (i_test == I_slice_expr .or. i_test == I_all) then
+     call test_slice_expr
+  end if
+
+  print *, 'OK'
+  stop
+
+contains
+
+  subroutine test_slice
+    integer, parameter :: n_tot = 5
+    real :: u(n_tot), u_eps(n_tot), u_ad(n_tot)
+    real :: fd(n_tot), eps, inner1, inner2
+
+    eps = 1.0e-3
+    u = (/1.0, 2.0, 3.0, 4.0, 5.0/)
+    call self_ref_slice(u, 3, 5, 1, 3)
+    u_eps = (/1.0, 2.0, 3.0, 4.0, 5.0/) + eps
+    call self_ref_slice(u_eps, 3, 5, 1, 3)
+    fd(:) = (u_eps(:) - u(:)) / eps
+    u = (/1.0, 2.0, 3.0, 4.0, 5.0/)
+    u_ad(:) = 1.0
+    call self_ref_slice_fwd_ad(u, u_ad, 3, 5, 1, 3)
+    if (any(abs((u_ad(:) - fd(:)) / fd(:)) > tol)) then
+       print *, 'test_slice_fwd failed'
+       error stop 1
+    end if
+
+    inner1 = sum(u_ad(:)**2)
+    call self_ref_slice_rev_ad(u, u_ad, 3, 5, 1, 3)
+    inner2 = sum(u_ad(:))
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_slice_rev failed', inner1, inner2
+       error stop 1
+    end if
+
+    return
+  end subroutine test_slice
+
+  subroutine test_slice_ptr
+    integer, parameter :: n_tot = 5
+    real, parameter :: tol_ptr = 5.0e-4
+    real :: u(n_tot), v(n_tot)
+    real :: u_eps(n_tot), v_eps(n_tot)
+    real :: u_ad(n_tot), v_ad(n_tot)
+    real :: fd_u(n_tot), fd_v(n_tot)
+    real :: eps, inner1, inner2
+
+    eps = 1.0e-3
+    u = (/1.0, 2.0, 3.0, 4.0, 5.0/)
+    v = (/6.0, 7.0, 8.0, 9.0, 10.0/)
+    call self_ref_slice_ptr(u, v, 3, 5, 1, 3)
+    u_eps = (/1.0, 2.0, 3.0, 4.0, 5.0/) + eps
+    v_eps = (/6.0, 7.0, 8.0, 9.0, 10.0/) + eps
+    call self_ref_slice_ptr(u_eps, v_eps, 3, 5, 1, 3)
+    fd_u(:) = (u_eps(:) - u(:)) / eps
+    fd_v(:) = (v_eps(:) - v(:)) / eps
+    u = (/1.0, 2.0, 3.0, 4.0, 5.0/)
+    v = (/6.0, 7.0, 8.0, 9.0, 10.0/)
+    u_ad(:) = 1.0
+    v_ad(:) = 1.0
+    call self_ref_slice_ptr_fwd_ad(u, u_ad, v, v_ad, 3, 5, 1, 3)
+    if (any(abs((u_ad(:) - fd_u(:)) / fd_u(:)) > tol_ptr) .or. &
+        any(abs((v_ad(:) - fd_v(:)) / fd_v(:)) > tol_ptr)) then
+       print *, 'test_slice_ptr_fwd failed'
+       error stop 1
+    end if
+
+    inner1 = sum(u_ad(:)**2) + sum(v_ad(:)**2)
+    call self_ref_slice_ptr_rev_ad(u, u_ad, v, v_ad, 3, 5, 1, 3)
+    inner2 = sum(u_ad(:)) + sum(v_ad(:))
+    if (abs((inner2 - inner1) / inner1) > tol_ptr) then
+       print *, 'test_slice_ptr_rev failed', inner1, inner2
+       error stop 1
+    end if
+
+    return
+  end subroutine test_slice_ptr
+
+  subroutine test_slice_expr
+    integer, parameter :: n = 3, m = 3
+    real, parameter :: tol_expr = 1.0e-2
+    real :: u(n,m), v(n,m), w(n,m)
+    real :: u_eps(n,m), v_eps(n,m), w_eps(n,m)
+    real :: u_ad(n,m), v_ad(n,m), w_ad(n,m)
+    real :: fd_u(n,m), fd_w(n,m)
+    real :: eps, inner1, inner2
+
+    eps = 1.0e-3
+    u = reshape((/1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0/), (/n,m/))
+    v = reshape((/9.0,8.0,7.0,6.0,5.0,4.0,3.0,2.0,1.0/), (/n,m/))
+    w = reshape((/1.0,1.0,1.0,2.0,2.0,2.0,3.0,3.0,3.0/), (/n,m/))
+    call self_ref_slice_expr(u, v, w, 2, 2, 1, 1, 2, 2)
+    u_eps = reshape((/1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0/), (/n,m/)) + eps
+    v_eps = reshape((/9.0,8.0,7.0,6.0,5.0,4.0,3.0,2.0,1.0/), (/n,m/)) + eps
+    w_eps = reshape((/1.0,1.0,1.0,2.0,2.0,2.0,3.0,3.0,3.0/), (/n,m/)) + eps
+    call self_ref_slice_expr(u_eps, v_eps, w_eps, 2, 2, 1, 1, 2, 2)
+    fd_u(:,:) = (u_eps(:,:) - u(:,:)) / eps
+    fd_w(:,:) = (w_eps(:,:) - w(:,:)) / eps
+    u = reshape((/1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0/), (/n,m/))
+    v = reshape((/9.0,8.0,7.0,6.0,5.0,4.0,3.0,2.0,1.0/), (/n,m/))
+    w = reshape((/1.0,1.0,1.0,2.0,2.0,2.0,3.0,3.0,3.0/), (/n,m/))
+    u_ad(:,:) = 1.0
+    v_ad(:,:) = 1.0
+    w_ad(:,:) = 1.0
+    call self_ref_slice_expr_fwd_ad(u, u_ad, v, v_ad, w, w_ad, 2, 2, 1, 1, 2, 2)
+    if (any(abs((u_ad(:,:) - fd_u(:,:)) / fd_u(:,:)) > tol_expr) .or. &
+        any(abs((w_ad(:,:) - fd_w(:,:)) / fd_w(:,:)) > tol_expr)) then
+       print *, 'test_slice_expr_fwd failed'
+       error stop 1
+    end if
+
+    inner1 = sum(u_ad(:,:)**2) + sum(w_ad(:,:)**2)
+    v_ad(:,:) = 0.0
+    call self_ref_slice_expr_rev_ad(u, u_ad, v, v_ad, w, w_ad, 2, 2, 1, 1, 2, 2)
+    inner2 = sum(u_ad(:,:)) + sum(v_ad(:,:)) + sum(w_ad(:,:))
+    if (abs((inner2 - inner1) / inner1) > tol_expr) then
+       print *, 'test_slice_expr_rev failed', inner1, inner2
+       error stop 1
+    end if
+
+    return
+  end subroutine test_slice_expr
+
+end program run_self_reference

--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -175,6 +175,12 @@ class TestFortranADCode(unittest.TestCase):
     def test_return_example(self):
         self._run_test("return_example", ["conditional_return"])
 
+    def test_self_reference(self):
+        self._run_test(
+            "self_reference",
+            ["slice", "slice_ptr", "slice_expr"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_fortran_runtime.py
+++ b/tests/test_fortran_runtime.py
@@ -54,6 +54,20 @@ class TestFortranRuntime(unittest.TestCase):
                 raise
             self.assertEqual(run.stdout.strip(), "OK")
 
+    def test_self_reference(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            exe = self._build(tmp, "run_self_reference")
+            try:
+                run = subprocess.run(
+                    [str(exe)], stdout=subprocess.PIPE, text=True, check=True
+                )
+            except subprocess.CalledProcessError as e:
+                if e.stdout:
+                    print(e.stdout)
+                raise
+            self.assertEqual(run.stdout.strip(), "OK")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_fortran_runtime.py
+++ b/tests/test_fortran_runtime.py
@@ -54,20 +54,6 @@ class TestFortranRuntime(unittest.TestCase):
                 raise
             self.assertEqual(run.stdout.strip(), "OK")
 
-    def test_self_reference(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tmp = Path(tmpdir)
-            exe = self._build(tmp, "run_self_reference")
-            try:
-                run = subprocess.run(
-                    [str(exe)], stdout=subprocess.PIPE, text=True, check=True
-                )
-            except subprocess.CalledProcessError as e:
-                if e.stdout:
-                    print(e.stdout)
-                raise
-            self.assertEqual(run.stdout.strip(), "OK")
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- rename array slice example to `self_reference` with clearer subroutine names
- add self-reference runtime test program and integrate with Fortran test suite
- update build system and tests to exercise new self-reference checks

## Testing
- `python tests/test_generator.py`
- `python tests/test_fortran_runtime.py`
- `python -m unittest tests.test_fortran_adcode.TestFortranADCode.test_self_reference`


------
https://chatgpt.com/codex/tasks/task_b_6895b2d248dc832d9357f11272897a08