### PR TITLE
Expand preprocessing for object macros and add multi-statement macro test

### DIFF
--- a/examples/macro_multistmt.F90
+++ b/examples/macro_multistmt.F90
@@ -1,0 +1,8 @@
+#define DO_TWO x  = x + 1; y = y * 2
+module macro_multistmt
+contains
+  subroutine foo(x, y)
+    real :: x, y
+    DO_TWO
+  end subroutine foo
+end module macro_multistmt

--- a/examples/macro_multistmt_ad.F90
+++ b/examples/macro_multistmt_ad.F90
@@ -1,0 +1,29 @@
+#define DO_TWO x  = x + 1; y = y * 2
+
+module macro_multistmt_ad
+  use macro_multistmt
+  implicit none
+
+contains
+
+  subroutine foo_fwd_ad(x, y, y_ad)
+    real :: x
+    real :: y
+    real :: y_ad
+
+    x = x + 1
+    y_ad = y_ad * 2 ! y = y * 2
+    y = y * 2
+
+    return
+  end subroutine foo_fwd_ad
+
+  subroutine foo_rev_ad(y_ad)
+    real, intent(inout) :: y_ad
+
+    y_ad = y_ad * 2 ! y = y * 2
+
+    return
+  end subroutine foo_rev_ad
+
+end module macro_multistmt_ad

--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -1084,6 +1084,10 @@ class Block(Node):
             self.append(node)
 
     def insert_before(self, id: int, node: Node) -> None:
+        if isinstance(node, Block):
+            for ch in reversed(node._children):
+                self.insert_before(id, ch)
+            return
         for i, child in enumerate(self._children):
             if child.get_id() == id:
                 node.build_do_index_list(self.do_index_list)
@@ -1092,6 +1096,11 @@ class Block(Node):
         raise ValueError("id is not found")
 
     def insert_after(self, id: int, node: Node) -> None:
+        if isinstance(node, Block):
+            for ch in node._children:
+                self.insert_after(id, ch)
+                id = ch.get_id()
+            return
         for i, child in enumerate(self._children):
             if child.get_id() == id:
                 node.build_do_index_list(self.do_index_list)
@@ -1100,6 +1109,10 @@ class Block(Node):
         raise ValueError("id is not found")
 
     def insert_begin(self, node: Node) -> None:
+        if isinstance(node, Block):
+            for ch in reversed(node._children):
+                self.insert_begin(ch)
+            return
         node.build_do_index_list(self.do_index_list)
         self._set_parent(node)
         return self._children.insert(0, node)

--- a/tests/fortran_runtime/Makefile
+++ b/tests/fortran_runtime/Makefile
@@ -20,7 +20,7 @@ PROGRAM_NAMES = run_simple_math.out run_arrays.out run_call_example.out run_cont
            run_directives.out run_parameter_var.out run_module_vars.out run_call_module_vars.out run_allocate_vars.out \
            run_exit_cycle.out run_pointer_arrays.out run_derived_alloc.out run_mpi_example.out \
                    run_stack.out run_where_forall.out run_omp_loops.out run_return_example.out run_self_reference.out \
-           run_macro_args.out
+           run_macro_args.out run_macro_multistmt.out
 PROGRAMS = $(addprefix $(OUTDIR)/,$(PROGRAM_NAMES))
 
 .PHONY: all clean
@@ -82,6 +82,7 @@ $(OUTDIR)/run_fautodiff_stack.o: $(OUTDIR)/fautodiff_stack.o
 
 $(OUTDIR)/run_self_reference.o: $(OUTDIR)/self_reference.o $(OUTDIR)/self_reference_ad.o
 $(OUTDIR)/run_macro_args.o: $(OUTDIR)/macro_args.o $(OUTDIR)/macro_args_ad.o
+$(OUTDIR)/run_macro_multistmt.o: $(OUTDIR)/macro_multistmt.o $(OUTDIR)/macro_multistmt_ad.o
 
 
 $(OUTDIR)/run_simple_math.out: $(OUTDIR)/run_simple_math.o $(OUTDIR)/simple_math.o $(OUTDIR)/simple_math_ad.o
@@ -113,6 +114,7 @@ $(OUTDIR)/run_fautodiff_stack.out: $(OUTDIR)/run_fautodiff_stack.o $(OUTDIR)/fau
 
 $(OUTDIR)/run_self_reference.out: $(OUTDIR)/run_self_reference.o $(OUTDIR)/self_reference.o $(OUTDIR)/self_reference_ad.o
 $(OUTDIR)/run_macro_args.out: $(OUTDIR)/run_macro_args.o $(OUTDIR)/macro_args.o $(OUTDIR)/macro_args_ad.o
