### PR TITLE
Remove unused arguments from AD subroutines

### DIFF
--- a/examples/allocate_vars_ad.f90
+++ b/examples/allocate_vars_ad.f90
@@ -81,9 +81,8 @@ contains
     return
   end subroutine module_vars_init_fwd_ad
 
-  subroutine module_vars_init_rev_ad(n, x, x_ad)
+  subroutine module_vars_init_rev_ad(n, x_ad)
     integer, intent(in)  :: n
-    real, intent(in)  :: x
     real, intent(inout) :: x_ad
     integer :: i
 

--- a/examples/arrays_ad.f90
+++ b/examples/arrays_ad.f90
@@ -21,11 +21,9 @@ contains
     return
   end subroutine elementwise_add_fwd_ad
 
-  subroutine elementwise_add_rev_ad(n, a, a_ad, b, b_ad, c_ad)
+  subroutine elementwise_add_rev_ad(n, a_ad, b_ad, c_ad)
     integer, intent(in)  :: n
-    real, intent(in)  :: a(n)
     real, intent(inout) :: a_ad(n)
-    real, intent(in)  :: b(n)
     real, intent(inout) :: b_ad(n)
     real, intent(inout) :: c_ad(n)
 
@@ -51,9 +49,8 @@ contains
     return
   end subroutine scale_array_fwd_ad
 
-  subroutine scale_array_rev_ad(n, a, a_ad)
+  subroutine scale_array_rev_ad(n, a_ad)
     integer, intent(in)  :: n
-    real, intent(inout) :: a(n)
     real, intent(inout) :: a_ad(n)
     integer :: i
 
@@ -88,10 +85,9 @@ contains
     return
   end subroutine multidimension_fwd_ad
 
-  subroutine multidimension_rev_ad(n, m, a, a_ad, b, b_ad, c, c_ad, d_ad)
+  subroutine multidimension_rev_ad(n, m, a_ad, b, b_ad, c, c_ad, d_ad)
     integer, intent(in)  :: n
     integer, intent(in)  :: m
-    real, intent(in)  :: a(n,m)
     real, intent(inout) :: a_ad(n,m)
     real, intent(in)  :: b(n,m)
     real, intent(inout) :: b_ad(n,m)
@@ -216,9 +212,8 @@ contains
     return
   end subroutine stencil_fwd_ad
 
-  subroutine stencil_rev_ad(n, a, a_ad, b_ad)
+  subroutine stencil_rev_ad(n, a_ad, b_ad)
     integer, intent(in)  :: n
-    real, intent(in)  :: a(n)
     real, intent(inout) :: a_ad(n)
     real, intent(inout) :: b_ad(n)
     integer :: i

--- a/examples/block_construct_ad.f90
+++ b/examples/block_construct_ad.f90
@@ -16,8 +16,7 @@ contains
     return
   end subroutine compute_module_fwd_ad
 
-  subroutine compute_module_rev_ad(val, val_ad)
-    real, intent(in)  :: val
+  subroutine compute_module_rev_ad(val_ad)
     real, intent(inout) :: val_ad
 
     val_ad = z_ad + val_ad ! z = val + 1.0
@@ -51,8 +50,7 @@ contains
     return
   end subroutine use_block_fwd_ad
 
-  subroutine use_block_rev_ad(x, x_ad, y_ad)
-    real, intent(in)  :: x
+  subroutine use_block_rev_ad(x_ad, y_ad)
     real, intent(inout) :: x_ad
     real, intent(inout) :: y_ad
     real :: z_ad

--- a/examples/call_example_ad.f90
+++ b/examples/call_example_ad.f90
@@ -16,10 +16,8 @@ contains
     return
   end subroutine foo_fwd_ad
 
-  subroutine foo_rev_ad(a, a_ad, b, b_ad)
-    real, intent(inout) :: a
+  subroutine foo_rev_ad(a_ad, b_ad)
     real, intent(inout) :: a_ad
-    real, intent(in)  :: b
     real, intent(inout) :: b_ad
 
     b_ad = a_ad + b_ad ! a = a * 2.0 + b

