### PR TITLE
Fix VarList handling of full array indices

### DIFF
--- a/examples/save_vars_ad.f90
+++ b/examples/save_vars_ad.f90
@@ -241,6 +241,7 @@ contains
         z(i,j) = z_save_62_ad
         x_ad(i,j) = z_ad(i,j) + x_ad(i,j) ! z(i,j) = x(i,j) + scalar
         scalar_ad = z_ad(i,j) + scalar_ad ! z(i,j) = x(i,j) + scalar
+        z_ad(i,j) = 0.0 ! z(i,j) = x(i,j) + scalar
         ary_ad(i,j) = scalar_ad * z(i,j) ! scalar = ary(i,j) * z(i,j)
         z_ad(i,j) = scalar_ad * ary(i,j) ! scalar = ary(i,j) * z(i,j)
         ary(i,j) = ary_save_60_ad

--- a/fautodiff/operators.py
+++ b/fautodiff/operators.py
@@ -130,18 +130,19 @@ class AryIndex:
         if len(index1.dims) != len(index2.dims):
             raise ValueError("Different number of dimensions")
 
-        def _check_found():
-            if diff_dim > 0:
-                return -1  # disallow differences in multiple dimensions
-
-        diff_dim = -1  # dimension at which difference was found
+        # ``diff_dim`` stores the first dimension where a difference is
+        # encountered.  If we find differences in more than one dimension the
+        # function returns ``-1`` to signal that the indices are too dissimilar
+        # to be merged.
+        diff_dim = -1
         for i, dim1 in enumerate(index1):
             dim2 = index2[i]
             if dim1 == dim2:
                 continue
             if AryIndex.dim_is_entire(dim1) and AryIndex.dim_is_entire(dim2):
                 continue
-            _check_found()
+            if diff_dim >= 0:
+                return -1
             diff_dim = i
 
         return diff_dim

--- a/tests/test_varlist.py
+++ b/tests/test_varlist.py
@@ -111,6 +111,21 @@ class TestVarList(unittest.TestCase):
         self.assertEqual(str(inter), "v(3:4)")
         self.assertEqual(inter.names(), ["v"])
 
+    def test_push_full_array(self):
+        ny = OpVar("ny", typename="integer")
+        nx = OpVar("nx", typename="integer")
+        one = OpInt(1)
+        zero = OpInt(0)
+        v1 = OpVar("v", index=[zero, OpRange([one, ny])])
+        v2 = OpVar("v", index=[OpRange([one, nx]), OpRange([one, ny])])
+        vl = VarList()
+        vl.push(v1)
+        vl.push(v2)
+        self.assertEqual(str(vl), "v(0,1:ny), v(1:nx,1:ny)")
+        v3 = OpVar("v", index=[None, None])
+        vl.push(v3)
+        self.assertEqual(str(vl), "v(:,:)")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Correct `AryIndex.get_diff_dim` to flag differences across multiple dimensions
- Ensure `VarList.push` replaces existing indices when a full array slice is added
- Add regression test for full-array VarList push and update expected Fortran output

## Testing
- `python tests/test_varlist.py`
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_68986a4aaa58832d87d8506fb5aa4bec