### PR TITLE
Support Fortran STOP and ERROR STOP statements

### DIFF
--- a/examples/stop_example.f90
+++ b/examples/stop_example.f90
@@ -1,0 +1,14 @@
+module stop_example
+contains
+  subroutine stop_sub(x, y)
+    real, intent(in) :: x
+    real, intent(out) :: y
+    if (x < 0.0) then
+      stop 'negative'
+    end if
+    if (x > 10.0) then
+      error stop 1
+    end if
+    y = x
+  end subroutine stop_sub
+end module stop_example

--- a/examples/stop_example_ad.f90
+++ b/examples/stop_example_ad.f90
@@ -1,0 +1,42 @@
+module stop_example_ad
+  use stop_example
+  implicit none
+
+contains
+
+  subroutine stop_sub_fwd_ad(x, x_ad, y, y_ad)
+    real, intent(in)  :: x
+    real, intent(in)  :: x_ad
+    real, intent(out) :: y
+    real, intent(out) :: y_ad
+
+    if (x < 0.0) then
+      stop 'negative'
+    end if
+    if (x > 10.0) then
+      error stop 1
+    end if
+    y_ad = x_ad ! y = x
+    y = x
+
+    return
+  end subroutine stop_sub_fwd_ad
+
+  subroutine stop_sub_rev_ad(x, x_ad, y_ad)
+    real, intent(in)  :: x
+    real, intent(inout) :: x_ad
+    real, intent(inout) :: y_ad
+
+    x_ad = y_ad + x_ad ! y = x
+    y_ad = 0.0 ! y = x
+    if (x > 10.0) then
+      error stop 1
+    end if
+    if (x < 0.0) then
+      stop 'negative'
+    end if
+
+    return
+  end subroutine stop_sub_rev_ad
+
+end module stop_example_ad

--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -1427,6 +1427,48 @@ class Statement(Node):
 
 
 @dataclass
+class StopStmt(Statement):
+    """Representation of a STOP or ERROR STOP statement."""
+
+    def generate_ad(
+        self,
+        saved_vars: List[OpVar],
+        reverse: bool = False,
+        assigned_advars: Optional[VarList] = None,
+        routine_map: Optional[dict] = None,
+        generic_map: Optional[dict] = None,
+        mod_vars: Optional[List[OpVar]] = None,
+        exitcycle_flags: Optional[List[OpVar]] = None,
+        return_flags: Optional[List[OpVar]] = None,
+        type_map: Optional[dict] = None,
+        warnings: Optional[list[str]] = None,
+    ) -> List["Node"]:
+        return [StopStmt(self.body)]
+
+    def prune_for(
+        self,
+        targets: VarList,
+        mod_vars: Optional[List[OpVar]] = None,
+        decl_map: Optional[Dict[str, "Declaration"]] = None,
+        base_targets: Optional[VarList] = None,
+    ) -> "StopStmt":
+        return StopStmt(self.body)
+
+    def set_for_returnexitcycle(
+        self,
+        return_flags: Optional[List[OpVar]] = None,
+        exitcycle_flags: Optional[List[OpVar]] = None,
+        set_return_cond: bool = False,
+        set_exitcycle_cond: bool = False,
+        set_do_index: Optional[Tuple[OpVar, OpVar]] = None,
+        label: Optional[str] = None,
+        label_map: Optional[List[Tuple[str, str]]] = None,
+        keep: bool = False,
+    ) -> List["Node"]:
+        return []
+
+
+@dataclass
 class PreprocessorLine(Node):
     """A single preprocessor directive line."""
 

