### PR TITLE
Add example for module use with differing kinds

### DIFF
--- a/examples/real4_module.f90
+++ b/examples/real4_module.f90
@@ -1,4 +1,4 @@
 module real4_module
   implicit none
-  real(4), parameter :: r = 1.0_4
+  real(4) :: r = 1.0_4
 end module real4_module

--- a/examples/real4_module.f90
+++ b/examples/real4_module.f90
@@ -1,0 +1,4 @@
+module real4_module
+  implicit none
+  real(4), parameter :: r = 1.0_4
+end module real4_module

--- a/examples/real4_module_ad.f90
+++ b/examples/real4_module_ad.f90
@@ -2,6 +2,8 @@ module real4_module_ad
   use real4_module
   implicit none
 
+  real(4) :: r_ad = 0.0e0
+
 contains
 
 end module real4_module_ad

--- a/examples/real4_module_ad.f90
+++ b/examples/real4_module_ad.f90
@@ -1,0 +1,7 @@
+module real4_module_ad
+  use real4_module
+  implicit none
+
+contains
+
+end module real4_module_ad

--- a/examples/real8_module.f90
+++ b/examples/real8_module.f90
@@ -1,0 +1,4 @@
+module real8_module
+  implicit none
+  real(8), parameter :: r = 2.0_8
+end module real8_module

--- a/examples/real8_module.f90
+++ b/examples/real8_module.f90
@@ -1,4 +1,4 @@
 module real8_module
   implicit none
-  real(8), parameter :: r = 2.0_8
+  real(8) :: r = 2.0_8
 end module real8_module

--- a/examples/real8_module_ad.f90
+++ b/examples/real8_module_ad.f90
@@ -1,0 +1,7 @@
+module real8_module_ad
+  use real8_module
+  implicit none
+
+contains
+
+end module real8_module_ad

--- a/examples/real8_module_ad.f90
+++ b/examples/real8_module_ad.f90
@@ -2,6 +2,8 @@ module real8_module_ad
   use real8_module
   implicit none
 
+  real(8) :: r_ad = 0.0d0
+
 contains
 
 end module real8_module_ad

--- a/examples/use_module_conflict.f90
+++ b/examples/use_module_conflict.f90
@@ -1,13 +1,18 @@
 module use_module_conflict
-  use real4_module, only: r4 => r
-  use real8_module
+  use real4_module
   implicit none
+
 contains
+
   subroutine add_with_mod(x, y)
     use real8_module
     real(8), intent(in) :: x
     real(8), intent(out) :: y
-    y = x + r
+
+    y = x + 1.0d0
+    r = x
+
     return
   end subroutine add_with_mod
+
 end module use_module_conflict

--- a/examples/use_module_conflict.f90
+++ b/examples/use_module_conflict.f90
@@ -1,0 +1,13 @@
+module use_module_conflict
+  use real4_module, only: r4 => r
+  use real8_module
+  implicit none
+contains
+  subroutine add_with_mod(x, y)
+    use real8_module
+    real(8), intent(in) :: x
+    real(8), intent(out) :: y
+    y = x + r
+    return
+  end subroutine add_with_mod
+end module use_module_conflict

--- a/examples/use_module_conflict_ad.f90
+++ b/examples/use_module_conflict_ad.f90
@@ -1,0 +1,31 @@
+module use_module_conflict_ad
+  use use_module_conflict
+  use real4_module, only: r4 => r
+  use real8_module
+  implicit none
+
+contains
+
+  subroutine add_with_mod_fwd_ad(x, x_ad, y, y_ad)
+    real(8), intent(in)  :: x
+    real(8), intent(in)  :: x_ad
+    real(8), intent(out) :: y
+    real(8), intent(out) :: y_ad
+
+    y_ad = x_ad ! y = x + r
+    y = x + r
+
+    return
+  end subroutine add_with_mod_fwd_ad
+
+  subroutine add_with_mod_rev_ad(x_ad, y_ad)
+    real(8), intent(inout) :: x_ad
+    real(8), intent(inout) :: y_ad
+
+    x_ad = y_ad + x_ad ! y = x + r
+    y_ad = 0.0d0 ! y = x + r
+
+    return
+  end subroutine add_with_mod_rev_ad
+
+end module use_module_conflict_ad

--- a/examples/use_module_conflict_ad.f90
+++ b/examples/use_module_conflict_ad.f90
@@ -1,29 +1,36 @@
 module use_module_conflict_ad
   use use_module_conflict
-  use real4_module, only: r4 => r
-  use real8_module
+  use real4_module
   implicit none
 
 contains
 
   subroutine add_with_mod_fwd_ad(x, x_ad, y, y_ad)
