### PR TITLE
Add MPI_Allreduce in-place wrappers

### DIFF
--- a/fortran_modules/mpi.fadmod
+++ b/fortran_modules/mpi.fadmod
@@ -751,6 +751,178 @@
         "out"
       ]
     },
+    "MPI_Allreduce_r4_inplace": {
+      "module": "mpi",
+      "args": [
+        "sendbuf",
+        "recvbuf",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "integer",
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "MPI_Allreduce_fwd_ad",
+      "args_fwd_ad": [
+        "sendbuf",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "MPI_Allreduce_rev_ad",
+      "args_rev_ad": [
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ]
+    },
+    "MPI_Allreduce_r8_inplace": {
+      "module": "mpi",
+      "args": [
+        "sendbuf",
+        "recvbuf",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents": [
+        "in",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "dims": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "type": [
+        "integer",
+        "real",
+        "integer",
+        "integer",
+        "integer",
+        "integer",
+        "integer"
+      ],
+      "kind": [
+        null,
+        "8",
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "name_fwd_ad": "MPI_Allreduce_fwd_ad",
+      "args_fwd_ad": [
+        "sendbuf",
+        "recvbuf",
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents_fwd_ad": [
+        "in",
+        "out",
+        "out",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ],
+      "name_rev_ad": "MPI_Allreduce_rev_ad",
+      "args_rev_ad": [
+        "recvbuf_ad",
+        "count",
+        "datatype",
+        "op",
+        "comm",
+        "ierr"
+      ],
+      "intents_rev_ad": [
+        "inout",
+        "in",
+        "in",
+        "in",
+        "in",
+        "out"
+      ]
+    },
     "MPI_Scatter_r4": {
       "module": "mpi",
       "args": [
@@ -5493,7 +5665,9 @@
     ],
     "MPI_Allreduce": [
       "MPI_Allreduce_r4",
-      "MPI_Allreduce_r8"
+      "MPI_Allreduce_r8",
+      "MPI_Allreduce_r4_inplace",
+      "MPI_Allreduce_r8_inplace"
     ],
     "MPI_Scatter": [
       "MPI_Scatter_r4",

--- a/fortran_modules/mpi_ad.f90
+++ b/fortran_modules/mpi_ad.f90
@@ -111,10 +111,14 @@ module mpi_ad
   interface mpi_allreduce_fwd_ad
      module procedure mpi_allreduce_fwd_ad_r4
      module procedure mpi_allreduce_fwd_ad_r8
+     module procedure mpi_allreduce_fwd_ad_r4_inplace
+     module procedure mpi_allreduce_fwd_ad_r8_inplace
   end interface
   interface mpi_allreduce_rev_ad
      module procedure mpi_allreduce_rev_ad_r4
      module procedure mpi_allreduce_rev_ad_r8
+     module procedure mpi_allreduce_rev_ad_r4_inplace
+     module procedure mpi_allreduce_rev_ad_r8_inplace
   end interface
   interface mpi_scatter_fwd_ad
      module procedure mpi_scatter_fwd_ad_r4
@@ -431,6 +435,45 @@ contains
   call MPI_Allreduce(rb_ad, sb_ad, count, datatype, op, comm, ierr)
   rb_ad(1:count) = 0.0_8
 end subroutine mpi_allreduce_rev_ad_r8
+
+
+  subroutine mpi_allreduce_fwd_ad_r4_inplace(sendbuf, recvbuf, recvbuf_ad, count, datatype, op, comm, ierr)
+    integer, intent(in) :: sendbuf
+    real, intent(out) :: recvbuf(..)
+    real, intent(out) :: recvbuf_ad(..)
+    integer, intent(in) :: count, datatype, op, comm
+    integer, intent(out), optional :: ierr
+
+    call MPI_Allreduce(sendbuf, recvbuf, count, datatype, op, comm, ierr)
+    call MPI_Allreduce(sendbuf, recvbuf_ad, count, datatype, op, comm, ierr)
+  end subroutine mpi_allreduce_fwd_ad_r4_inplace
+
+  subroutine mpi_allreduce_rev_ad_r4_inplace(recvbuf_ad, count, datatype, op, comm, ierr)
+    real, intent(inout), target, contiguous :: recvbuf_ad(..)
+    integer, intent(in) :: count, datatype, op, comm
+    integer, intent(out), optional :: ierr
+
+    call MPI_Allreduce(MPI_IN_PLACE, recvbuf_ad, count, datatype, op, comm, ierr)
+  end subroutine mpi_allreduce_rev_ad_r4_inplace
+
+  subroutine mpi_allreduce_fwd_ad_r8_inplace(sendbuf, recvbuf, recvbuf_ad, count, datatype, op, comm, ierr)
+    integer, intent(in) :: sendbuf
+    real(8), intent(out) :: recvbuf(..)
+    real(8), intent(out) :: recvbuf_ad(..)
+    integer, intent(in) :: count, datatype, op, comm
+    integer, intent(out), optional :: ierr
+
+    call MPI_Allreduce(sendbuf, recvbuf, count, datatype, op, comm, ierr)
+    call MPI_Allreduce(sendbuf, recvbuf_ad, count, datatype, op, comm, ierr)
+  end subroutine mpi_allreduce_fwd_ad_r8_inplace
+
+  subroutine mpi_allreduce_rev_ad_r8_inplace(recvbuf_ad, count, datatype, op, comm, ierr)
+    real(8), intent(inout), target, contiguous :: recvbuf_ad(..)
+    integer, intent(in) :: count, datatype, op, comm
+    integer, intent(out), optional :: ierr
+
+    call MPI_Allreduce(MPI_IN_PLACE, recvbuf_ad, count, datatype, op, comm, ierr)
+  end subroutine mpi_allreduce_rev_ad_r8_inplace
 
   subroutine mpi_scatter_fwd_ad_r4(sendbuf, sendbuf_ad, sendcount, sendtype, recvbuf, recvbuf_ad, recvcount, recvtype, root, comm, ierr)
     real, intent(in) :: sendbuf(..)


### PR DESCRIPTION
## Summary
- add forward and reverse AD wrappers for MPI_Allreduce with MPI_IN_PLACE
- regenerate mpi.fadmod to expose MPI_Allreduce_r4_inplace and MPI_Allreduce_r8_inplace

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_68a403c9c374832d990d788280d3dc3c