### PR TITLE
Align Fortran runtime tests with updated reverse AD interfaces

### DIFF
--- a/examples/call_example_ad.f90
+++ b/examples/call_example_ad.f90
@@ -60,13 +60,11 @@ contains
     return
   end subroutine call_subroutine_fwd_ad
 
-  subroutine call_subroutine_rev_ad(x, x_ad, y, y_ad)
-    real, intent(inout) :: x
+  subroutine call_subroutine_rev_ad(x_ad, y_ad)
     real, intent(inout) :: x_ad
-    real, intent(in)  :: y
     real, intent(inout) :: y_ad
 
-    call foo_rev_ad(x, x_ad, y, y_ad) ! call foo(x, y)
+    call foo_rev_ad(x_ad, y_ad) ! call foo(x, y)
 
     return
   end subroutine call_subroutine_rev_ad
@@ -105,15 +103,13 @@ contains
     return
   end subroutine arg_operation_fwd_ad
 
-  subroutine arg_operation_rev_ad(x, x_ad, y, y_ad)
-    real, intent(inout) :: x
+  subroutine arg_operation_rev_ad(x_ad, y_ad)
     real, intent(inout) :: x_ad
-    real, intent(in)  :: y
     real, intent(inout) :: y_ad
     real :: foo_arg1_save_45_ad
 
     foo_arg1_save_45_ad = 0.0
-    call foo_rev_ad(x, x_ad, y * 2.0, foo_arg1_save_45_ad) ! call foo(x, y * 2.0)
+    call foo_rev_ad(x_ad, foo_arg1_save_45_ad) ! call foo(x, y * 2.0)
     y_ad = foo_arg1_save_45_ad * 2.0 + y_ad ! call foo(x, y * 2.0)
 
     return
@@ -133,15 +129,14 @@ contains
     return
   end subroutine arg_function_fwd_ad
 
-  subroutine arg_function_rev_ad(x, x_ad, y, y_ad)
-    real, intent(inout) :: x
+  subroutine arg_function_rev_ad(x_ad, y, y_ad)
     real, intent(inout) :: x_ad
     real, intent(in)  :: y
     real, intent(inout) :: y_ad
     real :: foo_arg1_save_54_ad
 
     foo_arg1_save_54_ad = 0.0
-    call foo_rev_ad(x, x_ad, bar(y), foo_arg1_save_54_ad) ! call foo(x, bar(y))
+    call foo_rev_ad(x_ad, foo_arg1_save_54_ad) ! call foo(x, bar(y))
     call bar_rev_ad(y, y_ad, foo_arg1_save_54_ad) ! call foo(x, bar(y))
 
     return

--- a/examples/keyword_args_ad.f90
+++ b/examples/keyword_args_ad.f90
@@ -36,13 +36,11 @@ contains
     return
   end subroutine do_inc_fwd_ad
 
-  subroutine do_inc_rev_ad(x, x_ad, y, y_ad)
-    real, intent(inout) :: x
+  subroutine do_inc_rev_ad(x_ad, y_ad)
     real, intent(inout) :: x_ad
-    real, intent(in)  :: y
     real, intent(inout) :: y_ad
 
-    call inc_rev_ad(x, x_ad, y, y_ad) ! call inc(a=x, b=y)
+    call inc_rev_ad(x_ad, y_ad) ! call inc(a=x, b=y)
 
     return
   end subroutine do_inc_rev_ad

--- a/examples/where_forall_ad.f90
+++ b/examples/where_forall_ad.f90
@@ -4,7 +4,8 @@ module where_forall_ad
 
 contains
 
-  subroutine where_example_fwd_ad(a, a_ad, b, b_ad)
+  subroutine where_example_fwd_ad(n, a, a_ad, b, b_ad)
+    integer, intent(in)  :: n
     real, intent(inout) :: a(n)
     real, intent(inout) :: a_ad(n)
     real, intent(in)  :: b(n)
@@ -21,7 +22,8 @@ contains
     return
   end subroutine where_example_fwd_ad
 
