### PR TITLE
Add fadmod tests and use class loader in generator tests

### DIFF
--- a/tests/test_fadmod.py
+++ b/tests/test_fadmod.py
@@ -1,0 +1,35 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fautodiff import fadmod
+
+
+class TestFadmod(unittest.TestCase):
+    def test_roundtrip(self):
+        data = {
+            "routines": {"foo": {"module": "m", "name_fwd_ad": "foo_fwd_ad"}},
+            "variables": {"x": {"typename": "real", "constant": True}},
+        }
+        fm = fadmod.FadmodV1.from_dict(data)
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "test.fadmod"
+            fm.write(path)
+            loaded = fadmod.FadmodBase.load(path)
+        self.assertIsInstance(loaded, fadmod.FadmodV1)
+        self.assertEqual(loaded.dump(), fm.dump())
+
+    def test_unknown_version(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad.fadmod"
+            path.write_text(json.dumps({"version": 99}))
+            with self.assertRaisesRegex(RuntimeError, "unsupported fadmod version 99"):
+                fadmod.FadmodBase.load(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace direct JSON parsing in generator tests with FadmodV1 loader
- add round-trip and unknown-version tests for Fadmod

## Testing
- `isort tests/test_fadmod.py tests/test_generator.py --profile black`
- `black tests/test_fadmod.py tests/test_generator.py`
- `pytest tests/test_fadmod.py tests/test_generator.py tests/test_parser.py tests/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_b_68a67cdbfcec832db399cd073b531aaf