### PR TITLE
tests: cover MPI isend_irecv_alloc in runtime driver tests

### DIFF
--- a/tests/test_fortran_adcode.py
+++ b/tests/test_fortran_adcode.py
@@ -193,7 +193,7 @@ class TestFortranADCode(unittest.TestCase):
     def test_mpi_example(self):
         self._run_test(
             "mpi_example",
-            ["sum_reduce", "isend_irecv"],
+            ["sum_reduce", "isend_irecv", "isend_irecv_alloc"],
             use_mpi=True,
         )
 


### PR DESCRIPTION
Summary: Adds the missing "isend_irecv_alloc" subtest to tests/test_fortran_adcode.py::test_mpi_example, ensuring parity with the run_mpi_example.f90 driver.
Motivation: The runtime driver accepts "sum_reduce", "isend_irecv", and "isend_irecv_alloc". Our Python test only ran the first two, leaving a gap in MPI coverage.
Changes:
Update tests/test_fortran_adcode.py to include "isend_irecv_alloc" in the MPI test list.