### PR TITLE
Fix ordering of use statements before parameter declarations

### DIFF
--- a/examples/support_mod.f90
+++ b/examples/support_mod.f90
@@ -1,0 +1,9 @@
+module support_mod
+  implicit none
+contains
+  subroutine add_one(val)
+    real, intent(inout) :: val
+    val = val + 1.0
+    return
+  end subroutine add_one
+end module support_mod

--- a/examples/support_mod_ad.f90
+++ b/examples/support_mod_ad.f90
@@ -1,0 +1,20 @@
+module support_mod_ad
+  use support_mod
+  implicit none
+
+contains
+
+  subroutine add_one_fwd_ad(val)
+    real, intent(inout) :: val
+
+    val = val + 1.0
+
+    return
+  end subroutine add_one_fwd_ad
+
+  subroutine add_one_rev_ad()
+
+    return
+  end subroutine add_one_rev_ad
+
+end module support_mod_ad

--- a/examples/use_parameter.f90
+++ b/examples/use_parameter.f90
@@ -1,0 +1,16 @@
+module use_parameter
+  use support_mod
+  implicit none
+contains
+  subroutine scale_and_shift(x, y)
+    use support_mod
+    real, parameter :: c = 2.0
+    real, intent(inout) :: x
+    real, intent(out) :: y
+
+    call add_one(x)
+    y = c * x
+
+    return
+  end subroutine scale_and_shift
+end module use_parameter

--- a/examples/use_parameter_ad.f90
+++ b/examples/use_parameter_ad.f90
@@ -1,0 +1,38 @@
+module use_parameter_ad
+  use use_parameter
+  use support_mod
+  use support_mod_ad
+  implicit none
+
+contains
+
+  subroutine scale_and_shift_fwd_ad(x, x_ad, y, y_ad)
+    use support_mod
+    use support_mod_ad
+    real, parameter :: c = 2.0
+    real, intent(inout) :: x
+    real, intent(inout) :: x_ad
+    real, intent(out) :: y
+    real, intent(out) :: y_ad
+
+    call add_one_fwd_ad(x) ! call add_one(x)
+    y_ad = x_ad * c ! y = c * x
+    y = c * x
+
+    return
+  end subroutine scale_and_shift_fwd_ad
+
+  subroutine scale_and_shift_rev_ad(x_ad, y_ad)
+    use support_mod
+    use support_mod_ad
+    real, parameter :: c = 2.0
+    real, intent(inout) :: x_ad
+    real, intent(inout) :: y_ad
+
+    x_ad = y_ad * c + x_ad ! y = c * x
+    y_ad = 0.0 ! y = c * x
+
+    return
+  end subroutine scale_and_shift_rev_ad
+
+end module use_parameter_ad

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -884,6 +884,13 @@ def _prepare_fwd_ad_header(
         if isinstance(node, PreprocessorLine):
             subroutine.decls.append(node.copy())
     arg_info["name_fwd_ad"] = ad_name
+    # Copy use statements from the original routine
+    for node in decl_children:
+        if isinstance(node, Use):
+            subroutine.decls.append(node.deep_clone())
+            if not node.name.endswith(AD_SUFFIX):
+                subroutine.decls.append(Use(f"{node.name}{AD_SUFFIX}"))
+
     # Copy parameter declarations from the original routine
     for node in decl_children:
         if (
@@ -894,12 +901,6 @@ def _prepare_fwd_ad_header(
             clone = node.deep_clone()
             clone.donot_prune = True
             subroutine.decls.append(clone)
-
-    for node in decl_children:
-        if isinstance(node, Use):
-            subroutine.decls.append(node.deep_clone())
-            if not node.name.endswith(AD_SUFFIX):
-                subroutine.decls.append(Use(f"{node.name}{AD_SUFFIX}"))
 
     for var in args:
         subroutine.decls.append(
@@ -1042,6 +1043,13 @@ def _prepare_rev_ad_header(
         if isinstance(node, PreprocessorLine):
             subroutine.decls.append(node.copy())
     arg_info["name_rev_ad"] = ad_name
+    # Copy use statements from the original routine
+    for node in decl_children:
+        if isinstance(node, Use):
+            subroutine.decls.append(node.deep_clone())
+            if not node.name.endswith(AD_SUFFIX):
+                subroutine.decls.append(Use(f"{node.name}{AD_SUFFIX}"))
+
     # Copy parameter declarations from the original routine
     for node in decl_children:
         if (
@@ -1052,12 +1060,6 @@ def _prepare_rev_ad_header(
             clone = node.deep_clone()
             clone.donot_prune = True
             subroutine.decls.append(clone)
-
-    for node in decl_children:
-        if isinstance(node, Use):
-            subroutine.decls.append(node.deep_clone())
-            if not node.name.endswith(AD_SUFFIX):
-                subroutine.decls.append(Use(f"{node.name}{AD_SUFFIX}"))
 
     for var in args:
         subroutine.decls.append(


### PR DESCRIPTION
## Summary
- ensure generated subroutines emit `use` statements before parameter declarations
- add regression example with subroutine-level `use` and parameter

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_68a33e5f548c832d8c768002b910fb30