### PR TITLE
Handle ISO kind names in generic interface resolution

### DIFF
--- a/examples/generic_interface.f90
+++ b/examples/generic_interface.f90
@@ -1,4 +1,5 @@
 module generic_interface
+  use iso_fortran_env, only: real64
   implicit none
   interface add
     module procedure :: add_real4, add_real8, add_int
@@ -42,5 +43,11 @@ contains
     real(kind=RP), intent(out) :: z
     z = add(x, y)
   end subroutine call_add_real_kind
+
+  subroutine call_add_real_real64(x, y, z)
+    real(real64), intent(in) :: x, y
+    real(real64), intent(out) :: z
+    z = add(x, y)
+  end subroutine call_add_real_real64
 
 end module generic_interface

--- a/examples/generic_interface_ad.f90
+++ b/examples/generic_interface_ad.f90
@@ -131,4 +131,27 @@ contains
     return
   end subroutine call_add_real_kind_rev_ad
 
+  subroutine call_add_real_real64_fwd_ad(x, x_ad, y, y_ad, z, z_ad)
+    real(real64), intent(in)  :: x
+    real(real64), intent(in)  :: x_ad
+    real(real64), intent(in)  :: y
+    real(real64), intent(in)  :: y_ad
+    real(real64), intent(out) :: z
+    real(real64), intent(out) :: z_ad
+
+    call add_real8_fwd_ad(x, x_ad, y, y_ad, z, z_ad) ! z = add(x, y)
+
+    return
+  end subroutine call_add_real_real64_fwd_ad
+
+  subroutine call_add_real_real64_rev_ad(x_ad, y_ad, z_ad)
+    real(real64), intent(inout) :: x_ad
+    real(real64), intent(inout) :: y_ad
+    real(real64), intent(inout) :: z_ad
+
+    call add_real8_rev_ad(x_ad, y_ad, z_ad) ! z = add(x, y)
+
+    return
+  end subroutine call_add_real_real64_rev_ad
+
 end module generic_interface_ad

--- a/tests/fortran_runtime/run_generic_interface.f90
+++ b/tests/fortran_runtime/run_generic_interface.f90
@@ -5,7 +5,10 @@ program run_generic_interface
   real, parameter :: tol = 1.0e-4
 
   integer, parameter :: I_all = 0
-  integer, parameter :: I_call_add_real = 1
+  integer, parameter :: I_call_add_real_8 = 1
+  integer, parameter :: I_call_add_real_selected_real_kind = 2
+  integer, parameter :: I_call_add_real_kind = 3
+  integer, parameter :: I_call_add_real_real64 = 4
 
   integer :: length, status
   character(:), allocatable :: arg
@@ -19,8 +22,14 @@ program run_generic_interface
         call get_command_argument(1, arg, status=status)
         if (status == 0) then
            select case(arg)
-           case ("call_add_real")
-              i_test = I_call_add_real
+           case ("call_add_real_8")
+              i_test = I_call_add_real_8
+           case ("call_add_real_selected_real_kind")
+              i_test = I_call_add_real_selected_real_kind
+           case ("call_add_real_kind")
+              i_test = I_call_add_real_kind
+           case ("call_add_real_real64")
+              i_test = I_call_add_real_real64
            case default
               print *, 'Invalid test name: ', arg
               error stop 1
@@ -30,45 +39,155 @@ program run_generic_interface
      end if
   end if
 
-  if (i_test == I_call_add_real .or. i_test == I_all) then
-     call test_call_add_real
+  if (i_test == I_call_add_real_8 .or. i_test == I_all) then
+     call test_call_add_real_8
+  end if
+  if (i_test == I_call_add_real_selected_real_kind .or. i_test == I_all) then
+     call test_call_add_real_selected_real_kind
+  end if
+  if (i_test == I_call_add_real_kind .or. i_test == I_all) then
+     call test_call_add_real_kind
+  end if
+  if (i_test == I_call_add_real_real64 .or. i_test == I_all) then
+     call test_call_add_real_real64
   end if
 
   stop
 
 contains
 
-  subroutine test_call_add_real
-    real :: x, y, z
-    real :: x_ad, y_ad, z_ad
-    real :: z_eps, fd, eps
-    real :: inner1, inner2
+  subroutine test_call_add_real_8
+    real(8) :: x, y, z
+    real(8) :: x_ad, y_ad, z_ad
+    real(8) :: z_eps, fd, eps
+    real(8) :: inner1, inner2
 
-    eps = 1.0e-3
-    x = 2.0
-    y = 3.0
-    call call_add_real(x, y, z)
-    call call_add_real(x + eps, y + eps, z_eps)
+    eps = 1.0d-6
+    x = 2.0d0
+    y = 3.0d0
+    call call_add_real_8(x, y, z)
+    call call_add_real_8(x + eps, y + eps, z_eps)
     fd = (z_eps - z) / eps
-    x_ad = 1.0
-    y_ad = 1.0
-    call call_add_real_fwd_ad(x, x_ad, y, y_ad, z, z_ad)
+    x_ad = 1.0d0
+    y_ad = 1.0d0
+    call call_add_real_8_fwd_ad(x, x_ad, y, y_ad, z, z_ad)
     if (abs((z_ad - fd) / fd) > tol) then
-       print *, 'test_call_add_real_fwd failed', z_ad, fd
+       print *, 'test_call_add_real_8_fwd failed', z_ad, fd
        error stop 1
     end if
 
     inner1 = z_ad**2