-  subroutine where_example_rev_ad(a, a_ad, b_ad)
+  subroutine where_example_rev_ad(n, a, a_ad, b_ad)
+    integer, intent(in)  :: n
     real, intent(inout) :: a(n)
     real, intent(inout) :: a_ad(n)
     real, intent(inout) :: b_ad(n)

--- a/tests/fortran_runtime/run_allocate_vars.f90
+++ b/tests/fortran_runtime/run_allocate_vars.f90
@@ -105,7 +105,7 @@ contains
     inner1 = x_ad**2
     call module_vars_finalize_rev_ad(n, x_ad)
     call module_vars_main_rev_ad(n, x_ad)
-    call module_vars_init_rev_ad(n, x, x_ad)
+    call module_vars_init_rev_ad(n, x_ad)
     inner2 = x_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_module_vars_rev faile', inner1, inner2

--- a/tests/fortran_runtime/run_arrays.f90
+++ b/tests/fortran_runtime/run_arrays.f90
@@ -91,7 +91,7 @@ contains
     inner1 = sum(c_ad(:)**2)
     a_ad(:) = 0.0
     b_ad(:) = 0.0
-    call elementwise_add_rev_ad(n, a, a_ad, b, b_ad, c_ad)
+    call elementwise_add_rev_ad(n, a_ad, b_ad, c_ad)
     inner2 = sum(a_ad) + sum(b_ad)
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_elementwise_rev failed', inner1, inner2
@@ -126,7 +126,7 @@ contains
 
     inner1 = sum(a_ad(:)**2)
     a = (/1.0, 2.0, 3.0/)
-    call scale_array_rev_ad(n, a, a_ad)
+    call scale_array_rev_ad(n, a_ad)
     inner2 = sum(a_ad(:))
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_scale_array_rev failed', inner1, inner2
@@ -167,7 +167,7 @@ contains
     a_ad(:,:) = 0.0
     b_ad(:,:) = 0.0
     c_ad = 0.0
-    call multidimension_rev_ad(n, m, a, a_ad, b, b_ad, c, c_ad, d_ad)
+    call multidimension_rev_ad(n, m, a_ad, b, b_ad, c, c_ad, d_ad)
     inner2 = sum(a_ad(:,:)) + sum(b_ad(:,:)) + c_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_multidimension_rev failed', inner1, inner2
@@ -279,7 +279,7 @@ contains
 
     inner1 = sum(b_ad(:)**2)
     a_ad(:) = 0.0
-    call stencil_rev_ad(n, a, a_ad, b_ad)
+    call stencil_rev_ad(n, a_ad, b_ad)
     inner2 = sum(a_ad(:))
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_stencil_rev failed', inner1, inner2

--- a/tests/fortran_runtime/run_call_example.f90
+++ b/tests/fortran_runtime/run_call_example.f90
@@ -94,7 +94,7 @@ contains
     y = 2.0
     call call_subroutine(x, y)
     y_ad = 0.0
-    call call_subroutine_rev_ad(x, x_ad, y, y_ad)
+    call call_subroutine_rev_ad(x_ad, y_ad)
     inner2 = x_ad + y_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_call_subroutine_rev failed', inner1, inner2
@@ -165,7 +165,7 @@ contains
     y = 2.0
     call arg_operation(x, y)
     y_ad = 0.0
-    call arg_operation_rev_ad(x, x_ad, y, y_ad)
+    call arg_operation_rev_ad(x_ad, y_ad)
     inner2 = x_ad + y_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_arg_operation_rev failed', inner1, inner2
@@ -203,7 +203,7 @@ contains
     y = 2.0
     call arg_function(x, y)
     y_ad = 0.0
-    call arg_function_rev_ad(x, x_ad, y, y_ad)
+    call arg_function_rev_ad(x_ad, y, y_ad)
     inner2 = x_ad + y_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_arg_function_rev failed', inner1, inner2
@@ -241,7 +241,7 @@ contains
     b = 2.0
     call foo(a, b)
     b_ad = 0.0
-    call foo_rev_ad(a, a_ad, b, b_ad)
+    call foo_rev_ad(a_ad, b_ad)
     inner2 = a_ad + 0.5 * b_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_foo_rev failed', inner1, inner2

