### PR TITLE
Set in-place MPI_Allreduce buffer intent to inout

### DIFF
--- a/fortran_modules/mpi.fadmod
+++ b/fortran_modules/mpi.fadmod
@@ -764,7 +764,7 @@
       ],
       "intents": [
         "in",
-        "out",
+        "inout",
         "in",
         "in",
         "in",
@@ -811,8 +811,8 @@
       ],
       "intents_fwd_ad": [
         "in",
-        "out",
-        "out",
+        "inout",
+        "inout",
         "in",
         "in",
         "in",
@@ -850,7 +850,7 @@
       ],
       "intents": [
         "in",
-        "out",
+        "inout",
         "in",
         "in",
         "in",
@@ -897,8 +897,8 @@
       ],
       "intents_fwd_ad": [
         "in",
-        "out",
-        "out",
+        "inout",
+        "inout",
         "in",
         "in",
         "in",

--- a/fortran_modules/mpi_ad.f90
+++ b/fortran_modules/mpi_ad.f90
@@ -439,8 +439,8 @@ end subroutine mpi_allreduce_rev_ad_r8
 
   subroutine mpi_allreduce_fwd_ad_r4_inplace(sendbuf, recvbuf, recvbuf_ad, count, datatype, op, comm, ierr)
     integer, intent(in) :: sendbuf
-    real, intent(out) :: recvbuf(..)
-    real, intent(out) :: recvbuf_ad(..)
+    real, intent(inout) :: recvbuf(..)
+    real, intent(inout) :: recvbuf_ad(..)
     integer, intent(in) :: count, datatype, op, comm
     integer, intent(out), optional :: ierr
 
@@ -458,8 +458,8 @@ end subroutine mpi_allreduce_rev_ad_r8
 
   subroutine mpi_allreduce_fwd_ad_r8_inplace(sendbuf, recvbuf, recvbuf_ad, count, datatype, op, comm, ierr)
     integer, intent(in) :: sendbuf
-    real(8), intent(out) :: recvbuf(..)
-    real(8), intent(out) :: recvbuf_ad(..)
+    real(8), intent(inout) :: recvbuf(..)
+    real(8), intent(inout) :: recvbuf_ad(..)
     integer, intent(in) :: count, datatype, op, comm
     integer, intent(out), optional :: ierr
 


### PR DESCRIPTION
## Summary
- ensure in-place MPI_Allreduce forward AD wrappers treat recv buffers as inout
- regenerate `mpi.fadmod` to capture the updated intents

## Testing
- `isort . --profile black`
- `black .`
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_68a4091be158832db3ae1fe52a076be0