### PR TITLE
Warn about AD-suffixed identifiers in macro expansions

### DIFF
--- a/tests/test_macro_rename.py
+++ b/tests/test_macro_rename.py
@@ -1,0 +1,18 @@
+import textwrap
+import unittest
+
+from fautodiff import parser
+
+
+class TestMacroRename(unittest.TestCase):
+    def test_token_with_ad_suffix_renamed(self):
+        src = "!$CPP #define BAD foo_ad\n"
+        parser._extract_macros(src)
+        expanded = parser._expand_macros("BAD\n")
+        line = expanded.strip()
+        self.assertEqual(line, "foo_ad_macro ! foo_ad -> foo_ad_macro")
+        self.assertTrue(any("foo_ad" in m for m in parser.macro_warnings))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- warn when macro expansions emit identifiers ending in `_ad`
- allow renaming such identifiers via hook and annotate with original names
- test macro renaming hook

## Testing
- `python tests/test_generator.py`
- `python -m pytest tests/test_macro_rename.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a124a9b8cc832dbe11bfad8b4debe2