--- a/examples/control_flow_ad.f90
+++ b/examples/control_flow_ad.f90
@@ -5,11 +5,10 @@ module control_flow_ad
 
 contains
 
-  subroutine if_example_fwd_ad(x, x_ad, y, y_ad, z, z_ad)
+  subroutine if_example_fwd_ad(x, x_ad, y, z, z_ad)
     real, intent(in)  :: x
     real, intent(in)  :: x_ad
     real, intent(inout) :: y
-    real, intent(inout) :: y_ad
     real, intent(out) :: z
     real, intent(out) :: z_ad
 
@@ -29,11 +28,9 @@ contains
     return
   end subroutine if_example_fwd_ad
 
-  subroutine if_example_rev_ad(x, x_ad, y, y_ad, z_ad)
+  subroutine if_example_rev_ad(x, x_ad, z_ad)
     real, intent(in)  :: x
     real, intent(inout) :: x_ad
-    real, intent(inout) :: y
-    real, intent(inout) :: y_ad
     real, intent(inout) :: z_ad
 
     if (x > 0.0) then
@@ -71,9 +68,8 @@ contains
     return
   end subroutine select_example_fwd_ad
 
-  subroutine select_example_rev_ad(i, x, x_ad, z_ad)
+  subroutine select_example_rev_ad(i, x_ad, z_ad)
     integer, intent(in)  :: i
-    real, intent(in)  :: x
     real, intent(inout) :: x_ad
     real, intent(inout) :: z_ad
 
@@ -109,9 +105,8 @@ contains
     return
   end subroutine do_example_fwd_ad
 
-  subroutine do_example_rev_ad(n, x, x_ad, sum_ad)
+  subroutine do_example_rev_ad(n, x_ad, sum_ad)
     integer, intent(in)  :: n
-    real, intent(in)  :: x
     real, intent(inout) :: x_ad
     real, intent(inout) :: sum_ad
     integer :: i
@@ -124,11 +119,10 @@ contains
     return
   end subroutine do_example_rev_ad
 
-  subroutine do_while_example_rev_ad(x, x_ad, limit, limit_ad)
+  subroutine do_while_example_rev_ad(x, x_ad, limit)
     real, intent(in)  :: x
     real, intent(inout) :: x_ad
     real, intent(in)  :: limit
-    real, intent(inout) :: limit_ad
     real :: y_ad
     real :: y
 

--- a/examples/cross_mod_a_ad.f90
+++ b/examples/cross_mod_a_ad.f90
@@ -16,10 +16,8 @@ contains
     return
   end subroutine incval_fwd_ad
 
-  subroutine incval_rev_ad(a, a_ad, inc, inc_ad)
-    real, intent(inout) :: a
+  subroutine incval_rev_ad(a_ad, inc_ad)
     real, intent(inout) :: a_ad
-    real, intent(in)  :: inc
     real, intent(inout) :: inc_ad
 
     inc_ad = a_ad + inc_ad ! a = a + inc

--- a/examples/cross_mod_b_ad.f90
+++ b/examples/cross_mod_b_ad.f90
@@ -19,17 +19,13 @@ contains
     return
   end subroutine call_inc_fwd_ad
 
-  subroutine call_inc_rev_ad(b, b_ad)
-    real, intent(inout) :: b
+  subroutine call_inc_rev_ad(b_ad)
     real, intent(inout) :: b_ad
     real :: inc_ad
-    real :: inc
-
-    inc = 1.0
 
     inc_ad = 0.0
 
-    call incval_rev_ad(b, b_ad, inc, inc_ad) ! call incval(b, inc)
+    call incval_rev_ad(b_ad, inc_ad) ! call incval(b, inc)
 
     return
   end subroutine call_inc_rev_ad
@@ -47,17 +43,13 @@ contains
     return
   end subroutine call_inc_kw_fwd_ad
 
-  subroutine call_inc_kw_rev_ad(b, b_ad)
-    real, intent(inout) :: b
+  subroutine call_inc_kw_rev_ad(b_ad)
     real, intent(inout) :: b_ad
     real :: inc_ad
-    real :: inc
-
-    inc = 1.0
 
     inc_ad = 0.0
 