+    use real8_module
+    use real8_module_ad
     real(8), intent(in)  :: x
     real(8), intent(in)  :: x_ad
     real(8), intent(out) :: y
     real(8), intent(out) :: y_ad
 
-    y_ad = x_ad ! y = x + r
-    y = x + r
+    y_ad = x_ad ! y = x + 1.0d0
+    y = x + 1.0d0
+    r_ad = x_ad ! r = x
+    r = x
 
     return
   end subroutine add_with_mod_fwd_ad
 
   subroutine add_with_mod_rev_ad(x_ad, y_ad)
+    use real8_module
+    use real8_module_ad
     real(8), intent(inout) :: x_ad
     real(8), intent(inout) :: y_ad
 
-    x_ad = y_ad + x_ad ! y = x + r
-    y_ad = 0.0d0 ! y = x + r
+    x_ad = r_ad + x_ad ! r = x
+    r_ad = 0.0d0 ! r = x
+    x_ad = y_ad + x_ad ! y = x + 1.0d0
+    y_ad = 0.0d0 ! y = x + 1.0d0
 
     return
   end subroutine add_with_mod_rev_ad

--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -498,7 +498,9 @@ class Node:
                 if arg.dims:
                     if arg.index:
                         if len(arg.index) != len(arg.dims):
-                            raise RuntimeError(f"rank is not consistent: {arg.index} {arg.dims}")
+                            raise RuntimeError(
+                                f"rank is not consistent: {arg.index} {arg.dims}"
+                            )
                         ndims = 0
                         for idx in arg.index:
                             if idx is None or isinstance(idx, OpRange):
@@ -1852,6 +1854,15 @@ class Use(Node):
     def deep_clone(self) -> "Use":
         only = list(self.only) if self.only else None
         return Use(self.name, only)
