### PR TITLE
Refactor operators to require VarType

### DIFF
--- a/fautodiff/operators.py
+++ b/fautodiff/operators.py
@@ -286,6 +286,7 @@ class Operator:
     """Abstract fortran oprations."""
 
     args: Optional[List[Optional[Operator]]] = None
+    var_type: Optional[VarType] = None
     macro_name: Optional[str] = None
     PRIORITY: ClassVar[int] = -999
 
@@ -981,7 +982,6 @@ class OpVar(OpLeaf):
 
     name: str = field(default="")
     index: Optional[AryIndex] = None
-    var_type: Optional[VarType] = None
     dims: Optional[Tuple[str]] = field(repr=False, default=None)
     intent: Optional[str] = field(default=None, repr=False)
     ad_target: Optional[bool] = field(default=None, repr=False)
@@ -1003,14 +1003,9 @@ class OpVar(OpLeaf):
         self,
         name: str,
         index: Optional[AryIndex] = None,
-        kind: Optional[str] = None,
-        kind_val: Optional[str] = None,
-        kind_keyword: Optional[bool] = None,
-        char_len: Optional[str] = None,
         var_type: Optional[VarType] = None,
         dims: Optional[Tuple[str]] = None,
         reference: Optional[OpVar] = None,
-        typename: Optional[str] = None,
         intent: Optional[str] = None,
         ad_target: Optional[bool] = None,
         is_constant: Optional[bool] = None,
@@ -1025,7 +1020,7 @@ class OpVar(OpLeaf):
         declared_in: Optional[str] = None,
         ref_var: Optional[OpVar] = None,
     ):
-        super().__init__(args=[])
+        super().__init__(args=[], var_type=var_type)
         if not isinstance(name, str):
             raise ValueError(f"name must be str: {type(name)}")
         if not _NAME_RE.fullmatch(name):
@@ -1034,15 +1029,6 @@ class OpVar(OpLeaf):
         if index is not None and not isinstance(index, AryIndex):
             index = AryIndex(index)
         self.index = index
-        if var_type is None and (typename is not None or kind is not None):
-            var_type = VarType(
-                typename=typename or "",
-                kind=kind,
-                kind_val=kind_val,
-                kind_keyword=bool(kind_keyword),
-                char_len=char_len,
-            )
-        self.var_type = var_type
         if self.var_type is not None:
             self.kind = self.var_type.kind
         self.dims = dims
