### PR TITLE
Add option to ignore FAD directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ Suppress warnings about unsupported derivatives with ``--no-warn``:
 bin/fautodiff --no-warn examples/simple_math.f90
 ```
 
+Ignore any ``!$FAD`` directives in the source:
+```bash
+bin/fautodiff --ignore-fad examples/directives.f90
+```
+
 Each module's routine signatures are also written to a `<module>.fadmod` file when AD code is generated.
 These JSON files can be loaded when differentiating another file that uses the module.
 Add search directories with ``-I`` (repeat as needed), choose the output directory with ``-M DIR`` (defaults to the current directory), and disable writing with ``--no-fadmod``:

--- a/doc/directives.md
+++ b/doc/directives.md
@@ -1,7 +1,8 @@
 # Directives
 
 Optional directives can be added in Fortran comments to adjust how the automatic differentiation code is generated.
-Each directive starts with `!$FAD` and may appear immediately before a subroutine, function or module definition.
+Each directive starts with `!$FAD` and may appear immediately before a subroutine, function or module definition. Use the
+`--ignore-fad` command line option to treat all directives as ordinary comments and disable their effects.
 
 ## CONSTANT_VARS
 

--- a/fautodiff/cli.py
+++ b/fautodiff/cli.py
@@ -46,6 +46,11 @@ def main():
         default="both",
         help="AD mode to generate",
     )
+    parser_arg.add_argument(
+        "--ignore-fad",
+        action="store_true",
+        help="ignore !$FAD directives in source files",
+    )
     args = parser_arg.parse_args()
 
     search_dirs = args.search_dirs if args.search_dirs else []
@@ -63,6 +68,7 @@ def main():
             write_fadmod=not args.no_fadmod,
             fadmod_dir=args.fadmod_dir,
             mode=args.mode,
+            ignore_fad=args.ignore_fad,
         )
     except Exception as exc:
         raise

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -2430,6 +2430,7 @@ def generate_ad(
     write_fadmod: bool = True,
     fadmod_dir: Optional[Union[str, Path]] = None,
     mode: str = "both",
+    ignore_fad: bool = False,
 ) -> Optional[str]:
     """Generate an AD version of ``src``.
 
@@ -2448,6 +2449,12 @@ def generate_ad(
     cwd = "."
     if cwd not in search_dirs:
         search_dirs.append(cwd)
+
+    if ignore_fad:
+        src = "\n".join(
+            "" if line.lstrip().startswith("!$FAD") else line
+            for line in src.splitlines()
+        )
 
     modules_org = parser.parse_src(src, search_dirs=search_dirs, src_name=src_name)
     warnings.extend(parser.macro_warnings)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,6 +97,7 @@ class TestCLIUnit(unittest.TestCase):
             write_fadmod,
             fadmod_dir,
             mode,
+            ignore_fad,
         ):
             called.update(
                 dict(
@@ -108,6 +109,7 @@ class TestCLIUnit(unittest.TestCase):
                     write_fadmod=write_fadmod,
                     fadmod_dir=fadmod_dir,
                     mode=mode,
+                    ignore_fad=ignore_fad,
                 )
             )
             return "module dummy_ad\nend module dummy_ad\n"
@@ -130,12 +132,17 @@ class TestCLIUnit(unittest.TestCase):
             buf = io.StringIO()
             with patch.object(sys, "argv", argv), redirect_stdout(buf):
                 cli.main()
+            argv.append("--ignore-fad")
+            buf = io.StringIO()
+            with patch.object(sys, "argv", argv), redirect_stdout(buf):
+                cli.main()
         # '.' should be appended to search_dirs
         self.assertEqual(called["search_dirs"], ["foo", "bar", "."])
         self.assertFalse(called["warn"])  # --no-warn
         self.assertFalse(called["write_fadmod"])  # --no-fadmod
         self.assertIsNone(called["fadmod_dir"])  # default
         self.assertEqual(called["mode"], "both")
+        self.assertTrue(called["ignore_fad"])  # --ignore-fad
 
 
 if __name__ == "__main__":

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -311,6 +311,23 @@ class TestGenerator(unittest.TestCase):
         self.assertIn("skip_me", routines)
         self.assertTrue(routines["skip_me"].get("skip"))
 
+    def test_ignore_fad_directives(self):
+        code_tree.Node.reset()
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as tmp:
+            generated = gen(
+                "examples/directives.f90",
+                warn=False,
+                fadmod_dir=tmp,
+                ignore_fad=True,
+            )
+
+        self.assertIn("skip_me_rev_ad", generated)
+        self.assertIn(
+            "subroutine add_const_fwd_ad(x, x_ad, y, y_ad, z, z_ad)", generated
+        )
+
     def test_skip_call_skips_derivatives(self):
         code_tree.Node.reset()
         import textwrap


### PR DESCRIPTION
## Summary
- add `--ignore-fad` CLI option to skip `!$FAD` directives
- preprocess source in generator when ignoring directives
- document and test ignoring `!$FAD`

## Testing
- `python -m isort . --profile black`
- `python -m black .`
- `python tests/test_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_68c821c032a4832dbe5d3638b2e6ccce