### PR TITLE
Fix missing module variable stack handling in reverse AD routines

### DIFF
--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -1258,8 +1258,7 @@ def _generate_ad_subroutine(
         if reverse:
             _strip_sequential_omp(fw_block, warnings, reverse=True)
 
-        assigned = fw_block.assigned_vars(without_savevar=True)
-        assigned = ad_block.assigned_vars(assigned, without_savevar=True)
+        assigned = routine_org.content.assigned_vars(without_savevar=True)
         required = ad_block.required_vars(without_savevar=True)
         required = fw_block.required_vars(required, without_savevar=True)
         sub_fwd_rev = _module_var_fwd_rev(


### PR DESCRIPTION
## Summary
- include original routine assignments when detecting module-variable state changes
- remove redundant forward-block assignment scan
- avoid scanning reverse AD block for module-variable assignments

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_6897586439c0832d862de76fdecbc8ff