--- a/tests/fortran_runtime/run_control_flow.f90
+++ b/tests/fortran_runtime/run_control_flow.f90
@@ -70,7 +70,7 @@ contains
     fd = (z_eps - z) / eps
     x_ad = 1.0
     y_ad = 1.0
-    call if_example_fwd_ad(x, x_ad, y, y_ad, z, z_ad)
+    call if_example_fwd_ad(x, x_ad, y, z, z_ad)
     if (abs((z_ad - fd) / fd) > tol) then
        print *, 'test_if_example_fwd failed', z_ad, fd
        error stop 1
@@ -79,7 +79,7 @@ contains
     inner1 = z_ad**2
     x_ad = 0.0
     y_ad = 0.0
-    call if_example_rev_ad(x, x_ad, y, y_ad, z_ad)
+    call if_example_rev_ad(x, x_ad, z_ad)
     inner2 = x_ad + y_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_if_example_rev failed', inner1, inner2
@@ -111,7 +111,7 @@ contains
 
     inner1 = sum_ad**2
     x_ad = 0.0
-    call do_example_rev_ad(n, x, x_ad, sum_ad)
+    call do_example_rev_ad(n, x_ad, sum_ad)
     inner2 = x_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_do_example_rev failed', inner1, inner2
@@ -142,7 +142,7 @@ contains
     end if
     inner1 = z_ad**2
     x_ad = 0.0
-    call select_example_rev_ad(i, x, x_ad, z_ad)
+    call select_example_rev_ad(i, x_ad, z_ad)
     inner2 = x_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_select_example_rev failed case1', inner1, inner2
@@ -161,7 +161,7 @@ contains
     end if
     inner1 = z_ad**2
     x_ad = 0.0
-    call select_example_rev_ad(i, x, x_ad, z_ad)
+    call select_example_rev_ad(i, x_ad, z_ad)
     inner2 = x_ad
     if (abs(inner2 - inner1) > tol) then
        print *, 'test_select_example_rev failed default', inner1, inner2
@@ -192,7 +192,7 @@ contains
     inner1 = 0.0
     x_ad = 0.0
     limit_ad = 0.0
-    call do_while_example_rev_ad(x, x_ad, limit, limit_ad)
+    call do_while_example_rev_ad(x, x_ad, limit)
     inner2 = x_ad + limit_ad
     if (abs(inner2 - inner1) > tol) then
        print *, 'test_do_while_example_rev failed', inner1, inner2

--- a/tests/fortran_runtime/run_cross_mod.f90
+++ b/tests/fortran_runtime/run_cross_mod.f90
@@ -71,7 +71,7 @@ contains
 
     inner1 = x_ad**2
     x = 1.0
-    call call_inc_rev_ad(x, x_ad)
+    call call_inc_rev_ad(x_ad)
     inner2 = x_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_call_inc_rev failed', inner1, inner2
@@ -103,7 +103,7 @@ contains
 
     inner1 = x_ad**2
     x = 1.0
-    call call_inc_kw_rev_ad(x, x_ad)
+    call call_inc_kw_rev_ad(x_ad)
     inner2 = x_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_call_inc_kw_rev failed', inner1, inner2
@@ -136,7 +136,7 @@ contains
     inner1 = a_ad**2
     a = 1.0
     inc_ad = 0.0
-    call incval_rev_ad(a, a_ad, 1.0, inc_ad)
+    call incval_rev_ad(a_ad, inc_ad)
     inner2 = a_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_incval_rev failed', inner1, inner2

--- a/tests/fortran_runtime/run_derived_alloc.f90
+++ b/tests/fortran_runtime/run_derived_alloc.f90
@@ -77,7 +77,7 @@ contains
     end if
 
     call derived_alloc_finalize_fwd_ad(m)
-    call derived_alloc_init_rev_ad(n, m)
+    call derived_alloc_init_rev_ad(m)
     call derived_alloc_finalize(m)
 
     return

