### PR TITLE
Write fadmod after processing each module

### DIFF
--- a/examples/same_file_modules.f90
+++ b/examples/same_file_modules.f90
@@ -1,0 +1,18 @@
+module var_mod
+  implicit none
+  real :: b
+  !$FAD CONSTANT_VARS: b
+end module var_mod
+
+module use_mod
+  use var_mod
+  implicit none
+contains
+
+  subroutine add_b(x, y)
+    real, intent(in) :: x
+    real, intent(out) :: y
+    y = x + b
+  end subroutine add_b
+
+end module use_mod

--- a/examples/same_file_modules_ad.f90
+++ b/examples/same_file_modules_ad.f90
@@ -1,0 +1,37 @@
+module var_mod_ad
+  use var_mod
+  implicit none
+
+contains
+
+end module var_mod_ad
+
+module use_mod_ad
+  use use_mod
+  implicit none
+
+contains
+
+  subroutine add_b_fwd_ad(x, x_ad, y, y_ad)
+    real, intent(in)  :: x
+    real, intent(in)  :: x_ad
+    real, intent(out) :: y
+    real, intent(out) :: y_ad
+
+    y_ad = x_ad ! y = x + b
+    y = x + b
+
+    return
+  end subroutine add_b_fwd_ad
+
+  subroutine add_b_rev_ad(x_ad, y_ad)
+    real, intent(inout) :: x_ad
+    real, intent(inout) :: y_ad
+
+    x_ad = y_ad + x_ad ! y = x + b
+    y_ad = 0.0 ! y = x + b
+
+    return
+  end subroutine add_b_rev_ad
+
+end module use_mod_ad

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -1873,17 +1873,16 @@ def generate_ad(
             mod.uses.append(Use("fautodiff_stack"))
 
         modules.append(render_program(mod))
-
-    code = "\n".join(modules)
-    if out_file:
-        Path(out_file).write_text(code)
-    if write_fadmod:
-        for mod_org in modules_org:
+        if write_fadmod:
             _write_fadmod(
                 mod_org,
                 routine_map,
                 fadmod_dir,
             )
+
+    code = "\n".join(modules)
+    if out_file:
+        Path(out_file).write_text(code)
     if warn and warnings:
         for msg in warnings:
             print(f"Warning: {msg}", file=sys.stderr)


### PR DESCRIPTION
## Summary
- Write fadmod files immediately after each module is processed to make in-file module dependencies work
- Add example with multiple modules in one source file

## Testing
- `isort . --profile black`
- `black .`
- `python tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_68981f803d68832d96895651e8788062