--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -87,6 +87,7 @@ from .code_tree import (
     ReturnStmt,
     SelectBlock,
     Statement,
+    StopStmt,
     Subroutine,
     TypeDef,
     Use,
@@ -2292,6 +2293,10 @@ def _parse_routine(
         if isinstance(stmt, Fortran2003.Cycle_Stmt):
             label = stmt.items[1].string if stmt.items[1] is not None else None
             return CycleStmt(label=label)
+        if isinstance(stmt, Fortran2008.Error_Stop_Stmt):
+            return StopStmt(stmt.string)
+        if isinstance(stmt, Fortran2003.Stop_Stmt):
+            return StopStmt(stmt.string)
 
         print(type(stmt))
         print(stmt.items)

--- a/tests/fortran_runtime/Makefile
+++ b/tests/fortran_runtime/Makefile
@@ -20,7 +20,7 @@ PROGRAM_NAMES = run_simple_math.out run_arrays.out run_call_example.out run_cont
            run_directives.out run_parameter_var.out run_module_vars.out run_call_module_vars.out run_allocate_vars.out \
            run_exit_cycle.out run_pointer_arrays.out run_derived_alloc.out run_mpi_example.out \
                    run_stack.out run_where_forall.out run_omp_loops.out run_return_example.out run_self_reference.out \
-           run_macro_args.out run_macro_multistmt.out run_use_module_conflict.out
+           run_macro_args.out run_macro_multistmt.out run_use_module_conflict.out run_stop_example.out
 PROGRAMS = $(addprefix $(OUTDIR)/,$(PROGRAM_NAMES))
 
 .PHONY: all clean
@@ -76,6 +76,8 @@ $(OUTDIR)/run_where_forall.o: $(OUTDIR)/where_forall.o $(OUTDIR)/where_forall_ad
 
 $(OUTDIR)/run_return_example.o: $(OUTDIR)/return_example.o $(OUTDIR)/return_example_ad.o
 
+$(OUTDIR)/run_stop_example.o: $(OUTDIR)/stop_example.o $(OUTDIR)/stop_example_ad.o
+
 $(OUTDIR)/run_omp_loops.o: $(OUTDIR)/omp_loops.o $(OUTDIR)/omp_loops_ad.o
 
 $(OUTDIR)/run_fautodiff_stack.o: $(OUTDIR)/fautodiff_stack.o
@@ -108,6 +110,8 @@ $(OUTDIR)/run_mpi_example.out: $(OUTDIR)/run_mpi_example.o $(OUTDIR)/mpi_example
 $(OUTDIR)/run_where_forall.out: $(OUTDIR)/run_where_forall.o $(OUTDIR)/where_forall.o $(OUTDIR)/where_forall_ad.o
 
 $(OUTDIR)/run_return_example.out: $(OUTDIR)/run_return_example.o $(OUTDIR)/return_example.o $(OUTDIR)/return_example_ad.o
+
+$(OUTDIR)/run_stop_example.out: $(OUTDIR)/run_stop_example.o $(OUTDIR)/stop_example.o $(OUTDIR)/stop_example_ad.o
 
 $(OUTDIR)/run_omp_loops.out: $(OUTDIR)/run_omp_loops.o $(OUTDIR)/omp_loops.o $(OUTDIR)/omp_loops_ad.o
 

--- a/tests/fortran_runtime/run_stop_example.f90
+++ b/tests/fortran_runtime/run_stop_example.f90
@@ -1,0 +1,70 @@
+program run_stop_example
+  use stop_example
+  use stop_example_ad
+  implicit none
+  real, parameter :: tol = 3.0e-4
+
+  integer, parameter :: I_all = 0
+  integer, parameter :: I_stop_sub = 1
+
+  integer :: length, status
+  character(:), allocatable :: arg
+  integer :: i_test
+
+  i_test = I_all
+  if (command_argument_count() > 0) then
+     call get_command_argument(1, length=length, status=status)
+     if (status == 0) then
+        allocate(character(len=length) :: arg)
+        call get_command_argument(1, arg, status=status)
+        if (status == 0) then
+           select case(arg)
+           case ("stop_sub")
+              i_test = I_stop_sub
+           case default
+              print *, 'Invalid test name: ', arg
+              error stop 1
+           end select
+        end if
+        deallocate(arg)
+     end if
+  end if
+
+  if (i_test == I_stop_sub .or. i_test == I_all) then
+     call test_stop_sub
+  end if
+
+  stop
+contains
+
+  subroutine test_stop_sub
+    real :: x, y
+    real :: x_ad, y_ad
+    real :: y_eps, fd, eps
+    real :: inner1, inner2
+
+    eps = 1.0e-3
+    x = 1.0
+    call stop_sub(x, y)
+    call stop_sub(x + eps, y_eps)
+    fd = (y_eps - y) / eps
+    x_ad = 1.0
+    call stop_sub_fwd_ad(x, x_ad, y, y_ad)
+    if (abs((y_ad - fd) / fd) > tol) then
+       print *, 'test_stop_sub_fwd failed', y_ad, fd
+       error stop 1
+    end if
+
+    inner1 = y_ad**2
+    x_ad = 0.0
+    call stop_sub_rev_ad(x, x_ad, y_ad)
+    inner2 = x_ad
+    if (abs((inner2 - inner1) / inner1) > tol) then
+       print *, 'test_stop_sub_rev failed', inner1, inner2
+       error stop 1
+    end if
+
+    return
+  end subroutine test_stop_sub
+
+end program run_stop_example

--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -201,6 +201,9 @@ class TestFortranADCode(unittest.TestCase):
     def test_use_module_conflict(self):
         self._run_test("use_module_conflict", ["add_with_mod"])
 
+    def test_stop_example(self):
+        self._run_test("stop_example", ["stop_sub"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- preserve STOP and ERROR STOP statements during AD generation
- add stop statement example and runtime test

## Testing
- `python tests/test_generator.py`
- `python tests/test_fortran_adcode.py`


------
https://chatgpt.com/codex/tasks/task_b_68a3475e9e94832d8d7e46b9f701f38d