### PR TITLE
Handle conditional preprocessor macros

### DIFF
--- a/examples/conditional_macro.f90
+++ b/examples/conditional_macro.f90
@@ -1,0 +1,22 @@
+#define BASE 1
+#define TEMP BASE
+#define DOUBLE TEMP
+#undef TEMP
+#ifndef OMIT
+#define COND 5
+#endif
+module conditional_macro
+contains
+  subroutine foo(x, y)
+    real, intent(in) :: x
+    real, intent(out) :: y
+    real :: z
+    z = x + BASE
+    z = z + DOUBLE
+#ifdef COND
+    y = z + COND
+#else
+    y = z
+#endif
+  end subroutine foo
+end module conditional_macro

--- a/examples/conditional_macro_ad.f90
+++ b/examples/conditional_macro_ad.f90
@@ -1,0 +1,54 @@
+#define BASE 1
+#define TEMP BASE
+#define DOUBLE TEMP
+#undef TEMP
+#ifndef OMIT
+#define COND 5
+#endif
+
+module conditional_macro_ad
+  use conditional_macro
+  implicit none
+
+contains
+
+  subroutine foo_fwd_ad(x, x_ad, y, y_ad)
+    real, intent(in)  :: x
+    real, intent(in)  :: x_ad
+    real, intent(out) :: y
+    real, intent(out) :: y_ad
+    real :: z_ad
+    real :: z
+
+    z_ad = x_ad ! z = x + BASE
+    z = x + BASE
+    z = z + DOUBLE
+#ifdef COND
+    y_ad = z_ad ! y = z + COND
+    y = z + COND
+#else
+    y_ad = z_ad ! y = z
+    y = z
+#endif
+
+    return
+  end subroutine foo_fwd_ad
+
+  subroutine foo_rev_ad(x_ad, y_ad)
+    real, intent(inout) :: x_ad
+    real, intent(inout) :: y_ad
+    real :: z_ad
+
+#ifdef COND
+    z_ad = y_ad ! y = z + COND
+    y_ad = 0.0 ! y = z + COND
+#else
+    z_ad = y_ad ! y = z
+    y_ad = 0.0 ! y = z
+#endif
+    x_ad = z_ad + x_ad ! z = x + BASE
+
+    return
+  end subroutine foo_rev_ad
+
+end module conditional_macro_ad

--- a/examples/preprocessor_ad.f90
+++ b/examples/preprocessor_ad.f90
@@ -13,9 +13,9 @@ contains
     y_ad = x_ad ! y = x
     y = x
 #define SCALE_TWO 2
-    #ifdef USE_ADD
+#ifdef USE_ADD
     y = y + 1.0
-    #endif
+#endif
 
     return
   end subroutine foo_fwd_ad
@@ -24,6 +24,7 @@ contains
     real, intent(inout) :: x_ad
     real, intent(inout) :: y_ad
 
+#define SCALE_TWO 2
     x_ad = y_ad + x_ad ! y = x
     y_ad = 0.0 ! y = x
 

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -1902,13 +1902,9 @@ def generate_ad(
                 routine_map,
                 fadmod_dir,
             )
-    macro_lines = [
-        f"#define {name} {val}".rstrip()
-        for name, val in parser.macro_table.items()
-        if name not in parser.module_macros
-    ]
-    if macro_lines:
-        code = "\n".join(macro_lines + [""] + modules)
+    preamble = parser.file_cpp_lines
+    if preamble:
+        code = "\n".join(preamble + [""] + modules)
     else:
         code = "\n".join(modules)
     if out_file:

--- a/tests/test_macro_conditions.py
+++ b/tests/test_macro_conditions.py
@@ -1,0 +1,41 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fautodiff import code_tree, generator
+
+
+class TestMacroConditions(unittest.TestCase):
+    def test_conditional_macros(self):
+        code_tree.Node.reset()
+        src = Path(__file__).resolve().parents[1] / "examples" / "conditional_macro.f90"
+        generated = generator.generate_ad(str(src), warn=False)
+        lines = generated.splitlines()
+        stripped = [l.strip() for l in lines]
+
+        module_idx = stripped.index("module conditional_macro_ad")
+        top_lines = stripped[:module_idx]
+
+        # top level macro definitions and undef handling
+        self.assertIn("#define BASE 1", top_lines)
+        self.assertIn("#define TEMP BASE", top_lines)
+        self.assertIn("#define DOUBLE TEMP", top_lines)
+        self.assertIn("#undef TEMP", top_lines)
+        self.assertIn("#ifndef OMIT", top_lines)
+        self.assertIn("#define COND 5", top_lines)
+        self.assertIn("#endif", top_lines)
+
+        # conditional block preserved in subroutine
+        sub_start = stripped.index("subroutine foo_fwd_ad(x, x_ad, y, y_ad)")
+        sub_end = stripped.index("end subroutine foo_fwd_ad")
+        block = stripped[sub_start:sub_end]
+        self.assertIn("z = x + BASE", block)
+        self.assertIn("z = z + DOUBLE", block)
+        self.assertIn("#ifdef COND", block)
+        self.assertIn("y = z + COND", block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- retain all top-level preprocessor directives, including defines, undefs, and conditionals
- generate AD code for conditional macros with the original TEMP definition and surrounding directives intact
- extend regression test to verify preservation of these global preprocessor lines

## Testing
- `python tests/test_generator.py`
- `python tests/test_macro_conditions.py`


------
https://chatgpt.com/codex/tasks/task_b_689d454925b8832d979be12cc8e9be73