### PR TITLE
Improve parser/operators/code_tree; update generator, fadmod, and tests

### DIFF
--- a/tests/test_code_tree.py
+++ b/tests/test_code_tree.py
@@ -37,9 +37,14 @@ class TestOpVar(unittest.TestCase):
         self.assertFalse(var.is_array())
 
     def test_array(self):
-        var = OpVar("a", var_type=VarType("real"), dims=("n",))
+        var = OpVar(
+            "a",
+            var_type=VarType("real"),
+            dims=(OpVar("n"),),
+            dims_raw=("n",),
+        )
         self.assertTrue(var.is_array())
-        self.assertEqual(var.dims, ("n",))
+        self.assertEqual(str(var.dims[0]), "n")
 
     def test_invalid_name(self):
         with self.assertRaises(ValueError):
@@ -1219,7 +1224,7 @@ class TestLoopAnalysis(unittest.TestCase):
 class TestRemoveRedundantAllocates(unittest.TestCase):
     def _decl_alloc_real(self, name: str) -> Declaration:
         return Declaration(
-            name=name, var_type=VarType("real"), allocatable=True, dims=(":",)
+            name=name, var_type=VarType("real"), allocatable=True, dims=(None,)
         )
 
     def test_remove_alloc_dealloc_without_access(self):

--- a/tests/test_index_list.py
+++ b/tests/test_index_list.py
@@ -53,7 +53,8 @@ def v(name, *idx_dims) -> OpVar:
     var_type = VarType("real")
     var = OpVar(name, index=index, var_type=var_type)
     if index:
-        var.dims = (":",) * len(index)
+        var.dims = tuple([None] * len(index))
+        var.dims_raw = tuple([":"] * len(index))
     return var
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -253,10 +253,12 @@ class TestParser(unittest.TestCase):
         routine = module.routines[0]
         decl = routine.decls.find_by_name("x")
         self.assertIsNotNone(decl)
-        self.assertEqual(decl.dims, (":",))
+        self.assertEqual(decl.dims_raw, (":",))
+        self.assertEqual(decl.dims, (None,))
         decl = routine.decls.find_by_name("y")
         self.assertIsNotNone(decl)
-        self.assertEqual(decl.dims, ("n",))
+        self.assertEqual(decl.dims_raw, ("n",))
+        self.assertEqual(str(decl.dims[0]), "n")
 
     def test_parse_assumed_size(self):
         src = textwrap.dedent(
@@ -275,10 +277,13 @@ class TestParser(unittest.TestCase):
         routine = module.routines[0]
         decl = routine.decls.find_by_name("a")
         self.assertIsNotNone(decl)
-        self.assertEqual(decl.dims, ("*",))
+        self.assertEqual(decl.dims_raw, ("*",))
+        self.assertEqual(decl.dims, (None,))
         decl = routine.decls.find_by_name("b")
         self.assertIsNotNone(decl)
-        self.assertEqual(decl.dims, ("n", "*"))
+        self.assertEqual(decl.dims_raw, ("n", "*",))
+        self.assertEqual(str(decl.dims[0]), "n")
+        self.assertIsNone(decl.dims[1])
 
     def test_parse_public(self):
         src = textwrap.dedent(

--- a/tests/test_var_list.py
+++ b/tests/test_var_list.py
@@ -70,7 +70,8 @@ def v(name, *idx_dims) -> OpVar:
 
     # Set dims for multi-dim arrays
     if index:
-        var.dims = (":",) * len(index)
+        var.dims = tuple([None] * len(index))
+        var.dims_raw = tuple([":"] * len(index))
 
     return var
 
@@ -493,15 +494,34 @@ def make_dt_var(chain, index_dims=None):
     """
     ref = None
     for name, dims in chain:
+        dims_op = None
+        dims_raw = None
         if dims is not None:
-            dims = tuple(dims)
-        ref = OpVar(name, var_type=VarType("real"), dims=dims, ref_var=ref)
+            dims_raw = tuple(str(d) for d in dims)
+            dims_op = []
+            for d in dims:
+                if isinstance(d, str):
+                    if d in (":", "*"):
+                        dims_op.append(None)
+                    else:
+                        dims_op.append(OpVar(d))
+                else:
+                    dims_op.append(d)
+            dims_op = tuple(dims_op)
+        ref = OpVar(
+            name,
+            var_type=VarType("real"),
+            dims=dims_op,
+            dims_raw=dims_raw,
+            ref_var=ref,
+        )
     if index_dims is not None:
         ref = OpVar(
             ref.name,
             index=AryIndex(index_dims),
             var_type=ref.var_type,
             dims=ref.dims,
+            dims_raw=ref.dims_raw,
             ref_var=ref.ref_var,
         )
     return ref


### PR DESCRIPTION
This PR refines core parsing and differentiation utilities and aligns the generator with those updates.\n\nChanges:\n- Refine parsing and variable list handling.\n- Enhance operator coverage and gradient handling.\n- Tweak code tree traversal and node utilities.\n- Align generator and fadmod with parser changes.\n- Update MPI fadmod generator script.\n- Adjust tests for parser, code_tree, index_list, and var_list.\n\nTests:\n- Ran '/usr/bin/python3 tests/test_generator.py' locally; all tests passed.\n- Please review if 'a.f90' should be tracked or ignored.