### PR TITLE
Load generic routines from modules used inside routines

### DIFF
--- a/examples/mpi_sub_use.f90
+++ b/examples/mpi_sub_use.f90
@@ -1,0 +1,14 @@
+module mpi_sub_use
+  implicit none
+contains
+  subroutine foo(x, comm)
+    use mpi
+    real, intent(inout) :: x
+    integer, intent(in) :: comm
+    real :: tmp
+    integer :: ierr
+    call MPI_Allreduce(x, tmp, 1, MPI_REAL, MPI_SUM, comm, ierr)
+    x = tmp
+    return
+  end subroutine foo
+end module mpi_sub_use

--- a/examples/mpi_sub_use_ad.f90
+++ b/examples/mpi_sub_use_ad.f90
@@ -1,0 +1,41 @@
+module mpi_sub_use_ad
+  use mpi_sub_use
+  use mpi
+  use mpi_ad
+  implicit none
+
+contains
+
+  subroutine foo_fwd_ad(x, x_ad, comm)
+    use mpi
+    use mpi_ad
+    real, intent(inout) :: x
+    real, intent(inout) :: x_ad
+    integer, intent(in)  :: comm
+    real :: tmp_ad
+    real :: tmp
+    integer :: ierr
+
+    call MPI_Allreduce_fwd_ad(x, x_ad, tmp, tmp_ad, 1, MPI_REAL, MPI_SUM, comm, ierr) ! call MPI_Allreduce(x, tmp, 1, MPI_REAL, MPI_SUM, comm, ierr)
+    x_ad = tmp_ad ! x = tmp
+    x = tmp
+
+    return
+  end subroutine foo_fwd_ad
+
+  subroutine foo_rev_ad(x_ad, comm)
+    use mpi
+    use mpi_ad
+    real, intent(inout) :: x_ad
+    integer, intent(in)  :: comm
+    real :: tmp_ad
+    integer :: ierr
+
+    tmp_ad = x_ad ! x = tmp
+    x_ad = 0.0 ! x = tmp
+    call MPI_Allreduce_rev_ad(x_ad, tmp_ad, 1, MPI_REAL, MPI_SUM, comm, ierr) ! call MPI_Allreduce(x, tmp, 1, MPI_REAL, MPI_SUM, comm, ierr)
+
+    return
+  end subroutine foo_rev_ad
+
+end module mpi_sub_use_ad

--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -2376,9 +2376,13 @@ class Module(Node):
         return lines
 
     def find_use_modules(self) -> List[str]:
-        mods = []
+        mods: List[str] = []
         if self.uses is not None:
             for child in self.uses.iter_children():
+                if isinstance(child, Use):
+                    mods.append(child.name)
+        for routine in self.routines:
+            for child in routine.decls.iter_children():
                 if isinstance(child, Use):
                     mods.append(child.name)
         return mods


### PR DESCRIPTION
## Summary
- include modules used by contained routines when collecting generic procedure mappings
- add example exercising subroutine-level MPI use

## Testing
- `isort . --profile black`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3fe5c5b88832d85c4ec031e75b26c