-    x_ad = 0.0
-    y_ad = 0.0
-    call call_add_real_rev_ad(x, x_ad, y, y_ad, z_ad)
+    x_ad = 0.0d0
+    y_ad = 0.0d0
+    call call_add_real_8_rev_ad(x_ad, y_ad, z_ad)
     inner2 = x_ad + y_ad
     if (abs((inner2 - inner1) / inner1) > tol) then
-       print *, 'test_call_add_real_rev failed', inner1, inner2
+       print *, 'test_call_add_real_8_rev failed', inner1, inner2
        error stop 1
     end if
 
     return
-  end subroutine test_call_add_real
+  end subroutine test_call_add_real_8
+
+  subroutine test_call_add_real_selected_real_kind
+    integer, parameter :: RP = selected_real_kind(15, 307)
+    real(kind=RP) :: x, y, z
+    real(kind=RP) :: x_ad, y_ad, z_ad
+    real(kind=RP) :: z_eps, fd, eps
+    real(kind=RP) :: inner1, inner2
+
+    eps = 1.0d-6
+    x = 2.0d0
+    y = 3.0d0
+    call call_add_real_selected_real_kind(x, y, z)
+    call call_add_real_selected_real_kind(x + eps, y + eps, z_eps)
+    fd = (z_eps - z) / eps
+    x_ad = 1.0d0
+    y_ad = 1.0d0
+    call call_add_real_selected_real_kind_fwd_ad(x, x_ad, y, y_ad, z, z_ad)
+    if (abs((z_ad - fd) / fd) > tol) then
+       print *, 'test_call_add_real_selected_real_kind_fwd failed', z_ad, fd
+       error stop 1
+    end if
+
+    inner1 = z_ad**2
+    x_ad = 0.0d0
+    y_ad = 0.0d0
+    call call_add_real_selected_real_kind_rev_ad(x_ad, y_ad, z_ad)
+    inner2 = x_ad + y_ad
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_call_add_real_selected_real_kind_rev failed', inner1, inner2
+       error stop 1
+    end if
+
+    return
+  end subroutine test_call_add_real_selected_real_kind
+
+  subroutine test_call_add_real_kind
+    integer, parameter :: RP = kind(1.0d0)
+    real(kind=RP) :: x, y, z
+    real(kind=RP) :: x_ad, y_ad, z_ad
+    real(kind=RP) :: z_eps, fd, eps
+    real(kind=RP) :: inner1, inner2
+
+    eps = 1.0d-6
+    x = 2.0d0
+    y = 3.0d0
+    call call_add_real_kind(x, y, z)
+    call call_add_real_kind(x + eps, y + eps, z_eps)
+    fd = (z_eps - z) / eps
+    x_ad = 1.0d0
+    y_ad = 1.0d0
+    call call_add_real_kind_fwd_ad(x, x_ad, y, y_ad, z, z_ad)
+    if (abs((z_ad - fd) / fd) > tol) then
+       print *, 'test_call_add_real_kind_fwd failed', z_ad, fd
+       error stop 1
+    end if
+
+    inner1 = z_ad**2
+    x_ad = 0.0d0
+    y_ad = 0.0d0
+    call call_add_real_kind_rev_ad(x_ad, y_ad, z_ad)
+    inner2 = x_ad + y_ad
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_call_add_real_kind_rev failed', inner1, inner2
+       error stop 1
+    end if
+
+    return
+  end subroutine test_call_add_real_kind
+
+  subroutine test_call_add_real_real64
+    real(kind=real64) :: x, y, z
+    real(kind=real64) :: x_ad, y_ad, z_ad
+    real(kind=real64) :: z_eps, fd, eps
+    real(kind=real64) :: inner1, inner2
+
+    eps = 1.0d-6
+    x = 2.0d0
+    y = 3.0d0
+    call call_add_real_real64(x, y, z)
+    call call_add_real_real64(x + eps, y + eps, z_eps)
+    fd = (z_eps - z) / eps
+    x_ad = 1.0d0
+    y_ad = 1.0d0
+    call call_add_real_real64_fwd_ad(x, x_ad, y, y_ad, z, z_ad)
+    if (abs((z_ad - fd) / fd) > tol) then
+       print *, 'test_call_add_real_real64_fwd failed', z_ad, fd
+       error stop 1
+    end if
+
+    inner1 = z_ad**2
+    x_ad = 0.0d0
+    y_ad = 0.0d0
+    call call_add_real_real64_rev_ad(x_ad, y_ad, z_ad)
+    inner2 = x_ad + y_ad
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_call_add_real_real64_rev failed', inner1, inner2
+       error stop 1
+    end if
+
+    return
+  end subroutine test_call_add_real_real64
 
 end program run_generic_interface

--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -162,7 +162,15 @@ class TestFortranADCode(unittest.TestCase):
         self._run_test("derived_alloc", ["derived_alloc"])
 
     def test_generic_interface(self):
-        self._run_test("generic_interface", ["call_add_real"])
+        self._run_test(
+            "generic_interface",
+            [
+                "call_add_real_8",
+                "call_add_real_selected_real_kind",
+                "call_add_real_kind",
+                "call_add_real_real64",
+            ],
+        )
 
     mpifort = shutil.which("mpifort")
 


### PR DESCRIPTION
## Summary
- parse ISO_FORTRAN_ENV kind constants and `kind()` expressions to resolve generic procedures correctly
- load ISO_FORTRAN_ENV fadmod instead of skipping and add real64 generic interface example
- test all generic-interface subroutines in runtime tests
- use `real(real64)` declarations in the AD example to match original style

## Testing
- `python tests/test_generator.py`
- `pytest tests/test_fortran_adcode.py -k generic --config-file=pyproject.toml`


------
https://chatgpt.com/codex/tasks/task_b_68a0530edb00832db89a29075e3ec10a