### PR TITLE
docs: add preprocessor documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This source-to-source tool parses existing Fortran programs and emits new module
 with ``_ad`` suffixes, preserving the original structure while providing forward
 and reverse mode derivatives. Documentation of the supported Fortran constructs
 can be found in ``doc/fortran_support.md``.
+Basic C preprocessor macros are also recognized; see ``doc/preprocessor.md`` for
+details.
 
 ## Installation
 

--- a/doc/preprocessor.md
+++ b/doc/preprocessor.md
@@ -1,0 +1,24 @@
+# Preprocessor support
+
+The generator understands a limited subset of C preprocessor directives embedded in Fortran sources.
+
+## Supported range
+
+- Object-like `#define` macros.
+- Simple function-like macros without token pasting or variadic arguments.
+- Conditionals using `#if defined(NAME)`, `#if !defined(NAME)`, `#ifdef`, `#ifndef`, `#else`, and `#endif`.
+- Macros declared inside modules are tracked so later references expand within the module.
+
+## Unsupported features
+
+- `#include` directives.
+- `#elif` branches and general `#if` expressions beyond `defined(...)`.
+- Macros that use token pasting (`##`), stringification (`#`), variadic arguments, or line continuation characters (`\`).
+- Complex expression evaluation inside `#if` directives or macro bodies.
+
+## Known limitations
+
+- Expansion is purely textual and does not perform full C preprocessing.
+- Only macros defined in the current file are considered; macros from included files or build system definitions are ignored.
+- Directives that cannot be interpreted are preserved verbatim in the generated output.
+


### PR DESCRIPTION
## Summary
- document supported and unsupported preprocessor features
- mention basic macro handling in README overview

## Testing
- `isort . --profile black`
- `black .`
- `python tests/test_generator.py`
- `python tests/test_fortran_runtime.py`
- `python tests/test_fortran_adcode.py` *(fails: Command '['/tmp/tmpec0mewly/run_use_module_conflict.out', 'add_with_mod']' returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_b_68a1417730dc832da149d54641ba9921