@@ -1188,13 +1174,9 @@ class OpVar(OpLeaf):
         return OpVar(
             name=self.name,
             index=index,
-            kind=self.var_type.kind if self.var_type else None,
-            kind_val=self.var_type.kind_val if self.var_type else None,
-            kind_keyword=self.var_type.kind_keyword if self.var_type else None,
-            char_len=self.var_type.char_len if self.var_type else None,
+            var_type=self.var_type.copy() if self.var_type else None,
             dims=self.dims,
             reference=self.reference,
-            typename=self.var_type.typename if self.var_type else None,
             intent=self.intent,
             ad_target=self.ad_target,
             is_constant=self.is_constant,
@@ -1224,13 +1206,9 @@ class OpVar(OpLeaf):
         return OpVar(
             name,
             index=index,
-            kind=self.var_type.kind if self.var_type else None,
-            kind_val=self.var_type.kind_val if self.var_type else None,
-            kind_keyword=self.var_type.kind_keyword if self.var_type else None,
-            char_len=self.var_type.char_len if self.var_type else None,
+            var_type=self.var_type.copy() if self.var_type else None,
             dims=self.dims,
             reference=self.reference,
-            typename=self.var_type.typename if self.var_type else None,
             intent=self.intent,
             ad_target=self.ad_target,
             is_constant=self.is_constant,
@@ -1276,13 +1254,9 @@ class OpVar(OpLeaf):
         return OpVar(
             name,
             index=index,
-            kind=self.var_type.kind if self.var_type else None,
-            kind_val=self.var_type.kind_val if self.var_type else None,
-            kind_keyword=self.var_type.kind_keyword if self.var_type else None,
-            char_len=self.var_type.char_len if self.var_type else None,
+            var_type=self.var_type.copy() if self.var_type else None,
             dims=self.dims,
             reference=self.reference,
-            typename=self.var_type.typename if self.var_type else None,
             intent=self.intent,
             ad_target=self.ad_target,
             is_constant=self.is_constant,

--- a/fautodiff/var_list.py
+++ b/fautodiff/var_list.py
@@ -254,8 +254,7 @@ class VarList:
                 return OpVar(
                     var.name,
                     index=index,
-                    kind=var.var_type.kind if var.var_type else None,
-                    typename=var.var_type.typename if var.var_type else None,
+                    var_type=var.var_type.copy() if var.var_type else None,
                     ad_target=var.ad_target,
                     is_constant=var.is_constant,
                     ref_var=ref_var,

--- a/fortran_modules/gen_mpi_fadmod.py
+++ b/fortran_modules/gen_mpi_fadmod.py
@@ -18,6 +18,7 @@ from typing import Dict, List, Set
 
 from fautodiff import parser
 from fautodiff.code_tree import Declaration, Interface
+from fautodiff.var_type import VarType
 
 _MODE_RE = re.compile(r"mpi_(.*?)(_fwd_rev_ad|_fwd_ad|_rev_ad)(?:_(.*))?$", re.I)
 
@@ -273,17 +274,17 @@ variables: Dict[str, dict] = {
     "MPI_DISPLACEMENT_CURRENT": {},
     "MPI_OFFSET_KIND": {},
 }
-common = {"typename": "integer", "parameter": True}
+common = {"var_type": VarType("integer"), "parameter": True}
 decl_map = {}
 for name, v in variables.items():
     v.update(common)
     dims = tuple(v.get("dims")) if "dims" in v else None
     decl_map[name] = Declaration(
-        name=name, typename="integer", dims=dims, parameter=True
+        name=name, var_type=VarType("integer"), dims=dims, parameter=True
     )
 # iso_c_binding declarations used in mpi_ad.f90
 decl_map["c_null_ptr"] = Declaration(
-    name="c_null_ptr", typename="type(c_ptr)", parameter=True
+    name="c_null_ptr", var_type=VarType("type(c_ptr)"), parameter=True
 )
 
 

--- a/tests/test_code_tree.py
+++ b/tests/test_code_tree.py
@@ -25,23 +25,24 @@ from fautodiff.code_tree import (
 )
 from fautodiff.operators import OpFuncUser, OpInt, OpRange, OpReal, OpVar
 from fautodiff.var_list import VarList
+from fautodiff.var_type import VarType
 
 
 class TestOpVar(unittest.TestCase):
     def test_scalar(self):
-        var = OpVar("x", typename="real")
+        var = OpVar("x", var_type=VarType("real"))
         self.assertEqual(var.name, "x")
         self.assertEqual(var.var_type.typename, "real")
         self.assertFalse(var.is_array())
 
     def test_array(self):
-        var = OpVar("a", typename="real", dims=("n",))
+        var = OpVar("a", var_type=VarType("real"), dims=("n",))
         self.assertTrue(var.is_array())
         self.assertEqual(var.dims, ("n",))
 
     def test_invalid_name(self):
         with self.assertRaises(ValueError):
-            OpVar("a(i)", typename="real")
+            OpVar("a(i)", var_type=VarType("real"))
 
 
 class TestRenderProgram(unittest.TestCase):
@@ -185,8 +186,8 @@ class TestNodeMethods(unittest.TestCase):
             "",
             decls=Block(
                 [
-                    Declaration(name="a", typename="real", intent="in"),
-                    Declaration(name="b", typename="real"),
+                    Declaration(name="a", var_type=VarType("real"), intent="in"),
+                    Declaration(name="b", var_type=VarType("real")),
                 ]
             ),
             content=Block([Assignment(OpVar("b"), OpVar("a"))]),
@@ -195,7 +196,7 @@ class TestNodeMethods(unittest.TestCase):
         self.assertEqual({str(v) for v in sub.required_vars()}, set())
 
     def test_block_scope(self):
-        decls = Block([Declaration(name="a", typename="real")])
+        decls = Block([Declaration(name="a", var_type=VarType("real"))])
         body = Block([Assignment(OpVar("b"), OpVar("a"))])
         blk = BlockConstruct(decls, body)
         self.assertFalse(blk.has_reference_to(OpVar("a")))
@@ -209,7 +210,7 @@ class TestNodeMethods(unittest.TestCase):
         self.assertEqual({str(v) for v in vars}, {"a", "b"})
 
     def test_block_unrefered_advars(self):
-        decls = Block([Declaration(name="a_ad", typename="real")])
+        decls = Block([Declaration(name="a_ad", var_type=VarType("real"))])
         blk = BlockConstruct(decls, Block([]))
         vars = VarList([OpVar("b_ad")])
         vars = blk.unrefered_advars(vars)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -5,6 +5,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from fautodiff.operators import OpFunc, OpInt, OpRange, OpVar
+from fautodiff.var_type import VarType
 
 
 class TestOperatorsBasic(unittest.TestCase):
@@ -12,21 +13,21 @@ class TestOperatorsBasic(unittest.TestCase):
         self.assertEqual(OpInt(-1), -OpInt(1))
 
     def test_opint_str_with_kind(self):
-        target = OpVar("x", typename="real")
+        target = OpVar("x", var_type=VarType("real"))
         self.assertEqual(str(OpInt(2, target=target)), "2.0")
-        target = OpVar("y", typename="real", kind="4")
+        target = OpVar("y", var_type=VarType("real", kind="4"))
         self.assertEqual(str(OpInt(3, target=target)), "3.0")
-        target = OpVar("z", typename="real", kind="8")
+        target = OpVar("z", var_type=VarType("real", kind="8"))
         self.assertEqual(str(OpInt(4, target=target)), "4.0d0")
-        target = OpVar("t", typename="real", kind="RP")
+        target = OpVar("t", var_type=VarType("real", kind="RP"))
         self.assertEqual(str(OpInt(5, target=target)), "5.0_RP")
-        target = OpVar("i", typename="integer")
+        target = OpVar("i", var_type=VarType("integer"))
         self.assertEqual(str(OpInt(6, target=target)), "6")
-        target = OpVar("j", typename="integer", kind="4")
+        target = OpVar("j", var_type=VarType("integer", kind="4"))
         self.assertEqual(str(OpInt(7, target=target)), "7")
-        target = OpVar("k", typename="integer", kind="8")
+        target = OpVar("k", var_type=VarType("integer", kind="8"))
         self.assertEqual(str(OpInt(8, target=target)), "8_8")
-        target = OpVar("l", typename="integer", kind="IP")
+        target = OpVar("l", var_type=VarType("integer", kind="IP"))
         self.assertEqual(str(OpInt(9, target=target)), "9_IP")
 
     def test_opvar_suffix_and_eq(self):
@@ -37,7 +38,7 @@ class TestOperatorsBasic(unittest.TestCase):
         self.assertNotEqual(v, OpVar("b"))
 
     def test_basic_arithmetic_simplify(self):
-        x = OpVar("x", typename="real")
+        x = OpVar("x", var_type=VarType("real"))
         y = OpVar("y")
         z = OpVar("z")
         t = OpVar("t")

--- a/tests/test_var_list.py
+++ b/tests/test_var_list.py
@@ -6,6 +6,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from fautodiff.operators import AryIndex, OpInt, OpNeg, OpRange, OpVar
 from fautodiff.var_list import VarList
+from fautodiff.var_type import VarType
 
 
 class TestVarList(unittest.TestCase):
@@ -112,8 +113,8 @@ class TestVarList(unittest.TestCase):
         self.assertEqual(inter.names(), ["v"])
 
     def test_push_full_array(self):
-        ny = OpVar("ny", typename="integer")
-        nx = OpVar("nx", typename="integer")
+        ny = OpVar("ny", var_type=VarType("integer"))
+        nx = OpVar("nx", var_type=VarType("integer"))
         one = OpInt(1)
         zero = OpInt(0)
         v1 = OpVar("v", index=[zero, OpRange([one, ny])])
@@ -133,7 +134,9 @@ class TestVarList(unittest.TestCase):
         a = OpVar("a", index=a_idx)
         vl = VarList([a])
         # expand upward over negative stride; range should flip and stride cleared
-        vl.update_index_upward({"a": (0, 1)}, OpRange([OpInt(1), OpInt(5), OpNeg([OpInt(1)])]))
+        vl.update_index_upward(
+            {"a": (0, 1)}, OpRange([OpInt(1), OpInt(5), OpNeg([OpInt(1)])])
+        )
         names = vl.names()
         self.assertEqual(names, ["a"])
         # index list exists and contains a range
@@ -149,15 +152,19 @@ class TestVarList(unittest.TestCase):
 
     def test_intersection_various_cases(self):
         # self: a(:) and b(2:4)
-        vl1 = VarList([
-            OpVar("a", index=AryIndex([None])),
-            OpVar("b", index=AryIndex([OpRange([OpInt(2), OpInt(4), OpInt(1)])])),
-        ])
+        vl1 = VarList(
+            [
+                OpVar("a", index=AryIndex([None])),
+                OpVar("b", index=AryIndex([OpRange([OpInt(2), OpInt(4), OpInt(1)])])),
+            ]
+        )
         # other: a(3) and b(4)
-        vl2 = VarList([
-            OpVar("a", index=AryIndex([OpInt(3)])),
-            OpVar("b", index=AryIndex([OpInt(4)])),
-        ])
+        vl2 = VarList(
+            [
+                OpVar("a", index=AryIndex([OpInt(3)])),
+                OpVar("b", index=AryIndex([OpInt(4)])),
+            ]
+        )
         inter = vl1 & vl2
         s = sorted(str(v) for v in inter)
         self.assertEqual(s, ["a(3)", "b(4)"])
@@ -170,9 +177,11 @@ class TestVarList(unittest.TestCase):
 
     def test_update_index_downward(self):
         # names mapping: a uses index 0 and has 1 dim
-        vl = VarList([
-            OpVar("a", index=AryIndex([OpRange([OpInt(1), OpInt(3)])])),
-        ])
+        vl = VarList(
+            [
+                OpVar("a", index=AryIndex([OpRange([OpInt(1), OpInt(3)])])),
+            ]
+        )
         i = OpVar("i")
         vl.update_index_downward({"a": (0, 1)}, i)
         # now indices must be list of explicit i


### PR DESCRIPTION
## Summary
- add `var_type` field to base Operator
- update OpVar and Declaration to accept VarType instead of typename/kind
- adjust generator, parser, and tests for new VarType API

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_68a3d994b7ac832d934e1b7e29e46e49