### PR TITLE
Reverse: allocate AD arrays adjacent to primal allocate in fw_block

### DIFF
--- a/examples/allocate_vars_ad.f90
+++ b/examples/allocate_vars_ad.f90
@@ -47,12 +47,12 @@ contains
     integer :: i
     real, allocatable :: arr(:)
 
+    allocate(arr_ad(n))
     allocate(arr(n))
     do i = 1, n
       arr(i) = i * x
     end do
 
-    allocate(arr_ad(n))
     do i = n, 1, - 1
       arr_ad(i) = res_ad * x ! res = res + arr(i) * x
       x_ad = res_ad * arr(i) + x_ad ! res = res + arr(i) * x
@@ -131,13 +131,13 @@ contains
     real, allocatable :: arr(:)
     real, allocatable :: arr2(:)
 
+    allocate(arr_ad(n))
+    arr_ad = 0.0
     allocate(arr(n))
     do i = 1, n
       arr(i) = i * x
     end do
 
-    allocate(arr_ad(n))
-    arr_ad = 0.0
     if (n > 0) then
       allocate(arr2(n))
       arr2(:) = arr(:)
@@ -292,13 +292,13 @@ contains
     integer :: i
     real, allocatable :: htmp_save_93_ad(:)
 
+    allocate(htmp_ad(n))
     allocate(htmp(n))
     htmp = x
     allocate(htmp_save_93_ad, mold=htmp)
     htmp_save_93_ad(1:n) = htmp(1:n)
     htmp = x**2
 
-    allocate(htmp_ad(n))
     do i = n, 1, - 1
       htmp_ad(i) = z_ad * y ! z = z + htmp(i) * y
       y_ad = z_ad * htmp(i) + y_ad ! z = z + htmp(i) * y
@@ -478,6 +478,7 @@ contains
     real, allocatable :: arr(:)
 
     return_flag_156_ad = .true.
+    allocate(arr_ad(n))
     allocate(arr(n))
     if (n <= 0) then
       return_flag_156_ad = .false.
@@ -489,7 +490,6 @@ contains
     end if
 
     if (return_flag_156_ad) then
-      allocate(arr_ad(n))
       do i = n, 1, - 1
         arr_ad(i) = res_ad * x ! res = res + arr(i) * x
         x_ad = res_ad * arr(i) + x_ad ! res = res + arr(i) * x
@@ -501,7 +501,6 @@ contains
     end if
     if (n <= 0) then
       return_flag_156_ad = .true. ! return
-      allocate(arr_ad(n))
       if (return_flag_156_ad) then
         res_ad = 0.0 ! res = 0.0
       end if

--- a/examples/mpi_example_ad.f90
+++ b/examples/mpi_example_ad.f90
@@ -204,11 +204,11 @@ contains
     integer :: pn
     integer :: pp
 
-    allocate(z_ad(3))
-    z_ad = 0.0
     call MPI_Comm_rank(comm, rank, ierr)
     call MPI_Comm_size(comm, size, ierr)
     reqs_ad(:) = MPI_REQUEST_NULL
+    allocate(z_ad(3))
+    z_ad = 0.0
     pn = rank - 1
     pp = rank + 1
     if (pn >= 0) then

--- a/examples/pointer_arrays_ad.f90
+++ b/examples/pointer_arrays_ad.f90
@@ -57,10 +57,11 @@ contains
     real, pointer :: p_ad(:)
     integer :: i
 
+    allocate(p_ad(n))
+
     if (.not. associated(mod_p_ad)) then
       allocate(mod_p_ad, mold=mod_p)
     end if
-    allocate(p_ad(n))
     do i = n, 1, - 1
       p_ad(i) = res_ad ! res = res + p(i) + mod_p(i)
       mod_p_ad(i) = res_ad ! res = res + p(i) + mod_p(i)


### PR DESCRIPTION
This PR fixes reverse-mode allocation placement for AD arrays and adds a unit test.\n\nSummary:\n- Insert AD allocations immediately before the corresponding primal `allocate` within fw_block in reverse mode.\n- Zero-initialize numeric AD arrays right after their allocation.\n- Prune redundant ClearAssignment ops in reverse block and drop empty guards.\n- Update generated example outputs impacted by the change.\n- Add unit test `test_reverse_fwblock_ad_alloc_near_primal` to verify correct placement relative to size computations.\n\nWhy:\nPreviously, reverse-mode AD arrays could be allocated at the top of fw_block, before size expressions were computed, and zeroing could occur before allocation in some branches. This change ensures sizes computed in fw_block are available and that zeroing occurs after allocation.\n\nValidation:\n- Ran `/usr/bin/python3 tests/test_generator.py -q`: 69 tests passing locally.\n\nNotes:\n- Formatting applied via `black` and `isort` before commit.\n