+
+    def prune_for(
+        self,
+        targets: VarList,
+        mod_vars: Optional[List[OpVar]] = None,
+        decl_map: Optional[Dict[str, "Declaration"]] = None,
+        base_targets: Optional[VarList] = None,
+    ) -> "Use":
+        return self
 
     def render(self, indent: int = 0) -> List[str]:
         space = "  " * indent

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -898,6 +898,8 @@ def _prepare_fwd_ad_header(
     for node in decl_children:
         if isinstance(node, Use):
             subroutine.decls.append(node.deep_clone())
+            if not node.name.endswith(AD_SUFFIX):
+                subroutine.decls.append(Use(f"{node.name}{AD_SUFFIX}"))
 
     for var in args:
         subroutine.decls.append(
@@ -1054,6 +1056,8 @@ def _prepare_rev_ad_header(
     for node in decl_children:
         if isinstance(node, Use):
             subroutine.decls.append(node.deep_clone())
+            if not node.name.endswith(AD_SUFFIX):
+                subroutine.decls.append(Use(f"{node.name}{AD_SUFFIX}"))
 
     for var in args:
         subroutine.decls.append(

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -895,6 +895,10 @@ def _prepare_fwd_ad_header(
             clone.donot_prune = True
             subroutine.decls.append(clone)
 
+    for node in decl_children:
+        if isinstance(node, Use):
+            subroutine.decls.append(node.deep_clone())
+
     for var in args:
         subroutine.decls.append(
             Declaration(
@@ -1046,6 +1050,10 @@ def _prepare_rev_ad_header(
             clone = node.deep_clone()
             clone.donot_prune = True
             subroutine.decls.append(clone)
+
+    for node in decl_children:
+        if isinstance(node, Use):
+            subroutine.decls.append(node.deep_clone())
 
     for var in args:
         subroutine.decls.append(

--- a/tests/fortran_runtime/Makefile
+++ b/tests/fortran_runtime/Makefile
@@ -20,7 +20,7 @@ PROGRAM_NAMES = run_simple_math.out run_arrays.out run_call_example.out run_cont
            run_directives.out run_parameter_var.out run_module_vars.out run_call_module_vars.out run_allocate_vars.out \
            run_exit_cycle.out run_pointer_arrays.out run_derived_alloc.out run_mpi_example.out \
                    run_stack.out run_where_forall.out run_omp_loops.out run_return_example.out run_self_reference.out \
-           run_macro_args.out run_macro_multistmt.out
+           run_macro_args.out run_macro_multistmt.out run_use_module_conflict.out
 PROGRAMS = $(addprefix $(OUTDIR)/,$(PROGRAM_NAMES))
 
 .PHONY: all clean
@@ -83,6 +83,7 @@ $(OUTDIR)/run_fautodiff_stack.o: $(OUTDIR)/fautodiff_stack.o
 $(OUTDIR)/run_self_reference.o: $(OUTDIR)/self_reference.o $(OUTDIR)/self_reference_ad.o
 $(OUTDIR)/run_macro_args.o: $(OUTDIR)/macro_args.o $(OUTDIR)/macro_args_ad.o
 $(OUTDIR)/run_macro_multistmt.o: $(OUTDIR)/macro_multistmt.o $(OUTDIR)/macro_multistmt_ad.o
+$(OUTDIR)/run_use_module_conflict.o: $(OUTDIR)/real4_module.o $(OUTDIR)/real4_module_ad.o $(OUTDIR)/real8_module.o $(OUTDIR)/real8_module_ad.o $(OUTDIR)/use_module_conflict.o $(OUTDIR)/use_module_conflict_ad.o
 
 
 $(OUTDIR)/run_simple_math.out: $(OUTDIR)/run_simple_math.o $(OUTDIR)/simple_math.o $(OUTDIR)/simple_math_ad.o
@@ -115,6 +116,7 @@ $(OUTDIR)/run_fautodiff_stack.out: $(OUTDIR)/run_fautodiff_stack.o $(OUTDIR)/fau
 $(OUTDIR)/run_self_reference.out: $(OUTDIR)/run_self_reference.o $(OUTDIR)/self_reference.o $(OUTDIR)/self_reference_ad.o
 $(OUTDIR)/run_macro_args.out: $(OUTDIR)/run_macro_args.o $(OUTDIR)/macro_args.o $(OUTDIR)/macro_args_ad.o
 $(OUTDIR)/run_macro_multistmt.out: $(OUTDIR)/run_macro_multistmt.o $(OUTDIR)/macro_multistmt.o $(OUTDIR)/macro_multistmt_ad.o
+$(OUTDIR)/run_use_module_conflict.out: $(OUTDIR)/run_use_module_conflict.o $(OUTDIR)/real4_module.o $(OUTDIR)/real4_module_ad.o $(OUTDIR)/real8_module.o $(OUTDIR)/real8_module_ad.o $(OUTDIR)/use_module_conflict.o $(OUTDIR)/use_module_conflict_ad.o
 
 clean:
 	rm -f $(OUTDIR)/*.o $(OUTDIR)/*.mod

--- a/tests/fortran_runtime/run_use_module_conflict.f90
+++ b/tests/fortran_runtime/run_use_module_conflict.f90
@@ -1,0 +1,66 @@
+program run_use_module_conflict
+  use use_module_conflict
+  use use_module_conflict_ad
+  implicit none
+  real, parameter :: tol = 1.0e-5
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_add_with_mod = 1
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("add_with_mod")
+              i_test = I_add_with_mod
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_add_with_mod .or. i_test == I_all) then
+     call test_add_with_mod
+  end if
+
+  stop
+contains
+  subroutine test_add_with_mod
+    real(8) :: x, y
+    real(8) :: x_ad, y_ad
+    real(8) :: y_eps, fd, eps
+    real(8) :: inner1, inner2
+
+    eps = 1.0e-6_8
+    x = 2.0_8
+    call add_with_mod(x, y)
+    call add_with_mod(x + eps, y_eps)
+    fd = (y_eps - y) / eps
+    x_ad = 1.0_8
+    call add_with_mod_fwd_ad(x, x_ad, y, y_ad)
+    if (abs((y_ad - fd) / fd) > tol) then
+       print *, 'test_add_with_mod_fwd failed', y_ad, fd
+       error stop 1
+    end if
+
+    inner1 = y_ad**2
+    x_ad = 0.0_8
+    call add_with_mod_rev_ad(x_ad, y_ad)
+    inner2 = x_ad
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_add_with_mod_rev failed', inner1, inner2
+       error stop 1
+    end if
+  end subroutine test_add_with_mod
+end program run_use_module_conflict

--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -198,6 +198,9 @@ class TestFortranADCode(unittest.TestCase):
             ["slice", "slice_ptr", "slice_expr"],
         )
 
+    def test_use_module_conflict(self):
+        self._run_test("use_module_conflict", ["add_with_mod"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add example demonstrating subroutine-level module use with same-named variables of different kinds
- ensure generator preserves subroutine-level `use` statements
- cover new example in runtime test suite

## Testing
- `python tests/test_generator.py`
- `pytest tests/test_fortran_adcode.py::TestFortranADCode::test_use_module_conflict -q`

------
https://chatgpt.com/codex/tasks/task_b_68a13066e0c8832d8c0b6db2e45c40d6