--- a/tests/fortran_runtime/run_directives.f90
+++ b/tests/fortran_runtime/run_directives.f90
@@ -64,7 +64,7 @@ contains
 
     inner1 = y_ad**2
     x_ad = 0.0
-    call add_const_rev_ad(x, x_ad, y_ad, z)
+    call add_const_rev_ad(x_ad, y_ad)
     inner2 = x_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_add_const_rev failed', inner1, inner2
@@ -94,7 +94,7 @@ contains
 
     inner1 = z_ad**2
     x_ad = 0.0
-    call worker_rev_ad(x, x_ad, z_ad)
+    call worker_rev_ad(x_ad, z_ad)
     inner2 = x_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_worker_rev failed', inner1, inner2

--- a/tests/fortran_runtime/run_intrinsic_func.f90
+++ b/tests/fortran_runtime/run_intrinsic_func.f90
@@ -145,7 +145,7 @@ contains
     call non_differentiable_intrinsics(str, arr, idx, lb, ub, 1.0, y)
     call non_differentiable_intrinsics(str, arr, idx, lb, ub, 1.0 + eps, y_eps)
     fd = (y_eps - y) / eps
-    call non_differentiable_intrinsics_fwd_ad(str, arr, arr_ad, idx, lb, ub, 1.0, 1.0, y, y_ad)
+    call non_differentiable_intrinsics_fwd_ad(str, arr, idx, lb, ub, 1.0, y, y_ad)
     if (abs(y_ad - fd) > tol) then
        print *, 'test_non_diff_fwd failed', y_ad, fd
        error stop 1
@@ -154,7 +154,7 @@ contains
     inner1 = y_ad**2
     arr_ad = 0.0
     x_ad = 0.0
-    call non_differentiable_intrinsics_rev_ad(str, arr, arr_ad, 1.0, x_ad, y_ad)
+    call non_differentiable_intrinsics_rev_ad(x_ad, y_ad)
     inner2 = x_ad
     if (abs(inner2 - inner1) > tol) then
        print *, 'test_non_diff_rev failed', inner1, inner2
@@ -199,7 +199,7 @@ contains
 
     inner1 = sum(mat_out_ad(:,:)**2)
     mat_in_ad(:,:) = 0.0
-    call special_intrinsics_rev_ad(mat_in, mat_in_ad, mat_out_ad)
+    call special_intrinsics_rev_ad(mat_in_ad, mat_out_ad)
     inner2 = sum(mat_in_ad(:,:))
     if (abs((inner2 - inner1) / inner1) > tol2) then
        print *, 'test_special_rev failed', inner1, inner2
@@ -226,7 +226,7 @@ contains
     call casting_intrinsics(i, r + eps, d_eps, c, n)
     fd = (d_eps - d) / eps
     r_ad = 1.0
-    call casting_intrinsics_fwd_ad(i, r, r_ad, d, d_ad, c, n)
+    call casting_intrinsics_fwd_ad(r, r_ad, d, d_ad, c, n)
     if (abs((d_ad - fd) / fd) > tol) then
        print *, 'test_casting_fwd failed', d_ad, fd
        error stop 1
@@ -238,7 +238,7 @@ contains
     c = 'A'
     call casting_intrinsics(i, r, d, c, n)
     r_ad = 0.0
-    call casting_intrinsics_rev_ad(i, r, r_ad, d_ad, c)
+    call casting_intrinsics_rev_ad(r_ad, d_ad)
     inner2 = r_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_casting failed', inner1, inner2

--- a/tests/fortran_runtime/run_mpi_example.f90
+++ b/tests/fortran_runtime/run_mpi_example.f90
@@ -78,7 +78,7 @@ contains
     else
       call MPI_reduce(inner1, inner1, 1, MPI_REAL, MPI_SUM, 0, comm, ierr)
     end if
-    call sum_reduce_rev_ad(x, x_ad, comm)
+    call sum_reduce_rev_ad(x_ad, comm)
     inner2 = x_ad
     if (rank == 0) then
       call MPI_reduce(MPI_IN_PLACE, inner2, 1, MPI_REAL, MPI_SUM, 0, comm, ierr)
