### PR TITLE
Introduce VarType-only typing

### DIFF
--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -659,7 +659,7 @@ def _stmt2op(stmt, decl_map: dict, type_map: dict) -> Operator:
         if getattr(imag, "kind", None) == kind:
             pass
         elif getattr(imag, "kind", None) is not None:
-            kind = imag.kind
+            kind = imag.var_type.kind
         return OpComplex(real, imag, kind=kind)
 
     if isinstance(stmt, Fortran2003.Name):
@@ -675,12 +675,12 @@ def _stmt2op(stmt, decl_map: dict, type_map: dict) -> Operator:
         else:
             raise ValueError(f"Not found in the declaration section: {name}")
 
-        kind = decl.kind
-        kind_val = getattr(decl, "kind_val", None)
+        kind = decl.var_type.kind
+        kind_val = decl.var_type.kind_val
         if (
             kind_val is None
             and kind is None
-            and decl.typename.lower().startswith("double")
+            and decl.var_type.typename.lower().startswith("double")
         ):
             kind = "8"
             kind_val = "8"
@@ -711,10 +711,10 @@ def _stmt2op(stmt, decl_map: dict, type_map: dict) -> Operator:
 
         return OpVar(
             name=name,
-            typename=decl.typename,
+            typename=decl.var_type.typename,
             kind=kind,
             kind_val=kind_val,
-            char_len=decl.char_len,
+            char_len=decl.var_type.char_len,
             dims=decl.dims,
             ad_target=decl.ad_target(),
             is_constant=decl.parameter or getattr(decl, "constant", False),
@@ -763,10 +763,10 @@ def _stmt2op(stmt, decl_map: dict, type_map: dict) -> Operator:
             return OpVar(
                 name=name,
                 index=index,
-                typename=decl.typename,
-                kind=decl.kind,
-                kind_val=getattr(decl, "kind_val", None),
-                char_len=decl.char_len,
+                typename=decl.var_type.typename,
+                kind=decl.var_type.kind,
+                kind_val=decl.var_type.kind_val,
+                char_len=decl.var_type.char_len,
                 dims=decl.dims,
                 ad_target=decl.ad_target(),
                 is_constant=decl.parameter or getattr(decl, "constant", False),
@@ -2170,10 +2170,10 @@ def _parse_routine(
                 decl_map_new = decl_map.copy()
                 decl = decl_map[expr.name].copy()
                 if cond in type_map:
-                    decl.typename = f"type({cond})"
+                    decl.var_type.typename = f"type({cond})"
                     decl.type_def = type_map[cond]
                 else:
-                    decl.typename = cond
+                    decl.var_type.typename = cond
                 decl_map_new[expr.name] = decl
                 blk = _block(seg, decl_map_new, type_map)
                 cond_blocks.append(((OpType(cond),), blk))

--- a/fautodiff/var_list.py
+++ b/fautodiff/var_list.py
@@ -250,16 +250,16 @@ class VarList:
         if ref_var is not None:
             ref_var = VarList._force_stride_one(ref_var)
 
-        if replaced or ref_var is not var.ref_var:
-            return OpVar(
-                var.name,
-                index=index,
-                kind=var.kind,
-                typename=var.typename,
-                ad_target=var.ad_target,
-                is_constant=var.is_constant,
-                ref_var=ref_var,
-            )
+            if replaced or ref_var is not var.ref_var:
+                return OpVar(
+                    var.name,
+                    index=index,
+                    kind=var.var_type.kind if var.var_type else None,
+                    typename=var.var_type.typename if var.var_type else None,
+                    ad_target=var.ad_target,
+                    is_constant=var.is_constant,
+                    ref_var=ref_var,
+                )
         return var
 
     def push(self, var: OpVar, not_reorganize: bool = False) -> None:

--- a/fautodiff/var_type.py
+++ b/fautodiff/var_type.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class VarType:
+    """Representation of a Fortran variable type."""
+
+    typename: str
+    kind: Optional[str] = None
+    kind_val: Optional[str] = None
+    kind_keyword: bool = False
+    char_len: Optional[str] = None
+
+    def copy(self) -> "VarType":
+        return VarType(
+            typename=self.typename,
+            kind=self.kind,
+            kind_val=self.kind_val,
+            kind_keyword=self.kind_keyword,
+            char_len=self.char_len,
+        )
+
+    def __str__(self) -> str:
+        parts = []
+        if self.kind is not None:
+            if self.kind.isdigit():
+                parts.append(self.kind)
+            else:
+                parts.append(f"kind={self.kind}" if self.kind_keyword else self.kind)
+        if self.char_len is not None:
+            parts.append(f"len={self.char_len}")
+        if parts:
+            return f"{self.typename}(" + ",".join(parts) + ")"
+        return self.typename
+
+    def is_real_type(self) -> bool:
+        typename = self.typename.lower()
+        return typename.startswith("real") or typename.startswith("double")
+
+    def is_complex_type(self) -> bool:
+        return self.typename.lower().startswith("complex")
+
+    def is_integer_type(self) -> bool:
+        return self.typename.lower().startswith("integer")
+
+    def _binary_result(self, other: "VarType") -> "VarType":
+        if other is None:
+            return self.copy()
+        if self.is_complex_type() or other.is_complex_type():
+            kind = self.kind or other.kind
+            return VarType("complex", kind=kind)
+        if self.is_real_type() or other.is_real_type():
+            kind = self.kind or other.kind
+            return VarType("real", kind=kind)
+        if self.is_integer_type() and other.is_integer_type():
+            kind = self.kind or other.kind
+            return VarType("integer", kind=kind)
+        return self.copy()
+
+    def __add__(self, other: "VarType") -> "VarType":
+        return self._binary_result(other)
+
+    __sub__ = __add__
+    __mul__ = __add__
+    __truediv__ = __add__

--- a/fortran_modules/gen_mpi_fadmod.py
+++ b/fortran_modules/gen_mpi_fadmod.py
@@ -76,9 +76,9 @@ def _collect_routines(
                     dim = None
                 dims.append(dim)
                 types.append(
-                    decls.get(arg).typename.lower() if decls.get(arg) else None
+                    decls.get(arg).var_type.typename.lower() if decls.get(arg) else None
                 )
-                kinds.append(decls.get(arg).kind)
+                kinds.append(decls.get(arg).var_type.kind if decls.get(arg) else None)
             info["intents"] = intents
             info["dims"] = dims
             info["type"] = types

--- a/tests/test_code_tree.py
+++ b/tests/test_code_tree.py
@@ -31,7 +31,7 @@ class TestOpVar(unittest.TestCase):
     def test_scalar(self):
         var = OpVar("x", typename="real")
         self.assertEqual(var.name, "x")
-        self.assertEqual(var.typename, "real")
+        self.assertEqual(var.var_type.typename, "real")
         self.assertFalse(var.is_array())
 
     def test_array(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -137,7 +137,7 @@ class TestParser(unittest.TestCase):
         routine = module.routines[0]
         decl = routine.decls.find_by_name("x")
         self.assertIsNotNone(decl)
-        self.assertEqual(decl.kind, "8")
+        self.assertEqual(decl.var_type.kind, "8")
 
     def test_parse_real_kind_rp(self):
         src = textwrap.dedent(
@@ -155,7 +155,7 @@ class TestParser(unittest.TestCase):
         routine = module.routines[0]
         decl = routine.decls.find_by_name("x")
         self.assertIsNotNone(decl)
-        self.assertEqual(decl.kind, "RP")
+        self.assertEqual(decl.var_type.kind, "RP")
 
     def test_parse_dimension(self):
         src = textwrap.dedent(
@@ -251,7 +251,7 @@ class TestParser(unittest.TestCase):
         decl = module.decls.find_by_name("RP")
         self.assertIsNotNone(decl)
         self.assertTrue(decl.parameter)
-        self.assertEqual(decl.typename, "integer")
+        self.assertEqual(decl.var_type.typename, "integer")
         self.assertEqual(decl.access, "public")
 
     def test_module_vars_default_diff(self):
@@ -346,8 +346,8 @@ class TestParser(unittest.TestCase):
         routine = module.routines[0]
         decl = routine.decls.find_by_name("x")
         self.assertIsNotNone(decl)
-        self.assertEqual(decl.typename.lower(), "double precision")
-        self.assertIsNone(decl.kind)
+        self.assertEqual(decl.var_type.typename.lower(), "double precision")
+        self.assertIsNone(decl.var_type.kind)
 
     def test_parse_directives_constant_vars(self):
         src = textwrap.dedent(


### PR DESCRIPTION
## Summary
- define `VarType.__str__` including kind/length specifiers
- render declarations via `VarType.__str__`
- preserve numeric kind when initializing derivative variables

## Testing
- `python tests/test_generator.py`
- `python -m pytest tests/test_parser.py tests/test_operators.py tests/test_code_tree.py`


------
https://chatgpt.com/codex/tasks/task_b_68a3ce647cb8832dbe01bc34b1893f06