### PR TITLE
Preserve kind syntax and module uses in generated code

### DIFF
--- a/examples/same_file_modules_ad.f90
+++ b/examples/same_file_modules_ad.f90
@@ -8,6 +8,7 @@ end module var_mod_ad
 
 module use_mod_ad
   use use_mod
+  use var_mod
   implicit none
 
 contains

--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -2408,6 +2408,8 @@ class Routine(Node):
         return OpVar(
             name,
             kind=decl.kind,
+            kind_val=decl.kind_val,
+            kind_keyword=decl.kind_keyword,
             char_len=decl.char_len,
             dims=decl.dims,
             typename=decl.typename,
@@ -2533,6 +2535,7 @@ class Declaration(Node):
     typename: str
     kind: Optional[str] = None
     kind_val: Optional[str] = None
+    kind_keyword: bool = False
     char_len: Optional[str] = None
     dims: Optional[Union[Tuple[str], str]] = None
     intent: Optional[str] = None
@@ -2557,6 +2560,10 @@ class Declaration(Node):
             raise ValueError(f"kind must be str: {type(self.kind)}")
         if self.kind_val is not None and not isinstance(self.kind_val, str):
             raise ValueError(f"kind_val must be str: {type(self.kind_val)}")
+        if self.kind_keyword is None:
+            self.kind_keyword = False
+        elif not isinstance(self.kind_keyword, bool):
+            raise ValueError(f"kind_keyword must be bool: {type(self.kind_keyword)}")
         if self.char_len is not None and not isinstance(self.char_len, str):
             raise ValueError(f"char_len must be str: {type(self.char_len)}")
         if self.dims is not None and (
@@ -2575,6 +2582,7 @@ class Declaration(Node):
             typename=self.typename,
             kind=self.kind,
             kind_val=self.kind_val,
+            kind_keyword=self.kind_keyword,
             char_len=self.char_len,
             dims=self.dims,
             intent=self.intent,
@@ -2601,6 +2609,7 @@ class Declaration(Node):
             typename=self.typename,
             kind=self.kind,
             kind_val=self.kind_val,
+            kind_keyword=self.kind_keyword,
             char_len=self.char_len,
             dims=dims,
             intent=self.intent,
@@ -2627,6 +2636,7 @@ class Declaration(Node):
                 typename=self.typename,
                 kind=self.kind,
                 kind_val=self.kind_val,
+                kind_keyword=self.kind_keyword,
                 is_constant=self.parameter or self.constant,
                 allocatable=self.allocatable,
                 pointer=self.pointer,
@@ -2654,6 +2664,7 @@ class Declaration(Node):
             typename=self.typename,
             kind=self.kind,
             kind_val=self.kind_val,
+            kind_keyword=self.kind_keyword,
             is_constant=self.parameter or self.constant,
             allocatable=self.allocatable,
             pointer=self.pointer,
@@ -2684,7 +2695,10 @@ class Declaration(Node):
             if self.kind.isdigit():
                 line += f"({self.kind})"
             else:
-                line += f"(kind={self.kind})"
+                if self.kind_keyword:
+                    line += f"(kind={self.kind})"
+                else:
+                    line += f"({self.kind})"
         if self.char_len is not None:
             line += f"(len={self.char_len})"
         if self.parameter:

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -855,6 +855,7 @@ def _prepare_fwd_ad_header(
                 typename=typ,
                 kind=kind,
                 kind_val=kind_val,
+                kind_keyword=getattr(arg, "kind_keyword", None),
                 dims=dims,
                 intent=arg.intent,
                 ad_target=True,
@@ -901,6 +902,7 @@ def _prepare_fwd_ad_header(
                 typename=var.typename,
                 kind=var.kind,
                 kind_val=getattr(var, "kind_val", None),
+                kind_keyword=getattr(var, "kind_keyword", False),
                 char_len=var.char_len,
                 dims=var.dims,
                 intent=var.intent,
@@ -980,6 +982,7 @@ def _prepare_rev_ad_header(
                     typename=typ,
                     kind=kind,
                     kind_val=kind_val,
+                    kind_keyword=getattr(arg, "kind_keyword", None),
                     dims=dims,
                     intent="inout",
                     ad_target=True,
@@ -1006,6 +1009,7 @@ def _prepare_rev_ad_header(
                     typename=typ,
                     kind=kind,
                     kind_val=kind_val,
+                    kind_keyword=getattr(arg, "kind_keyword", None),
                     dims=dims,
                     intent="inout",
                     ad_target=True,
@@ -1050,6 +1054,7 @@ def _prepare_rev_ad_header(
                 typename=var.typename,
                 kind=var.kind,
                 kind_val=getattr(var, "kind_val", None),
+                kind_keyword=getattr(var, "kind_keyword", False),
                 char_len=var.char_len,
                 dims=var.dims,
                 intent=var.intent,
@@ -1179,7 +1184,9 @@ def _generate_ad_subroutine(
         and not has_save_grad_input
     ):
         for arg in out_grad_args:
-            lhs = OpVar(arg.name, kind=arg.kind)
+            lhs = OpVar(
+                arg.name, kind=arg.kind, kind_keyword=getattr(arg, "kind_keyword", None)
+            )
             if arg.is_complex_type:
                 zero = OpComplex(
                     OpReal("0.0", kind=arg.kind),
@@ -1251,6 +1258,8 @@ def _generate_ad_subroutine(
                             name=name,
                             typename=base_decl.typename,
                             kind=base_decl.kind,
+                            kind_val=base_decl.kind_val,
+                            kind_keyword=base_decl.kind_keyword,
                             dims=base_decl.dims,
                             parameter=base_decl.parameter,
                             init_val=base_decl.init_val,
@@ -1468,6 +1477,8 @@ def _generate_ad_subroutine(
                             name=name,
                             typename=base_decl.typename,
                             kind=base_decl.kind,
+                            kind_val=base_decl.kind_val,
+                            kind_keyword=base_decl.kind_keyword,
                             dims=base_decl.dims,
                             parameter=base_decl.parameter,
                             init_val=base_decl.init_val,
@@ -1646,6 +1657,14 @@ def _generate_ad_subroutine(
                 name=var.name,
                 typename=typename,
                 kind=kind,
+                kind_val=(
+                    base_decl.kind_val if base_decl else getattr(var, "kind_val", None)
+                ),
+                kind_keyword=(
+                    base_decl.kind_keyword
+                    if base_decl
+                    else getattr(var, "kind_keyword", False)
+                ),
                 dims=dims,
                 parameter=base_decl.parameter if base_decl else False,
                 init_val=base_decl.init_val if base_decl else None,
@@ -1781,7 +1800,13 @@ def generate_ad(
             else:
                 mod.uses = Block([])
         else:
-            mod.uses = Block([Use(name)])
+            if mod_org.uses is not None:
+                uses = Block([Use(name)])
+                for child in mod_org.uses.iter_children():
+                    uses.append(child.deep_clone())
+                mod.uses = uses
+            else:
+                mod.uses = Block([Use(name)])
 
         if mod_org.decls:
             type_map = {}
@@ -1924,9 +1949,12 @@ def generate_ad(
                     mod.routines.append(info["wrapper"])
 
         name_mod = mod.name
+        existing_uses = {u.name for u in mod.uses.iter_children() if isinstance(u, Use)}
         for m in sorted(ad_modules_used):
             if m != name_mod:
-                mod.uses.append(Use(m))
+                if m not in existing_uses:
+                    mod.uses.append(Use(m))
+                    existing_uses.add(m)
                 mod.uses.append(Use(f"{m}{AD_SUFFIX}"))
         if pushpop_used:
             mod.uses.append(Use("fautodiff_stack"))

--- a/fautodiff/operators.py
+++ b/fautodiff/operators.py
@@ -981,6 +981,7 @@ class OpVar(OpLeaf):
     index: Optional[AryIndex] = None
     kind: Optional[str] = None
     kind_val: Optional[str] = None
+    kind_keyword: Optional[bool] = field(default=None, repr=False)
     char_len: Optional[str] = None
     typename: Optional[str] = field(default=None)
     dims: Optional[Tuple[str]] = field(repr=False, default=None)
@@ -1006,6 +1007,7 @@ class OpVar(OpLeaf):
         index: Optional[AryIndex] = None,
         kind: Optional[str] = None,
         kind_val: Optional[str] = None,
+        kind_keyword: Optional[bool] = None,
         char_len: Optional[str] = None,
         dims: Optional[Tuple[str]] = None,
         reference: Optional[OpVar] = None,
@@ -1035,6 +1037,7 @@ class OpVar(OpLeaf):
         self.index = index
         self.kind = kind
         self.kind_val = kind_val
+        self.kind_keyword = kind_keyword
         self.char_len = char_len
         self.dims = dims
         self.reference = reference
@@ -1177,6 +1180,8 @@ class OpVar(OpLeaf):
             name=self.name,
             index=index,
             kind=self.kind,
+            kind_val=self.kind_val,
+            kind_keyword=self.kind_keyword,
             char_len=self.char_len,
             dims=self.dims,
             reference=self.reference,
@@ -1211,6 +1216,8 @@ class OpVar(OpLeaf):
             name,
             index=index,
             kind=self.kind,
+            kind_val=self.kind_val,
+            kind_keyword=self.kind_keyword,
             char_len=self.char_len,
             dims=self.dims,
             reference=self.reference,
@@ -1261,6 +1268,8 @@ class OpVar(OpLeaf):
             name,
             index=index,
             kind=self.kind,
+            kind_val=self.kind_val,
+            kind_keyword=self.kind_keyword,
             char_len=self.char_len,
             dims=self.dims,
             reference=self.reference,

--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -756,6 +756,7 @@ def _parse_decl_stmt(
     type_spec = stmt.items[0]
     kind = None
     kind_val = None
+    kind_keyword = False
     char_len = None
     type_def = None
     if isinstance(type_spec, Fortran2003.Intrinsic_Type_Spec):
@@ -791,6 +792,8 @@ def _parse_decl_stmt(
                         kind_val = _eval_kind(init)
                         if kind_val is None:
                             kind_val = _eval_iso_kind(init) or init
+                    if not init.strip().isdigit():
+                        kind_keyword = True
         elif isinstance(selector, Fortran2003.Length_Selector):
             char_len = selector.items[1].string
         else:
@@ -929,6 +932,7 @@ def _parse_decl_stmt(
                 typename=base_type.lower(),
                 kind=kind,
                 kind_val=kind_val,
+                kind_keyword=kind_keyword,
                 char_len=char_len,
                 dims=dims,
                 intent=intent,


### PR DESCRIPTION
## Summary
- infer when original declarations omitted the `kind=` keyword so generated code mirrors that syntax
- align `generic_interface_ad.f90` expectations with shorthand kind usage

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_68a083082220832d8a58f17d615ba077