### PR TITLE
Add allocate tests for loops and mid-if blocks

### DIFF
--- a/examples/allocate_vars.f90
+++ b/examples/allocate_vars.f90
@@ -49,6 +49,54 @@ contains
     return
   end subroutine allocate_in_if
 
+  subroutine allocate_in_if_nonfirst(n, x, res)
+    integer, intent(in) :: n
+    real, intent(in) :: x
+    real, intent(out) :: res
+    real, allocatable :: arr(:)
+    real, allocatable :: arr2(:)
+    integer :: i
+
+    allocate(arr(n))
+    do i = 1, n
+      arr(i) = i * x
+    end do
+    if (n > 0) then
+      res = 0.0
+      allocate(arr2(n))
+      arr2 = arr
+      do i = 1, n
+        res = res + arr2(i) * x
+      end do
+      deallocate(arr2)
+    else
+      res = 0.0
+    end if
+    deallocate(arr)
+
+    return
+  end subroutine allocate_in_if_nonfirst
+
+  subroutine allocate_in_loop(n, x, res)
+    integer, intent(in) :: n
+    real, intent(in) :: x
+    real, intent(out) :: res
+    real, allocatable :: arr(:)
+    integer :: i, j
+
+    res = 0.0
+    do i = 1, n
+      allocate(arr(i))
+      do j = 1, i
+        arr(j) = j * x
+      end do
+      res = res + arr(i) * x
+      deallocate(arr)
+    end do
+
+    return
+  end subroutine allocate_in_loop
+
   subroutine save_alloc(n, x, y, z)
     integer, intent(in) :: n
     real, intent(in) :: x(n), y

--- a/examples/allocate_vars_ad.f90
+++ b/examples/allocate_vars_ad.f90
@@ -141,6 +141,172 @@ contains
     return
   end subroutine allocate_in_if_rev_ad
 