+$(OUTDIR)/run_macro_multistmt.out: $(OUTDIR)/run_macro_multistmt.o $(OUTDIR)/macro_multistmt.o $(OUTDIR)/macro_multistmt_ad.o
 
 clean:
 	rm -f $(OUTDIR)/*.o $(OUTDIR)/*.mod

--- a/tests/fortran_runtime/run_macro_multistmt.f90
+++ b/tests/fortran_runtime/run_macro_multistmt.f90
@@ -1,0 +1,75 @@
+program run_macro_multistmt
+  use macro_multistmt
+  use macro_multistmt_ad
+  implicit none
+  real, parameter :: tol = 1.0e-4
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_foo = 1
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("foo")
+              i_test = I_foo
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_foo .or. i_test == I_all) then
+     call test_foo
+  end if
+
+  stop
+contains
+
+  subroutine test_foo
+    real :: x, y
+    real :: y_ad
+    real :: y_eps, fd, eps
+    real :: inner1, inner2
+
+    eps = 1.0e-3
+    x = 1.0
+    y = 3.0
+    call foo(x, y)
+    x = 1.0
+    y_eps = 3.0 + eps
+    call foo(x, y_eps)
+    fd = (y_eps - y) / eps
+
+    x = 1.0
+    y = 3.0
+    y_ad = 1.0
+    call foo_fwd_ad(x, y, y_ad)
+    if (abs((y_ad - fd) / fd) > tol) then
+       print *, 'test_foo_fwd failed', y_ad, fd
+       error stop 1
+    end if
+
+    inner1 = y_ad**2
+    call foo_rev_ad(y_ad)
+    inner2 = y_ad
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_foo_rev failed', inner1, inner2
+       error stop 1
+    end if
+
+    return
+  end subroutine test_foo
+
+end program run_macro_multistmt

--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -181,6 +181,9 @@ class TestFortranADCode(unittest.TestCase):
     def test_macro_args(self):
         self._run_test("macro_args", ["foo"])
 
+    def test_macro_multistmt(self):
+        self._run_test("macro_multistmt", ["foo"])
+
     def test_self_reference(self):
         self._run_test(
             "self_reference",

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -366,6 +366,12 @@ class TestGenerator(unittest.TestCase):
         self.assertFalse(routines["foo"].get("skip"))
         self.assertFalse(routines["bar"].get("skip"))
 
+    def test_macro_multistmt_example(self):
+        code_tree.Node.reset()
+        generated = generator.generate_ad("examples/macro_multistmt.F90", warn=False)
+        expected = Path("examples/macro_multistmt_ad.F90").read_text()
+        self.assertEqual(generated, expected)
+
     def test_deallocate_mod_grad_var_prevents_skip(self):
         code_tree.Node.reset()
         import textwrap

--- a/tests/test_macro_multistmt.py
+++ b/tests/test_macro_multistmt.py
@@ -1,0 +1,28 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fautodiff import code_tree, generator, parser
+
+
+class TestMacroMultiStmt(unittest.TestCase):
+    def test_multi_statement_macro(self):
+        code_tree.Node.reset()
+        src = Path(__file__).resolve().parents[1] / "examples" / "macro_multistmt.F90"
+        generated = generator.generate_ad(str(src), warn=False)
+        lines = generated.splitlines()
+        stripped = [l.strip() for l in lines]
+
+        # macro definition moved to top
+        self.assertEqual(stripped[0], "#define DO_TWO x  = x + 1; y = y * 2")
+        # expanded statements are present
+        self.assertTrue(any("x = x + 1" in l for l in stripped))
+        self.assertTrue(any("y = y * 2" in l for l in stripped))
+        # generated code should parse without errors
+        parser.parse_src(generated)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- preserve macro directives within modules and routines while expanding stand-alone macro statements
- restore macro-related tests and expected AD output
- include generated AD example for multi-statement macro

## Testing
- `pytest tests/test_macro_preserve.py tests/test_macro_conditions.py tests/test_macro_multistmt.py tests/test_generator.py`
- `pytest tests/test_fortran_adcode.py::TestFortranADCode::test_macro_multistmt`

------
https://chatgpt.com/codex/tasks/task_b_68a080677b18832db0cc2b6ac0ef46a4