### PR TITLE
Refactor fadmod handling and add schema validation

### DIFF
--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -1544,31 +1544,11 @@ def _search_use(
                 break
         if fad is None:
             raise RuntimeError(f"fadmod file not found for module {name}")
-        for vname, info in fad.variables_raw.items():
+        decls = fad.variable_declarations(lambda v: _get_kind(v, decl_map))
+        for vname, decl in decls.items():
             if only is None or vname in only:
-                kind_name = info.get("kind_name")
-                if kind_name is not None:
-                    kind = _get_kind(kind_name, decl_map)
-                elif info.get("kind") is not None:
-                    val = info["kind"]
-                    kind = Kind(OpInt(val), val=val)
-                else:
-                    kind = None
-                decl_map[vname] = Declaration(
-                    vname,
-                    var_type=VarType(info["typename"], kind=kind),
-                    dims=(
-                        tuple(info["dims"]) if info.get("dims") is not None else None
-                    ),
-                    intent=None,
-                    parameter=info.get("parameter", False),
-                    constant=info.get("constant", False),
-                    init_val=info.get("init_val"),
-                    access=info.get("access"),
-                    pointer=info.get("pointer", False),
-                    optional=info.get("optional", False),
-                    declared_in="use",
-                )
+                decl.declared_in = "use"
+                decl_map[vname] = decl
 
 
 def _process_spec_part(

--- a/tests/test_fadmod.py
+++ b/tests/test_fadmod.py
@@ -30,6 +30,11 @@ class TestFadmod(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "unsupported fadmod version 99"):
                 fadmod.FadmodBase.load(path)
 
+    def test_invalid_variable_entry(self):
+        data = {"routines": {}, "variables": {"x": {"constant": True}}}
+        with self.assertRaisesRegex(RuntimeError, "missing 'typename'"):
+            fadmod.FadmodV1.from_dict(data)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- use `FadmodBase.variable_declarations` in parser instead of raw JSON
- add version-aware declaration retrieval and strict schema validation in `FadmodV1`
- test invalid fadmod entries

## Testing
- `python3 tests/test_generator.py`
- `python3 tests/test_fadmod.py`


------
https://chatgpt.com/codex/tasks/task_b_68a6803cd608832db8145e6875321e73