### PR TITLE
Handle allocatable temporaries in SaveAssignment

### DIFF
--- a/examples/allocate_vars_ad.f90
+++ b/examples/allocate_vars_ad.f90
@@ -28,8 +28,12 @@ contains
       res_ad = res_ad + arr_ad(i) * x + x_ad * arr(i) ! res = res + arr(i) * x
       res = res + arr(i) * x
     end do
-    deallocate(arr_ad)
-    deallocate(arr)
+    if (allocated(arr_ad)) then
+      deallocate(arr_ad)
+    end if
+    if (allocated(arr)) then
+      deallocate(arr)
+    end if
 
     return
   end subroutine allocate_and_sum_fwd_ad
@@ -57,8 +61,12 @@ contains
     do i = n, 1, - 1
       x_ad = arr_ad(i) * i + x_ad ! arr(i) = i * x
     end do
-    deallocate(arr_ad)
-    deallocate(arr)
+    if (allocated(arr_ad)) then
+      deallocate(arr_ad)
+    end if
+    if (allocated(arr)) then
+      deallocate(arr)
+    end if
 
     return
   end subroutine allocate_and_sum_rev_ad
@@ -91,8 +99,12 @@ contains
       z_ad = z_ad + htmp_ad(i) * y + y_ad * htmp(i) ! z = z + htmp(i) * y
       z = z + htmp(i) * y
     end do
-    deallocate(htmp_ad)
-    deallocate(htmp)
+    if (allocated(htmp_ad)) then
+      deallocate(htmp_ad)
+    end if
+    if (allocated(htmp)) then
+      deallocate(htmp)
+    end if
 
     return
   end subroutine save_alloc_fwd_ad
@@ -121,6 +133,9 @@ contains
       y_ad = z_ad * htmp(i) + y_ad ! z = z + htmp(i) * y
     end do
     htmp(1:n) = htmp_save_42_ad(1:n)
+    if (allocated(htmp_save_42_ad)) then
+      deallocate(htmp_save_42_ad)
+    end if
     x_ad = htmp_ad * 2.0 * x + x_ad ! htmp = x**2
     do i = n, 1, - 1
       htmp_ad(i) = z_ad * y ! z = z + htmp(i) * y
@@ -130,9 +145,6 @@ contains
     x_ad = htmp_ad + x_ad ! htmp = x
     if (allocated(htmp_ad)) then
       deallocate(htmp_ad)
-    end if
-    if (allocated(htmp_save_42_ad)) then
-      deallocate(htmp_save_42_ad)
     end if
     if (allocated(htmp)) then
       deallocate(htmp)
@@ -218,7 +230,9 @@ contains
       x_ad = x_ad + mod_arr_diff_ad(i) * mod_arr(i) ! x = x + mod_arr(i) * mod_arr_diff(i)
       x = x + mod_arr(i) * mod_arr_diff(i)
     end do
-    deallocate(mod_arr_diff_ad)
+    if (allocated(mod_arr_diff_ad)) then
+      deallocate(mod_arr_diff_ad)
+    end if
 
     return
   end subroutine module_vars_finalize_fwd_ad

--- a/examples/derived_alloc_ad.f90
+++ b/examples/derived_alloc_ad.f90
@@ -50,9 +50,13 @@ contains
     integer :: j
 
     do j = 1, m
-      deallocate(obj_ad(j)%arr_ad)
+      if (allocated(obj_ad) .and. allocated(obj_ad(j)%arr_ad)) then
+        deallocate(obj_ad(j)%arr_ad)
+      end if
     end do
-    deallocate(obj_ad)
+    if (allocated(obj_ad)) then
+      deallocate(obj_ad)
+    end if
 
     return
   end subroutine derived_alloc_finalize_fwd_ad

--- a/examples/pointer_arrays_ad.f90
+++ b/examples/pointer_arrays_ad.f90
@@ -37,9 +37,15 @@ contains
       res_ad = res_ad + p_ad(i) + mod_p_ad(i) ! res = res + p(i) + mod_p(i)
       res = res + p(i) + mod_p(i)
     end do
-    deallocate(p_ad)
-    deallocate(p)
-    deallocate(mod_p_ad)
+    if (associated(p_ad)) then
+      deallocate(p_ad)
+    end if
+    if (associated(p)) then
+      deallocate(p)
+    end if
+    if (associated(mod_p_ad)) then
+      deallocate(mod_p_ad)
+    end if
 
     return
   end subroutine pointer_allocate_fwd_ad
@@ -67,7 +73,9 @@ contains
     if (associated(mod_p_ad)) then
       deallocate(mod_p_ad)
     end if
-    deallocate(p_ad)
+    if (associated(p_ad)) then
+      deallocate(p_ad)
+    end if
 
     return
   end subroutine pointer_allocate_rev_ad
@@ -98,7 +106,9 @@ contains
       res = res + p(i)
     end do
     p => null()
-    deallocate(mod_p_ad)
+    if (associated(mod_p_ad)) then
+      deallocate(mod_p_ad)
+    end if
 
     return
   end subroutine pointer_subarray_fwd_ad

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -393,8 +393,10 @@ def _parse_allocate(
         for name in map:
             if map[name]:
                 if name not in mod_var_names or name in local:
-                    var = OpVar(name, index=map[name][0])
-                    node.append(Deallocate([var]))
+                    var = OpVar(name, index=map[name][0], allocatable=True)
+                    node.append(
+                        Allocate._add_if(Deallocate([var]), var, name in mod_var_names)
+                    )
 
 
 def _parse_pointer(

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -600,8 +600,8 @@ class TestGenerator(unittest.TestCase):
                 generated, r"if \(\.not\. allocated\(htmp_save_\d+_ad\)\)"
             )
             self.assertRegex(generated, r"allocate\(htmp_save_\d+_ad, mold=htmp\)")
-            self.assertIn("if (.not. allocated(htmp))", generated)
-            self.assertRegex(generated, r"allocate\(htmp, mold=htmp_save_\d+_ad\)")
+            self.assertNotIn("if (.not. allocated(htmp))", generated)
+            self.assertNotRegex(generated, r"allocate\(htmp, mold=htmp_save_\d+_ad\)")
 
     def test_persistent_mpi_wrappers(self):
         code_tree.Node.reset()


### PR DESCRIPTION
## Summary
- avoid reallocating original variable when restoring from `_save_*_ad` temporary
- guard all generated `deallocate` statements with allocation checks
- free `_save_*_ad` temporaries after use
- ensure nested deallocations check parent allocations

## Testing
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_68a68c75d458832d9498df51df1f379a