### PR TITLE
Add AD implementations for MPI scatter/gather/alltoall

### DIFF
--- a/fortran_modules/gen_mpi_fadmod.py
+++ b/fortran_modules/gen_mpi_fadmod.py
@@ -195,6 +195,10 @@ variables: Dict[str, dict] = {
     "MPI_STATUS_SIZE": {},
     "MPI_STATUS_IGNORE": {"dims": ["MPI_STATUS_SIZE"]},
     "MPI_STATUSES_IGNORE": {"dims": ["MPI_STATUS_SIZE", ":"]},
+    "MPI_IN_PLACE": {},
+    "MPI_BOTTOM": {},
+    "MPI_UNWEIGHTED": {},
+    "MPI_WEIGHTS_EMPTY": {},
     "MPI_REQUEST_NULL": {},
     "MPI_SUM": {},
     "MPI_MAX": {},
@@ -274,7 +278,7 @@ variables: Dict[str, dict] = {
     "MPI_DISPLACEMENT_CURRENT": {},
     "MPI_OFFSET_KIND": {},
 }
-common = {"var_type": VarType("integer"), "parameter": True}
+common = {"typename": "integer", "parameter": True}
 decl_map = {}
 for name, v in variables.items():
     v.update(common)
@@ -307,7 +311,7 @@ def main() -> None:
     routines = _collect_routines(mod, routines_mpi, assumed_rank)
     generics = _interfaces_to_generics(mod)
     data = {"routines": routines, "variables": variables, "generics": generics}
-    print(json.dumps(data, indent=2))
+    print(json.dumps(data, indent=2, default=str))
 
 
 if __name__ == "__main__":

--- a/fortran_modules/mpi.fadmod
+++ b/fortran_modules/mpi.fadmod
@@ -751,6 +751,636 @@
         "out"
       ]
     },
