### PR TITLE
generator: insert deallocations before early returns in _parse_allocate

### DIFF
--- a/examples/allocate_vars.f90
+++ b/examples/allocate_vars.f90
@@ -144,4 +144,30 @@ contains
     return
   end subroutine module_vars_finalize
 
+  subroutine allocate_with_early_return(n, x, res)
+    integer, intent(in) :: n
+    real, intent(in) :: x
+    real, intent(out) :: res
+    real, allocatable :: arr(:)
+    integer :: i
+
+    allocate(arr(n))
+
+    if (n <= 0) then
+      res = 0.0
+      return
+    end if
+
+    do i = 1, n
+      arr(i) = i * x
+    end do
+    res = 0.0
+    do i = 1, n
+      res = res + arr(i) * x
+    end do
+    deallocate(arr)
+
+    return
+  end subroutine allocate_with_early_return
+
 end module allocate_vars

--- a/examples/allocate_vars_ad.f90
+++ b/examples/allocate_vars_ad.f90
@@ -424,4 +424,98 @@ contains
     return
   end subroutine module_vars_finalize_rev_ad
 
+  subroutine allocate_with_early_return_fwd_ad(n, x, x_ad, res, res_ad)
+    integer, intent(in)  :: n
+    real, intent(in)  :: x
+    real, intent(in)  :: x_ad
+    real, intent(out) :: res
+    real, intent(out) :: res_ad
+    real, allocatable :: arr_ad(:)
+    integer :: i
+    real, allocatable :: arr(:)
+
+    allocate(arr(n))
+    allocate(arr_ad(n))
+    if (n <= 0) then
+      res_ad = 0.0 ! res = 0.0
+      res = 0.0
+      if (allocated(arr_ad)) then
+        deallocate(arr_ad)
+      end if
+      if (allocated(arr)) then
+        deallocate(arr)
+      end if
+      return
+    end if
+    do i = 1, n
+      arr_ad(i) = x_ad * i ! arr(i) = i * x
+      arr(i) = i * x
+    end do
+    res_ad = 0.0 ! res = 0.0
+    res = 0.0
+    do i = 1, n
+      res_ad = res_ad + arr_ad(i) * x + x_ad * arr(i) ! res = res + arr(i) * x
+      res = res + arr(i) * x
+    end do
+    if (allocated(arr_ad)) then
+      deallocate(arr_ad)
+    end if
+    if (allocated(arr)) then
+      deallocate(arr)
+    end if
+
+    return
+  end subroutine allocate_with_early_return_fwd_ad
+
+  subroutine allocate_with_early_return_rev_ad(n, x, x_ad, res_ad)
+    integer, intent(in)  :: n
+    real, intent(in)  :: x
+    real, intent(inout) :: x_ad
+    real, intent(inout) :: res_ad
+    real, allocatable :: arr_ad(:)
+    logical :: return_flag_156_ad
+    integer :: i
+    real, allocatable :: arr(:)
+
+    return_flag_156_ad = .true.
+    allocate(arr(n))
+    if (n <= 0) then
+      return_flag_156_ad = .false.
+    end if
+    if (return_flag_156_ad) then
+      do i = 1, n
+        arr(i) = i * x
+      end do
+    end if
+
+    if (return_flag_156_ad) then
+      allocate(arr_ad(n))
+      do i = n, 1, - 1
+        arr_ad(i) = res_ad * x ! res = res + arr(i) * x
+        x_ad = res_ad * arr(i) + x_ad ! res = res + arr(i) * x
+      end do
+      res_ad = 0.0 ! res = 0.0
+      do i = n, 1, - 1
+        x_ad = arr_ad(i) * i + x_ad ! arr(i) = i * x
+      end do
+    end if
+    if (n <= 0) then
+      return_flag_156_ad = .true. ! return
+      allocate(arr_ad(n))
+      if (return_flag_156_ad) then
+        res_ad = 0.0 ! res = 0.0
+      end if
+    end if
+    if (return_flag_156_ad) then
+      if (allocated(arr_ad)) then
+        deallocate(arr_ad)
+      end if
+      if (allocated(arr)) then
+        deallocate(arr)
+      end if
+    end if
+
+    return
+  end subroutine allocate_with_early_return_rev_ad
+
 end module allocate_vars_ad

--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -158,6 +158,7 @@ class TestFortranADCode(unittest.TestCase):
                 "allocate_in_loop",
                 "save_alloc",
                 "module_vars",
+                "allocate_with_early_return",
             ],
         )
 


### PR DESCRIPTION
- Ensure routine-local allocated arrays are deallocated on early return.

- Enables reverse-mode AD to safely (re)allocate corresponding _ad arrays.

examples: add early-return allocate example

- Add allocate_with_early_return to allocate_vars.f90.

- Provide matching fwd/rev AD implementations in allocate_vars_ad.f90.

tests: exercise early return and add reverse checks

- Hook new subroutine into runtime driver and Python harness.

- Add reverse-mode inner-product tests for allocate_in_if and allocate_in_loop.