### PR TITLE
Add missing MPI constants and improve MPI fadmod generation

### DIFF
--- a/fortran_modules/gen_mpi_fadmod.py
+++ b/fortran_modules/gen_mpi_fadmod.py
@@ -240,6 +240,20 @@ variables: Dict[str, dict] = {
     "MPI_ERR_OTHER": {},
     "MPI_ERR_IN_STATUS": {},
     "MPI_ERR_PENDING": {},
+    # RMA constants
+    "MPI_MODE_NOCHECK": {},
+    "MPI_MODE_NOPRECEDE": {},
+    "MPI_MODE_NOPUT": {},
+    "MPI_MODE_NOSTORE": {},
+    "MPI_MODE_NOSUCCEED": {},
+    # Data distribution constants
+    "MPI_DISTRIBUTE_BLOCK": {},
+    "MPI_DISTRIBUTE_CYCLIC": {},
+    "MPI_DISTRIBUTE_NONE": {},
+    "MPI_DISTRIBUTE_DFLT_DARG": {},
+    # Memory order constants
+    "MPI_ORDER_C": {},
+    "MPI_ORDER_FORTRAN": {},
     # MPI-IO constants
     "MPI_FILE_NULL": {},
     "MPI_INFO_NULL": {},
@@ -267,6 +281,10 @@ for name, v in variables.items():
     decl_map[name] = Declaration(
         name=name, typename="integer", dims=dims, parameter=True
     )
+# iso_c_binding declarations used in mpi_ad.f90
+decl_map["c_null_ptr"] = Declaration(
+    name="c_null_ptr", typename="type(c_ptr)", parameter=True
+)
 
 
 def main() -> None:
@@ -284,7 +302,7 @@ def main() -> None:
     with tempfile.NamedTemporaryFile("w", suffix=".f90") as tmp:
         tmp.write(processed)
         tmp.flush()
-        mod = parser.parse_file(tmp.name, search_dirs=[str(here)], decl_map=decl_map)[0]
+        mod = parser.parse_file(tmp.name, decl_map=decl_map)[0]
     routines = _collect_routines(mod, routines_mpi, assumed_rank)
     generics = _interfaces_to_generics(mod)
     data = {"routines": routines, "variables": variables, "generics": generics}

--- a/fortran_modules/mpi.fadmod
+++ b/fortran_modules/mpi.fadmod
@@ -4723,6 +4723,50 @@
       "typename": "integer",
       "parameter": true
     },
+    "MPI_MODE_NOCHECK": {
+      "typename": "integer",
+      "parameter": true
+    },
+    "MPI_MODE_NOPRECEDE": {
+      "typename": "integer",
+      "parameter": true
+    },
+    "MPI_MODE_NOPUT": {
+      "typename": "integer",
+      "parameter": true
+    },
+    "MPI_MODE_NOSTORE": {
+      "typename": "integer",
+      "parameter": true
+    },
+    "MPI_MODE_NOSUCCEED": {
+      "typename": "integer",
+      "parameter": true
+    },
+    "MPI_DISTRIBUTE_BLOCK": {
+      "typename": "integer",
+      "parameter": true
+    },
+    "MPI_DISTRIBUTE_CYCLIC": {
+      "typename": "integer",
+      "parameter": true
+    },
+    "MPI_DISTRIBUTE_NONE": {
+      "typename": "integer",
+      "parameter": true
+    },
+    "MPI_DISTRIBUTE_DFLT_DARG": {
+      "typename": "integer",
+      "parameter": true
+    },
+    "MPI_ORDER_C": {
+      "typename": "integer",
+      "parameter": true
+    },
+    "MPI_ORDER_FORTRAN": {
+      "typename": "integer",
+      "parameter": true
+    },
     "MPI_FILE_NULL": {
       "typename": "integer",
       "parameter": true


### PR DESCRIPTION
## Summary
- extend MPI fadmod generator with additional constants (memory order, RMA and darray distribution)
- avoid dependency on existing mpi.fadmod and add iso_c_binding declaration
- regenerate mpi.fadmod including new constants

## Testing
- `python -m black .`
- `python -m isort . --profile black`
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_68a3c35af1c8832dbd39837da15fe12d