-    call incval_rev_ad(b, b_ad, inc, inc_ad) ! call incval(inc=inc, a=b)
+    call incval_rev_ad(b_ad, inc_ad) ! call incval(inc=inc, a=b)
 
     return
   end subroutine call_inc_kw_rev_ad

--- a/examples/derived_alloc_ad.f90
+++ b/examples/derived_alloc_ad.f90
@@ -29,8 +29,7 @@ contains
     return
   end subroutine derived_alloc_init_fwd_ad
 
-  subroutine derived_alloc_init_rev_ad(n, m)
-    integer, intent(in)  :: n
+  subroutine derived_alloc_init_rev_ad(m)
     integer, intent(in)  :: m
     integer :: j
 

--- a/examples/directives_ad.f90
+++ b/examples/directives_ad.f90
@@ -17,11 +17,9 @@ contains
     return
   end subroutine add_const_fwd_ad
 
-  subroutine add_const_rev_ad(x, x_ad, y_ad, z)
-    real, intent(in)  :: x
+  subroutine add_const_rev_ad(x_ad, y_ad)
     real, intent(inout) :: x_ad
     real, intent(inout) :: y_ad
-    real, intent(in)  :: z
 
     x_ad = y_ad + x_ad ! y = x + z
     y_ad = 0.0 ! y = x + z
@@ -45,8 +43,7 @@ contains
     return
   end subroutine worker_fwd_ad
 
-  subroutine worker_rev_ad(x, x_ad, z_ad)
-    real, intent(in)  :: x
+  subroutine worker_rev_ad(x_ad, z_ad)
     real, intent(inout) :: x_ad
     real, intent(inout) :: z_ad
     real :: y_ad

--- a/examples/intrinsic_func_ad.f90
+++ b/examples/intrinsic_func_ad.f90
@@ -165,15 +165,13 @@ contains
     return
   end subroutine reduction_rev_ad
 
-  subroutine non_differentiable_intrinsics_fwd_ad(str, arr, arr_ad, idx, lb, ub, x, x_ad, y, y_ad)
+  subroutine non_differentiable_intrinsics_fwd_ad(str, arr, idx, lb, ub, x, y, y_ad)
     character(len=*), intent(in)  :: str
     real, intent(in)  :: arr(:)
-    real, intent(in)  :: arr_ad(:)
     integer, intent(out) :: idx
     integer, intent(out) :: lb
     integer, intent(out) :: ub
     real, intent(in)  :: x
-    real, intent(in)  :: x_ad
     real, intent(out) :: y
     real, intent(out) :: y_ad
     real :: a_ad
@@ -198,11 +196,7 @@ contains
     return
   end subroutine non_differentiable_intrinsics_fwd_ad
 
-  subroutine non_differentiable_intrinsics_rev_ad(str, arr, arr_ad, x, x_ad, y_ad)
-    character(len=*), intent(in)  :: str
-    real, intent(in)  :: arr(:)
-    real, intent(inout) :: arr_ad(:)
-    real, intent(in)  :: x
+  subroutine non_differentiable_intrinsics_rev_ad(x_ad, y_ad)
     real, intent(inout) :: x_ad
     real, intent(inout) :: y_ad
 
@@ -225,8 +219,7 @@ contains
     return
   end subroutine special_intrinsics_fwd_ad
 
-  subroutine special_intrinsics_rev_ad(mat_in, mat_in_ad, mat_out_ad)
-    real, intent(in)  :: mat_in(:,:)
+  subroutine special_intrinsics_rev_ad(mat_in_ad, mat_out_ad)
     real, intent(inout) :: mat_in_ad(:,:)
     real, intent(inout) :: mat_out_ad(:,:)
 
@@ -236,8 +229,7 @@ contains
     return
   end subroutine special_intrinsics_rev_ad
 
-  subroutine casting_intrinsics_fwd_ad(i, r, r_ad, d, d_ad, c, n)
-    integer, intent(in)  :: i
+  subroutine casting_intrinsics_fwd_ad(r, r_ad, d, d_ad, c, n)
     real, intent(in)  :: r
     real, intent(in)  :: r_ad
     double precision, intent(out) :: d