@@ -122,7 +122,7 @@ contains
     else
       call MPI_reduce(inner1, inner1, 1, MPI_REAL, MPI_SUM, 0, comm, ierr)
     end if
-    call isend_irecv_rev_ad(x, x_ad, y_ad, comm)
+    call isend_irecv_rev_ad(x_ad, y_ad, comm)
     inner2 = sum(x_ad)
     if (rank == 0) then
       call MPI_reduce(MPI_IN_PLACE, inner2, 1, MPI_REAL, MPI_SUM, 0, comm, ierr)

--- a/tests/fortran_runtime/run_omp_loops.f90
+++ b/tests/fortran_runtime/run_omp_loops.f90
@@ -65,7 +65,7 @@ contains
 
     inner1 = sum(y_ad(:)**2) + s_ad**2
     x_ad(:) = 0.0
-    call sum_loop_rev_ad(n, x, x_ad, y_ad, s_ad)
+    call sum_loop_rev_ad(n, x_ad, y_ad, s_ad)
     inner2 = sum(x_ad(:))
     if (abs((inner2 - inner1) / inner1) > tol) then
       print *, 'test_sum_loop_rev failed', inner1, inner2
@@ -97,7 +97,7 @@ contains
 
     inner1 = sum(y_ad(:)**2)
     x_ad(:) = 0.0
-    call stencil_loop_rev_ad(n, x, x_ad, y_ad)
+    call stencil_loop_rev_ad(n, x_ad, y_ad)
     inner2 = sum(x_ad(:))
     if (abs((inner2 - inner1) / inner1) > tol_stencil) then
        print *, 'test_stencil_loop_rev failed', inner1, inner2

--- a/tests/fortran_runtime/run_pointer_arrays.f90
+++ b/tests/fortran_runtime/run_pointer_arrays.f90
@@ -78,7 +78,7 @@ contains
 
     inner1 = res_ad**2
     x_ad = 0.0
-    call pointer_allocate_rev_ad(n, x, x_ad, res_ad)
+    call pointer_allocate_rev_ad(n, x_ad, res_ad)
     inner2 = x_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_pointer_allocate_rev failed', inner1, inner2
@@ -113,7 +113,7 @@ contains
 
     inner1 = res_ad**2
     x_ad = 0.0
-    call pointer_subarray_rev_ad(n, x, x_ad, res_ad)
+    call pointer_subarray_rev_ad(n, x_ad, res_ad)
     inner2 = x_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_pointer_subarray_rev failed', inner1, inner2
@@ -168,7 +168,7 @@ contains
        error stop 1
     end if
 
-    call pointer_allsub_init_rev_ad(n)
+    call pointer_allsub_init_rev_ad()
     deallocate(all_p)
 
     return
@@ -202,7 +202,7 @@ contains
     inner1 = res_ad**2
     x_ad(:) = 0.0
     y_ad(:) = 0.0
-    call pointer_swap_rev_ad(n, x, x_ad, y, y_ad, res_ad)
+    call pointer_swap_rev_ad(n, x_ad, y_ad, res_ad)
     inner2 = sum(x_ad) + sum(y_ad)
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_pointer_swap_rev failed', inner1, inner2

--- a/tests/fortran_runtime/run_real_kind.f90
+++ b/tests/fortran_runtime/run_real_kind.f90
@@ -72,7 +72,7 @@ contains
     inner1 = x_ad**2
     x = 2.0_8
     call scale_8(x)
-    call scale_8_rev_ad(x, x_ad)
+    call scale_8_rev_ad(x_ad)
     inner2 = x_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_scale_8 failed', inner1, inner2
@@ -105,7 +105,7 @@ contains
     inner1 = x_ad**2
     x = 2.0_RP
     call scale_rp(x)
-    call scale_rp_rev_ad(x, x_ad)
+    call scale_rp_rev_ad(x_ad)
     inner2 = x_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_scale_rp failed', inner1, inner2
@@ -138,7 +138,7 @@ contains
     inner1 = x_ad**2
     x = 2.0d0
     call scale_dp(x)
