### PR TITLE
fix(reverse-ad): keep slice clears; add minimal test

### DIFF
--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -1637,7 +1637,11 @@ def _generate_ad_subroutine(
                             _prune_clears(c, names)
                             if isinstance(c, ClearAssignment):
                                 v = c.lhs
-                                if v is not None and v.name in names:
+                                # Only prune clears that target the whole variable.
+                                # Slice clears (e.g., var_ad(i:j, k:l) = 0) are
+                                # required in reverse mode between overwrites and
+                                # must not be removed.
+                                if v is not None and v.index is None and v.name in names:
                                     to_remove.append(c)
                         for n in to_remove:
                             node.remove_child(n)


### PR DESCRIPTION
This PR fixes reverse-mode slice clear pruning and adds a minimal unit test.

Changes:
- generator: Do not prune ClearAssignment for slices when removing redundant clears after fw_block initialization. Only prune when clearing the whole variable (no index).
- tests: Add compact minimal reproducer to ensure repeated slice overwrites keep the necessary clears; clarify expected clears are N-1 (for 3 overwrites, expect 2 clears).

Why:
- Previously, slice clears like `htmp_ad(istart:iend,...) = 0.0` could be removed by the pruning step, causing missing initialization in reverse sweeps.

Validation:
- `pytest -k test_reverse_slice_clear_minimal` passes locally.