@@ -255,12 +247,9 @@ contains
     return
   end subroutine casting_intrinsics_fwd_ad
 
-  subroutine casting_intrinsics_rev_ad(i, r, r_ad, d_ad, c)
-    integer, intent(in)  :: i
-    real, intent(in)  :: r
+  subroutine casting_intrinsics_rev_ad(r_ad, d_ad)
     real, intent(inout) :: r_ad
     double precision, intent(inout) :: d_ad
-    character(len=1), intent(inout) :: c
 
     r_ad = d_ad + r_ad ! d = dble(r) + dble(i2)
     d_ad = 0.0d0 ! d = dble(r) + dble(i2)

--- a/examples/keyword_args_ad.f90
+++ b/examples/keyword_args_ad.f90
@@ -16,10 +16,8 @@ contains
     return
   end subroutine inc_fwd_ad
 
-  subroutine inc_rev_ad(a, a_ad, b, b_ad)
-    real, intent(inout) :: a
+  subroutine inc_rev_ad(a_ad, b_ad)
     real, intent(inout) :: a_ad
-    real, intent(in)  :: b
     real, intent(inout) :: b_ad
 
     b_ad = a_ad + b_ad ! a = a + b

--- a/examples/main_program_ad.f90
+++ b/examples/main_program_ad.f90
@@ -21,10 +21,8 @@ contains
     return
   end subroutine simple_fwd_ad
 
-  subroutine simple_rev_ad(a, a_ad, b, b_ad, c_ad)
-    real, intent(in)  :: a
+  subroutine simple_rev_ad(a_ad, b_ad, c_ad)
     real, intent(inout) :: a_ad
-    real, intent(in)  :: b
     real, intent(inout) :: b_ad
     real, intent(inout) :: c_ad
 

--- a/examples/mpi_example_ad.f90
+++ b/examples/mpi_example_ad.f90
@@ -21,8 +21,7 @@ contains
     return
   end subroutine sum_reduce_fwd_ad
 
-  subroutine sum_reduce_rev_ad(x, x_ad, comm)
-    real, intent(inout) :: x
+  subroutine sum_reduce_rev_ad(x_ad, comm)
     real, intent(inout) :: x_ad
     integer, intent(in)  :: comm
     real :: tmp_ad
@@ -69,8 +68,7 @@ contains
     return
   end subroutine isend_irecv_fwd_ad
 
-  subroutine isend_irecv_rev_ad(x, x_ad, y_ad, comm)
-    real, intent(inout) :: x(2)
+  subroutine isend_irecv_rev_ad(x_ad, y_ad, comm)
     real, intent(inout) :: x_ad(2)
     real, intent(inout) :: y_ad
     integer, intent(in)  :: comm

--- a/examples/omp_loops_ad.f90
+++ b/examples/omp_loops_ad.f90
@@ -28,9 +28,8 @@ contains
     return
   end subroutine sum_loop_fwd_ad
 
-  subroutine sum_loop_rev_ad(n, x, x_ad, y_ad, s_ad)
+  subroutine sum_loop_rev_ad(n, x_ad, y_ad, s_ad)
     integer, intent(in)  :: n
-    real, intent(in)  :: x(n)
     real, intent(inout) :: x_ad(n)
     real, intent(inout) :: y_ad(n)
     real, intent(inout) :: s_ad
@@ -75,9 +74,8 @@ contains
     return
   end subroutine stencil_loop_fwd_ad
 
-  subroutine stencil_loop_rev_ad(n, x, x_ad, y_ad)
+  subroutine stencil_loop_rev_ad(n, x_ad, y_ad)
     integer, intent(in)  :: n
-    real, intent(in)  :: x(n)
     real, intent(inout) :: x_ad(n)
     real, intent(inout) :: y_ad(n)
     integer :: i

--- a/examples/pointer_arrays_ad.f90
+++ b/examples/pointer_arrays_ad.f90
@@ -44,9 +44,8 @@ contains
     return
   end subroutine pointer_allocate_fwd_ad
 