+    "MPI_Scatter_r4": {
+      "module": "mpi",
+      "args": [
+        "sendbuf",
+        "sendcount",
+        "sendtype",
+        "recvbuf",
+        "recvcount",
+        "recvtype",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "MPI_Scatter_fwd_ad",
+      "args_fwd_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "sendcount",
+        "sendtype",
+        "recvbuf",
+        "recvbuf_ad",
+        "recvcount",
+        "recvtype",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "MPI_Scatter_rev_ad",
+      "args_rev_ad": [
+        "sendbuf_ad",
+        "sendcount",
+        "sendtype",
+        "recvbuf_ad",
+        "recvcount",
+        "recvtype",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ]
+    },
+    "MPI_Scatter_r8": {
+      "module": "mpi",
+      "args": [
+        "sendbuf",
+        "sendcount",
+        "sendtype",
+        "recvbuf",
+        "recvcount",
+        "recvtype",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        null,
+        null,
+        "8",
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "MPI_Scatter_fwd_ad",
+      "args_fwd_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "sendcount",
+        "sendtype",
+        "recvbuf",
+        "recvbuf_ad",
+        "recvcount",
+        "recvtype",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "MPI_Scatter_rev_ad",
+      "args_rev_ad": [
+        "sendbuf_ad",
+        "sendcount",
+        "sendtype",
+        "recvbuf_ad",
+        "recvcount",
+        "recvtype",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ]
+    },
+    "MPI_Gather_r4": {
+      "module": "mpi",
+      "args": [
+        "sendbuf",
+        "sendcount",
+        "sendtype",
+        "recvbuf",
+        "recvcount",
+        "recvtype",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "MPI_Gather_fwd_ad",
+      "args_fwd_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "sendcount",
+        "sendtype",
+        "recvbuf",
+        "recvbuf_ad",
+        "recvcount",
+        "recvtype",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "MPI_Gather_rev_ad",
+      "args_rev_ad": [
+        "sendbuf_ad",
+        "sendcount",
+        "sendtype",
+        "recvbuf_ad",
+        "recvcount",
+        "recvtype",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ]
+    },
+    "MPI_Gather_r8": {
+      "module": "mpi",
+      "args": [
+        "sendbuf",
+        "sendcount",
+        "sendtype",
+        "recvbuf",
+        "recvcount",
+        "recvtype",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        null,
+        null,
+        "8",
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "MPI_Gather_fwd_ad",
+      "args_fwd_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "sendcount",
+        "sendtype",
+        "recvbuf",
+        "recvbuf_ad",
+        "recvcount",
+        "recvtype",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "MPI_Gather_rev_ad",
+      "args_rev_ad": [
+        "sendbuf_ad",
+        "sendcount",
+        "sendtype",
+        "recvbuf_ad",
+        "recvcount",
+        "recvtype",
+        "root",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ]
+    },
+    "MPI_Alltoall_r4": {
+      "module": "mpi",
+      "args": [
+        "sendbuf",
+        "sendcount",
+        "sendtype",
+        "recvbuf",
+        "recvcount",
+        "recvtype",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "out",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "MPI_Alltoall_fwd_ad",
+      "args_fwd_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "sendcount",
+        "sendtype",
+        "recvbuf",
+        "recvbuf_ad",
+        "recvcount",
+        "recvtype",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "MPI_Alltoall_rev_ad",
+      "args_rev_ad": [
+        "sendbuf_ad",
+        "sendcount",
+        "sendtype",
+        "recvbuf_ad",
+        "recvcount",
+        "recvtype",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "out"
+      ]
+    },
+    "MPI_Alltoall_r8": {
+      "module": "mpi",
+      "args": [
+        "sendbuf",
+        "sendcount",
+        "sendtype",
+        "recvbuf",
+        "recvcount",
+        "recvtype",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "in",
+        "in",
+        "out",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "real",
+        "integer",
+        "integer",
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        "8",
+        null,
+        null,
+        "8",
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "MPI_Alltoall_fwd_ad",
+      "args_fwd_ad": [
+        "sendbuf",
+        "sendbuf_ad",
+        "sendcount",
+        "sendtype",
+        "recvbuf",
+        "recvbuf_ad",
+        "recvcount",
+        "recvtype",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "in",
+        "in",
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "MPI_Alltoall_rev_ad",
+      "args_rev_ad": [
+        "sendbuf_ad",
+        "sendcount",
+        "sendtype",
+        "recvbuf_ad",
+        "recvcount",
+        "recvtype",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "inout",
+        "in",
+        "in",
+        "in",
+        "out"
+      ]
+    },
     "MPI_Recv_r4": {
       "module": "mpi",
       "args": [
@@ -4539,6 +5169,22 @@
       "typename": "integer",
       "parameter": true
     },
+    "MPI_IN_PLACE": {
+      "typename": "integer",
+      "parameter": true
+    },
+    "MPI_BOTTOM": {
+      "typename": "integer",
+      "parameter": true
+    },
+    "MPI_UNWEIGHTED": {
+      "typename": "integer",
+      "parameter": true
+    },
+    "MPI_WEIGHTS_EMPTY": {
+      "typename": "integer",
+      "parameter": true
+    },
     "MPI_REQUEST_NULL": {
       "typename": "integer",
       "parameter": true
@@ -4848,6 +5494,18 @@
     "MPI_Allreduce": [
       "MPI_Allreduce_r4",
       "MPI_Allreduce_r8"
+    ],
+    "MPI_Scatter": [
+      "MPI_Scatter_r4",
+      "MPI_Scatter_r8"
+    ],
+    "MPI_Gather": [
+      "MPI_Gather_r4",
+      "MPI_Gather_r8"
+    ],
+    "MPI_Alltoall": [
+      "MPI_Alltoall_r4",
+      "MPI_Alltoall_r8"
     ],
     "MPI_Recv": [
       "MPI_Recv_r4",


### PR DESCRIPTION
## Summary
- remove skip stubs so generated mpi.fadmod only lists implemented collectives
- regenerate mpi.fadmod showing MPI_Scatter, MPI_Gather, and MPI_Alltoall variants

## Testing
- `isort . --profile black`
- `black fortran_modules/gen_mpi_fadmod.py`
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_68a3f328bbd8832d86057cf69d32bb94