### PR TITLE
Warn and preserve unsupported function macros

### DIFF
--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -1731,6 +1731,7 @@ def generate_ad(
         search_dirs.append(cwd)
 
     modules_org = parser.parse_file(in_file, search_dirs=search_dirs)
+    warnings.extend(parser.macro_warnings)
     if fadmod_dir is None:
         fadmod_dir = Path.cwd()
     else:

--- a/tests/test_macro_warnings.py
+++ b/tests/test_macro_warnings.py
@@ -1,0 +1,51 @@
+import io
+import sys
+import textwrap
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fautodiff import code_tree, generator, parser
+
+
+class TestMacroWarnings(unittest.TestCase):
+    def test_token_paste_and_variadic_macro_warn(self):
+        code_tree.Node.reset()
+        src = textwrap.dedent(
+            """
+            #define CONCAT(a, b) a ## b
+            #define VARIADIC(...) (__VA_ARGS__)
+            program foo
+            end program foo
+            """
+        )
+        with NamedTemporaryFile("w", suffix=".F90", delete=False) as tmp:
+            tmp.write(src)
+            path = tmp.name
+        try:
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                generated = generator.generate_ad(path)
+            msgs = buf.getvalue().splitlines()
+            self.assertTrue(any("CONCAT" in m for m in msgs))
+            self.assertTrue(any("VARIADIC" in m for m in msgs))
+            lines = [l.strip() for l in generated.splitlines()]
+            self.assertIn("#define CONCAT(a, b) a ## b", lines)
+            self.assertIn("#define VARIADIC(...) (__VA_ARGS__)", lines)
+        finally:
+            Path(path).unlink()
+
+    def test_line_continuation_macro_warn(self):
+        src = "#define BIG(a) a + \\\n  a\n"
+        injected = parser._inject_cpp_lines(src)
+        parser._extract_macros(injected)
+        self.assertTrue(any("BIG" in m for m in parser.macro_warnings))
+        self.assertNotIn("BIG", parser.macro_table.func)
+        self.assertIn("#define BIG(a) a + \\", parser.file_cpp_lines)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- track unsupported function-like macros in parser.macro_warnings
- add macro warnings to generator's warning list for stderr reporting
- capture and check warnings via stderr in tests

## Testing
- `python tests/test_macro_warnings.py`
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_68a055485688832db44ff6ec05e75bc5