-  subroutine pointer_allocate_rev_ad(n, x, x_ad, res_ad)
+  subroutine pointer_allocate_rev_ad(n, x_ad, res_ad)
     integer, intent(in)  :: n
-    real, intent(in)  :: x
     real, intent(inout) :: x_ad
     real, intent(inout) :: res_ad
     real, pointer :: p_ad(:)
@@ -104,9 +103,8 @@ contains
     return
   end subroutine pointer_subarray_fwd_ad
 
-  subroutine pointer_subarray_rev_ad(n, x, x_ad, res_ad)
+  subroutine pointer_subarray_rev_ad(n, x_ad, res_ad)
     integer, intent(in)  :: n
-    real, intent(in)  :: x
     real, intent(inout) :: x_ad
     real, intent(inout) :: res_ad
     real, pointer :: p_ad(:)
@@ -154,8 +152,7 @@ contains
     return
   end subroutine pointer_allsub_init_fwd_ad
 
-  subroutine pointer_allsub_init_rev_ad(n)
-    integer, intent(in)  :: n
+  subroutine pointer_allsub_init_rev_ad()
 
     if (allocated(all_p_ad)) then
       deallocate(all_p_ad)
@@ -272,11 +269,9 @@ contains
     return
   end subroutine pointer_swap_fwd_ad
 
-  subroutine pointer_swap_rev_ad(n, x, x_ad, y, y_ad, res_ad)
+  subroutine pointer_swap_rev_ad(n, x_ad, y_ad, res_ad)
     integer, intent(in)  :: n
-    real, intent(in), target  :: x(n)
     real, intent(inout), target :: x_ad(n)
-    real, intent(in), target  :: y(n)
     real, intent(inout), target :: y_ad(n)
     real, intent(inout) :: res_ad
     real, pointer :: swap_ad(:)

--- a/examples/preprocessor_ad.f90
+++ b/examples/preprocessor_ad.f90
@@ -20,8 +20,7 @@ contains
     return
   end subroutine foo_fwd_ad
 
-  subroutine foo_rev_ad(x, x_ad, y_ad)
-    real, intent(in)  :: x
+  subroutine foo_rev_ad(x_ad, y_ad)
     real, intent(inout) :: x_ad
     real, intent(inout) :: y_ad
 

--- a/examples/real_kind_ad.f90
+++ b/examples/real_kind_ad.f90
@@ -14,8 +14,7 @@ contains
     return
   end subroutine scale_8_fwd_ad
 
-  subroutine scale_8_rev_ad(x, x_ad)
-    real(8), intent(inout) :: x
+  subroutine scale_8_rev_ad(x_ad)
     real(8), intent(inout) :: x_ad
 
     x_ad = x_ad * 2.0d0 ! x = x * 2.0_8
@@ -33,8 +32,7 @@ contains
     return
   end subroutine scale_rp_fwd_ad
 
-  subroutine scale_rp_rev_ad(x, x_ad)
-    real(RP), intent(inout) :: x
+  subroutine scale_rp_rev_ad(x_ad)
     real(RP), intent(inout) :: x_ad
 
     x_ad = x_ad * 2.0_RP ! x = x * 2.0_RP
@@ -52,8 +50,7 @@ contains
     return
   end subroutine scale_dp_fwd_ad
 
-  subroutine scale_dp_rev_ad(x, x_ad)
-    double precision, intent(inout) :: x
+  subroutine scale_dp_rev_ad(x_ad)
     double precision, intent(inout) :: x_ad
 
     x_ad = x_ad * 2.0d0 ! x = x * 2.0d0

--- a/examples/save_vars_ad.f90
+++ b/examples/save_vars_ad.f90
@@ -30,10 +30,9 @@ contains
     return
   end subroutine simple_fwd_ad
 
-  subroutine simple_rev_ad(x, x_ad, y, y_ad, z_ad)
+  subroutine simple_rev_ad(x, x_ad, y_ad, z_ad)
     real, intent(in)  :: x
     real, intent(inout) :: x_ad
-    real, intent(in)  :: y
     real, intent(inout) :: y_ad
     real, intent(inout) :: z_ad
     real :: work_ad

