### PR TITLE
Add schema version to FADMOD definitions

### DIFF
--- a/fortran_modules/gen_mpi_fadmod.py
+++ b/fortran_modules/gen_mpi_fadmod.py
@@ -79,7 +79,13 @@ def _collect_routines(
                 types.append(
                     decls.get(arg).var_type.typename.lower() if decls.get(arg) else None
                 )
-                kinds.append(decls.get(arg).var_type.kind if decls.get(arg) else None)
+                raw_kind = decls.get(arg).var_type.kind if decls.get(arg) else None
+                if raw_kind is not None:
+                    kind_str = str(raw_kind).strip()
+                    kind = int(kind_str) if kind_str.isdigit() else None
+                else:
+                    kind = None
+                kinds.append(kind)
             info["intents"] = intents
             info["dims"] = dims
             info["type"] = types
@@ -310,7 +316,9 @@ def main() -> None:
         mod = parser.parse_file(tmp.name, decl_map=decl_map)[0]
     routines = _collect_routines(mod, routines_mpi, assumed_rank)
     generics = _interfaces_to_generics(mod)
-    data = {"routines": routines, "variables": variables, "generics": generics}
+    data = {"version": 1, "routines": routines, "variables": variables}
+    if generics:
+        data["generics"] = generics
     print(json.dumps(data, indent=2, default=str))
 
 

--- a/fortran_modules/ieee_arithmetic.fadmod
+++ b/fortran_modules/ieee_arithmetic.fadmod
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "routines": {
     "ieee_is_nan": {
       "module": "ieee_arithmetic",

--- a/fortran_modules/ieee_exceptions.fadmod
+++ b/fortran_modules/ieee_exceptions.fadmod
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "routines": {
     "ieee_get_flag": {
       "module": "ieee_exceptions",

--- a/fortran_modules/ieee_features.fadmod
+++ b/fortran_modules/ieee_features.fadmod
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "routines": {
     "ieee_get_underflow_mode": {
       "module": "ieee_features",

--- a/fortran_modules/iso_c_binding.fadmod
+++ b/fortran_modules/iso_c_binding.fadmod
@@ -1,8 +1,10 @@
 {
+  "version": 1,
+  "routines": {},
   "variables": {
     "c_null_ptr": {
-        "typename": "type(c_ptr)",
-        "parameter": true
+      "typename": "type(c_ptr)",
+      "parameter": true
     }
   }
 }

--- a/fortran_modules/iso_fortran_env.fadmod
+++ b/fortran_modules/iso_fortran_env.fadmod
@@ -1,4 +1,6 @@
 {
+  "version": 1,
+  "routines": {},
   "variables": {
     "int8": {"typename": "integer", "parameter": true},
     "int16": {"typename": "integer", "parameter": true},

--- a/fortran_modules/mpi.fadmod
+++ b/fortran_modules/mpi.fadmod
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "routines": {
     "MPI_Comm_rank": {
       "args": [
@@ -329,7 +330,7 @@
         "integer"
       ],
       "kind": [
-        "8",
+        8,
         null,
         null,
         null,
@@ -515,8 +516,8 @@
         "integer"
       ],
       "kind": [
-        "8",
-        "8",
+        8,
+        8,
         null,
         null,
         null,
@@ -702,8 +703,8 @@
         "integer"
       ],
       "kind": [
-        "8",
-        "8",
+        8,
+        8,
         null,
         null,
         null,
@@ -885,7 +886,7 @@
       ],
       "kind": [
         null,
-        "8",
+        8,
         null,
         null,
         null,
@@ -1090,10 +1091,10 @@
         "integer"
       ],
       "kind": [
-        "8",
+        8,
         null,
         null,
-        "8",
+        8,
         null,
         null,
         null,
@@ -1306,10 +1307,10 @@
         "integer"
       ],
       "kind": [
-        "8",
+        8,
         null,
         null,
-        "8",
+        8,
         null,
         null,
         null,
@@ -1509,10 +1510,10 @@
         "integer"
       ],
       "kind": [
-        "8",
+        8,
         null,
         null,
-        "8",
+        8,
         null,
         null,
         null,
@@ -1707,7 +1708,7 @@
         "integer"
       ],
       "kind": [
-        "8",
+        8,
         null,
         null,
         null,
@@ -1886,7 +1887,7 @@
         "integer"
       ],
       "kind": [
-        "8",
+        8,
         null,
         null,
         null,
@@ -2144,12 +2145,12 @@
         "integer"
       ],
       "kind": [
-        "8",
+        8,
         null,
         null,
         null,
         null,
-        "8",
+        8,
         null,
         null,
         null,
@@ -2386,7 +2387,7 @@
         "integer"
       ],
       "kind": [
-        "8",
+        8,
         null,
         null,
         null,
@@ -2626,7 +2627,7 @@
         "integer"
       ],
       "kind": [
-        "8",
+        8,
         null,
         null,
         null,
@@ -2754,7 +2755,7 @@
         null,
         null,
         null,
-        "MPI_ADDRESS_KIND",
+        null,
         null,
         null,
         null,
@@ -2856,11 +2857,11 @@
         "integer"
       ],
       "kind": [
-        "8",
+        8,
         null,
         null,
         null,
-        "MPI_ADDRESS_KIND",
+        null,
         null,
         null,
         null,
@@ -2966,7 +2967,7 @@
         null,
         null,
         null,
-        "MPI_ADDRESS_KIND",
+        null,
         null,
         null,
         null,
@@ -3068,11 +3069,11 @@
         "integer"
       ],
       "kind": [
-        "8",
+        8,
         null,
         null,
         null,
-        "MPI_ADDRESS_KIND",
+        null,
         null,
         null,
         null,
@@ -3182,7 +3183,7 @@
         null,
         null,
         null,
-        "MPI_ADDRESS_KIND",
+        null,
         null,
         null,
         null,
@@ -3293,11 +3294,11 @@
         "integer"
       ],
       "kind": [
-        "8",
+        8,
         null,
         null,
         null,
-        "MPI_ADDRESS_KIND",
+        null,
         null,
         null,
         null,
@@ -3520,7 +3521,7 @@
         "integer"
       ],
       "kind": [
-        "8",
+        8,
         null,
         null,
         null,
@@ -3760,7 +3761,7 @@
         "integer"
       ],
       "kind": [
-        "8",
+        8,
         null,
         null,
         null,

--- a/fortran_modules/omp_lib.fadmod
+++ b/fortran_modules/omp_lib.fadmod
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "routines": {
     "omp_get_num_threads": {
       "module": "omp_lib",
@@ -16,5 +17,6 @@
       "type": ["integer"],
       "kind": [null]
     }
-  }
+  },
+  "variables": {}
 }


### PR DESCRIPTION
## Summary
- add version field and required sections to Fortran module `.fadmod` files
- update MPI FADMOD generator to emit version metadata and omit `generics` when empty
- normalize `kind` values to integers in generated MPI FADMOD

## Testing
- `isort . --profile black`
- `black .`
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_68a6830385e8832d9513a3e96760d4b6