-    call scale_dp_rev_ad(x, x_ad)
+    call scale_dp_rev_ad(x_ad)
     inner2 = x_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_scale_dp failed', inner1, inner2

--- a/tests/fortran_runtime/run_save_vars.f90
+++ b/tests/fortran_runtime/run_save_vars.f90
@@ -91,7 +91,7 @@ contains
     inner1 = z_ad**2
     x_ad = 0.0
     y_ad = 0.0
-    call simple_rev_ad(x, x_ad, y, y_ad, z_ad)
+    call simple_rev_ad(x, x_ad, y_ad, z_ad)
     inner2 = x_ad + y_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_simple_rev failed', inner1, inner2

--- a/tests/fortran_runtime/run_self_reference.f90
+++ b/tests/fortran_runtime/run_self_reference.f90
@@ -71,7 +71,7 @@ contains
     end if
 
     inner1 = sum(u_ad(:)**2)
-    call self_ref_slice_rev_ad(u, u_ad, 3, 5, 1, 3)
+    call self_ref_slice_rev_ad(u_ad, 3, 5, 1)
     inner2 = sum(u_ad(:))
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_slice_rev failed', inner1, inner2
@@ -111,7 +111,7 @@ contains
     end if
 
     inner1 = sum(u_ad(:)**2) + sum(v_ad(:)**2)
-    call self_ref_slice_ptr_rev_ad(u, u_ad, v, v_ad, 3, 5, 1, 3)
+    call self_ref_slice_ptr_rev_ad(u_ad, v_ad, 3, 5, 1, 3)
     inner2 = sum(u_ad(:)) + sum(v_ad(:))
     if (abs((inner2 - inner1) / inner1) > tol_ptr) then
        print *, 'test_slice_ptr_rev failed', inner1, inner2

--- a/tests/fortran_runtime/run_simple_math.f90
+++ b/tests/fortran_runtime/run_simple_math.f90
@@ -85,7 +85,7 @@ contains
     inner1 = c_ad**2
     a_ad = 0.0
     b_ad = 0.0
-    call add_numbers_rev_ad(a, a_ad, b, b_ad, c_ad)
+    call add_numbers_rev_ad(a_ad, b_ad, c_ad)
     inner2 = a_ad + b_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_add_numbers_rev failed', inner1, inner2
@@ -118,7 +118,7 @@ contains
     inner1 = c_ad**2
     a_ad = 0.0
     b_ad = 0.0
-    call subtract_numbers_rev_ad(a, a_ad, b, b_ad, c_ad)
+    call subtract_numbers_rev_ad(a_ad, b_ad, c_ad)
     inner2 = a_ad + b_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_subtract_numbers_rev failed', inner1, inner2

--- a/tests/fortran_runtime/run_where_forall.f90
+++ b/tests/fortran_runtime/run_where_forall.f90
@@ -74,7 +74,7 @@ contains
     a = a0
     b = b0
     b_ad(:) = 0.0
-    call where_example_rev_ad(n, a, a_ad, b, b_ad)
+    call where_example_rev_ad(n, a, a_ad, b_ad)
     inner2 = sum(a_ad(:)) + sum(b_ad(:))
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_where_example_rev failed'
@@ -103,7 +103,7 @@ contains
 
     inner1 = sum(b_ad(:)**2)
     a_ad(:) = 0.0
-    call forall_example_rev_ad(n, a, a_ad, b_ad)
+    call forall_example_rev_ad(n, a_ad, b_ad)
     inner2 = sum(a_ad(:))
     if (abs((inner2 - inner1) / inner1) > tol) then
        print *, 'test_forall_example_rev failed'


### PR DESCRIPTION
## Summary
- generate call graphs in dependency order so reverse-mode calls match pruned arguments
- keep dimension variables when pruning to expose loop bounds
- update AD examples and runtime tests to pass adjoint-only arguments
- drop dimension parameters tied to pruned arguments

## Testing
- `python tests/test_generator.py`
- `python tests/test_fortran_adcode.py`


------
https://chatgpt.com/codex/tasks/task_b_6896e4cd62f8832db858a596bd72c853