--- a/examples/self_reference_ad.f90
+++ b/examples/self_reference_ad.f90
@@ -18,13 +18,11 @@ contains
     return
   end subroutine self_ref_slice_fwd_ad
 
-  subroutine self_ref_slice_rev_ad(u, u_ad, n, m, i, j)
-    real, intent(inout) :: u(:)
+  subroutine self_ref_slice_rev_ad(u_ad, n, m, i)
     real, intent(inout) :: u_ad(:)
     integer, intent(in)  :: n
     integer, intent(in)  :: m
     integer, intent(in)  :: i
-    integer, intent(in)  :: j
     integer :: n1_12_ad
     real :: tmp_save_12_ad
 
@@ -68,10 +66,8 @@ contains
     return
   end subroutine self_ref_slice_ptr_fwd_ad
 
-  subroutine self_ref_slice_ptr_rev_ad(u, u_ad, v, v_ad, n, m, i, j)
-    real, intent(inout), target :: u(:)
+  subroutine self_ref_slice_ptr_rev_ad(u_ad, v_ad, n, m, i, j)
     real, intent(inout), target :: u_ad(:)
-    real, intent(inout), target :: v(:)
     real, intent(inout), target :: v_ad(:)
     integer, intent(in)  :: n
     integer, intent(in)  :: m

--- a/examples/simple_math_ad.f90
+++ b/examples/simple_math_ad.f90
@@ -24,10 +24,8 @@ contains
     return
   end subroutine add_numbers_fwd_ad
 
-  subroutine add_numbers_rev_ad(a, a_ad, b, b_ad, c_ad)
-    real, intent(in)  :: a
+  subroutine add_numbers_rev_ad(a_ad, b_ad, c_ad)
     real, intent(inout) :: a_ad
-    real, intent(in)  :: b
     real, intent(inout) :: b_ad
     real, intent(inout) :: c_ad
     real :: work_ad
@@ -57,10 +55,8 @@ contains
     return
   end subroutine subtract_numbers_fwd_ad
 
-  subroutine subtract_numbers_rev_ad(a, a_ad, b, b_ad, c_ad)
-    real, intent(in)  :: a
+  subroutine subtract_numbers_rev_ad(a_ad, b_ad, c_ad)
     real, intent(inout) :: a_ad
-    real, intent(in)  :: b
     real, intent(inout) :: b_ad
     real, intent(inout) :: c_ad
 

--- a/examples/where_forall_ad.f90
+++ b/examples/where_forall_ad.f90
@@ -4,8 +4,7 @@ module where_forall_ad
 
 contains
 
-  subroutine where_example_fwd_ad(n, a, a_ad, b, b_ad)
-    integer, intent(in)  :: n
+  subroutine where_example_fwd_ad(a, a_ad, b, b_ad)
     real, intent(inout) :: a(n)
     real, intent(inout) :: a_ad(n)
     real, intent(in)  :: b(n)
@@ -22,11 +21,9 @@ contains
     return
   end subroutine where_example_fwd_ad
 
-  subroutine where_example_rev_ad(n, a, a_ad, b, b_ad)
-    integer, intent(in)  :: n
+  subroutine where_example_rev_ad(a, a_ad, b_ad)
     real, intent(inout) :: a(n)
     real, intent(inout) :: a_ad(n)
-    real, intent(in)  :: b(n)
     real, intent(inout) :: b_ad(n)
 
     where (a > 0.0)
@@ -54,9 +51,8 @@ contains
     return
   end subroutine forall_example_fwd_ad
 
-  subroutine forall_example_rev_ad(n, a, a_ad, b_ad)
+  subroutine forall_example_rev_ad(n, a_ad, b_ad)
     integer, intent(in)  :: n
-    real, intent(in)  :: a(n)
     real, intent(inout) :: a_ad(n)
     real, intent(inout) :: b_ad(n)
     integer :: i


### PR DESCRIPTION
## Summary
- prune unused arguments from generated AD subroutines
- refresh example AD outputs to reflect streamlined interfaces

## Testing
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_6896cb113184832da3355f6a09900bcc