+  subroutine allocate_in_if_nonfirst_fwd_ad(n, x, x_ad, res, res_ad)
+    integer, intent(in)  :: n
+    real, intent(in)  :: x
+    real, intent(in)  :: x_ad
+    real, intent(out) :: res
+    real, intent(out) :: res_ad
+    real, allocatable :: arr2_ad(:)
+    real, allocatable :: arr_ad(:)
+    integer :: i
+    real, allocatable :: arr(:)
+    real, allocatable :: arr2(:)
+
+    allocate(arr(n))
+    allocate(arr_ad(n))
+    do i = 1, n
+      arr_ad(i) = x_ad * i ! arr(i) = i * x
+      arr(i) = i * x
+    end do
+    if (n > 0) then
+      res_ad = 0.0 ! res = 0.0
+      res = 0.0
+      allocate(arr2(n))
+      allocate(arr2_ad(n))
+      arr2_ad = arr_ad ! arr2 = arr
+      arr2 = arr
+      do i = 1, n
+        res_ad = res_ad + arr2_ad(i) * x + x_ad * arr2(i) ! res = res + arr2(i) * x
+        res = res + arr2(i) * x
+      end do
+      if (allocated(arr2_ad)) then
+        deallocate(arr2_ad)
+      end if
+      if (allocated(arr2)) then
+        deallocate(arr2)
+      end if
+    else
+      res_ad = 0.0 ! res = 0.0
+      res = 0.0
+    end if
+    if (allocated(arr_ad)) then
+      deallocate(arr_ad)
+    end if
+    if (allocated(arr)) then
+      deallocate(arr)
+    end if
+
+    return
+  end subroutine allocate_in_if_nonfirst_fwd_ad
+
+  subroutine allocate_in_if_nonfirst_rev_ad(n, x, x_ad, res_ad)
+    integer, intent(in)  :: n
+    real, intent(in)  :: x
+    real, intent(inout) :: x_ad
+    real, intent(inout) :: res_ad
+    real, allocatable :: arr2_ad(:)
+    real, allocatable :: arr_ad(:)
+    integer :: i
+    real, allocatable :: arr(:)
+    real, allocatable :: arr2(:)
+
+    allocate(arr(n))
+    do i = 1, n
+      arr(i) = i * x
+    end do
+    allocate(arr_ad(n))
+    arr_ad = 0.0
+    if (n > 0) then
+      allocate(arr2(n))
+      arr2 = arr
+      allocate(arr2_ad(n))
+      do i = n, 1, - 1
+        arr2_ad(i) = res_ad * x ! res = res + arr2(i) * x
+        x_ad = res_ad * arr2(i) + x_ad ! res = res + arr2(i) * x
+      end do
+      arr_ad = arr2_ad ! arr2 = arr
+      if (allocated(arr2_ad)) then
+        deallocate(arr2_ad)
+      end if
+      if (allocated(arr2)) then
+        deallocate(arr2)
+      end if
+      res_ad = 0.0 ! res = 0.0
+    else
+      res_ad = 0.0 ! res = 0.0
+    end if
+    do i = n, 1, - 1
+      x_ad = arr_ad(i) * i + x_ad ! arr(i) = i * x
+    end do
+    if (allocated(arr_ad)) then
+      deallocate(arr_ad)
+    end if
+    if (allocated(arr)) then
+      deallocate(arr)
+    end if
+
+    return
+  end subroutine allocate_in_if_nonfirst_rev_ad
+
+  subroutine allocate_in_loop_fwd_ad(n, x, x_ad, res, res_ad)
+    integer, intent(in)  :: n
+    real, intent(in)  :: x
+    real, intent(in)  :: x_ad
+    real, intent(out) :: res
+    real, intent(out) :: res_ad
+    real, allocatable :: arr_ad(:)
+    integer :: i
+    integer :: j
+    real, allocatable :: arr(:)
+
+    res_ad = 0.0 ! res = 0.0
+    res = 0.0
+    do i = 1, n
+      allocate(arr(i))
+      allocate(arr_ad(i))
+      do j = 1, i
+        arr_ad(j) = x_ad * j ! arr(j) = j * x
+        arr(j) = j * x
+      end do
+      res_ad = res_ad + arr_ad(i) * x + x_ad * arr(i) ! res = res + arr(i) * x
+      res = res + arr(i) * x
+      if (allocated(arr_ad)) then
+        deallocate(arr_ad)
+      end if
+      if (allocated(arr)) then
+        deallocate(arr)
+      end if
+    end do
+
+    return
+  end subroutine allocate_in_loop_fwd_ad
+
+  subroutine allocate_in_loop_rev_ad(n, x, x_ad, res_ad)
+    integer, intent(in)  :: n
+    real, intent(in)  :: x
+    real, intent(inout) :: x_ad
+    real, intent(inout) :: res_ad
+    real, allocatable :: arr_ad(:)
+    integer :: i
+    integer :: j
+    real, allocatable :: arr(:)
+
+    do i = n, 1, - 1
+      allocate(arr(i))
+      do j = 1, i
+        arr(j) = j * x
+      end do
+      allocate(arr_ad(i))
+      arr_ad = 0.0
+      arr_ad(i) = res_ad * x ! res = res + arr(i) * x
+      x_ad = res_ad * arr(i) + x_ad ! res = res + arr(i) * x
+      do j = i, 1, - 1
+        x_ad = arr_ad(j) * j + x_ad ! arr(j) = j * x
+        arr_ad(j) = 0.0 ! arr(j) = j * x
+      end do
+      if (allocated(arr_ad)) then
+        deallocate(arr_ad)
+      end if
+      if (allocated(arr)) then
+        deallocate(arr)
+      end if
+    end do
+    res_ad = 0.0 ! res = 0.0
+
+    return
+  end subroutine allocate_in_loop_rev_ad
+
   subroutine save_alloc_fwd_ad(n, x, x_ad, y, y_ad, z, z_ad)
     integer, intent(in)  :: n
     real, intent(in)  :: x(n)
@@ -189,12 +355,12 @@ contains
     real, allocatable :: htmp_ad(:)
     real, allocatable :: htmp(:)
     integer :: i
-    real, allocatable :: htmp_save_65_ad(:)
+    real, allocatable :: htmp_save_114_ad(:)
 
     allocate(htmp(n))
     htmp = x
-    allocate(htmp_save_65_ad, mold=htmp)
-    htmp_save_65_ad(1:n) = htmp(1:n)
+    allocate(htmp_save_114_ad, mold=htmp)
+    htmp_save_114_ad(1:n) = htmp(1:n)
     htmp = x**2
 
     allocate(htmp_ad(n))
@@ -202,9 +368,9 @@ contains
       htmp_ad(i) = z_ad * y ! z = z + htmp(i) * y
       y_ad = z_ad * htmp(i) + y_ad ! z = z + htmp(i) * y
     end do
-    htmp(1:n) = htmp_save_65_ad(1:n)
-    if (allocated(htmp_save_65_ad)) then
-      deallocate(htmp_save_65_ad)
+    htmp(1:n) = htmp_save_114_ad(1:n)
+    if (allocated(htmp_save_114_ad)) then
+      deallocate(htmp_save_114_ad)
     end if
     x_ad = htmp_ad * 2.0 * x + x_ad ! htmp = x**2
     do i = n, 1, - 1

--- a/tests/fortran_runtime/run_allocate_vars.f90
+++ b/tests/fortran_runtime/run_allocate_vars.f90
@@ -8,6 +8,8 @@ program run_allocate_vars
   integer, parameter :: I_allocate_and_sum = 1
   integer, parameter :: I_module_vars = 2
   integer, parameter :: I_save_alloc = 3
+  integer, parameter :: I_allocate_in_if_nonfirst = 4
+  integer, parameter :: I_allocate_in_loop = 5
 
   integer :: length, status
   character(:), allocatable :: arg
@@ -27,6 +29,10 @@ program run_allocate_vars
               i_test = I_module_vars
            case ("save_alloc")
               i_test = I_save_alloc
+           case ("allocate_in_if_nonfirst")
+              i_test = I_allocate_in_if_nonfirst
+           case ("allocate_in_loop")
+              i_test = I_allocate_in_loop
            case default
               print *, 'Invalid test name: ', arg
               error stop 1
@@ -44,6 +50,12 @@ program run_allocate_vars
   end if
   if (i_test == I_save_alloc .or. i_test == I_all) then
      call test_save_alloc
+  end if
+  if (i_test == I_allocate_in_if_nonfirst .or. i_test == I_all) then
+     call test_allocate_in_if_nonfirst
+  end if
+  if (i_test == I_allocate_in_loop .or. i_test == I_all) then
+     call test_allocate_in_loop
   end if
 
   stop
@@ -159,6 +171,50 @@ contains
 
     return
   end subroutine test_save_alloc
+
+  subroutine test_allocate_in_if_nonfirst
+    real, parameter :: tol = 3.0e-4
+    integer, parameter :: n = 5
+    real :: x, res
+    real :: x_ad, res_ad
+    real :: res_eps, fd, eps
+
+    eps = 1.0e-3
+    x = 2.0
+    call allocate_in_if_nonfirst(n, x, res)
+    call allocate_in_if_nonfirst(n, x + eps, res_eps)
+    fd = (res_eps - res) / eps
+    x_ad = 1.0
+    call allocate_in_if_nonfirst_fwd_ad(n, x, x_ad, res, res_ad)
+    if (abs((res_ad - fd) / fd) > tol) then
+       print *, 'test_allocate_in_if_nonfirst_fwd failed', res_ad, fd
+       error stop 1
+    end if
+
+    return
+  end subroutine test_allocate_in_if_nonfirst
+
+  subroutine test_allocate_in_loop
+    real, parameter :: tol = 3.0e-4
+    integer, parameter :: n = 5
+    real :: x, res
+    real :: x_ad, res_ad
+    real :: res_eps, fd, eps
+
+    eps = 1.0e-3
+    x = 2.0
+    call allocate_in_loop(n, x, res)
+    call allocate_in_loop(n, x + eps, res_eps)
+    fd = (res_eps - res) / eps
+    x_ad = 1.0
+    call allocate_in_loop_fwd_ad(n, x, x_ad, res, res_ad)
+    if (abs((res_ad - fd) / fd) > tol) then
+       print *, 'test_allocate_in_loop_fwd failed', res_ad, fd
+       error stop 1
+    end if
+
+    return
+  end subroutine test_allocate_in_loop
 
 
 

--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -151,7 +151,14 @@ class TestFortranADCode(unittest.TestCase):
 
     def test_allocate(self):
         self._run_test(
-            "allocate_vars", ["allocate_and_sum", "module_vars", "save_alloc"]
+            "allocate_vars",
+            [
+                "allocate_and_sum",
+                "module_vars",
+                "save_alloc",
+                "allocate_in_if_nonfirst",
+                "allocate_in_loop",
+            ],
         )
 
     def test_exit_cycle(self):


### PR DESCRIPTION
## Summary
- exercise allocation inside loops and non-leading `if` blocks in `allocate_vars`
- generate updated AD stubs for new allocation patterns
- extend runtime driver and tests to cover the new allocation routines

## Testing
- `isort . --profile black`
- `black .`
- `pytest tests/test_generator.py tests/test_fortran_adcode.py::TestFortranADCode::test_allocate -q` *(fails: Mismatch for allocate_vars.f90)*

------
https://chatgpt.com/codex/tasks/task_b_68a6cc9428dc832db9ccef55b5bf2c1d