### PR TITLE
Ensure generator warnings carry source basenames with accurate metadata

### DIFF
--- a/examples/allocate_vars_ad.f90
+++ b/examples/allocate_vars_ad.f90
@@ -288,22 +288,22 @@ contains
     real, allocatable :: htmp_ad(:)
     real, allocatable :: htmp(:)
     integer :: i
-    real, allocatable :: htmp_save_93_ad(:)
+    real, allocatable :: htmp_save_92_ad(:)
 
     allocate(htmp_ad(n))
     allocate(htmp(n))
     htmp = x
-    allocate(htmp_save_93_ad, mold=htmp)
-    htmp_save_93_ad(:) = htmp(:)
+    allocate(htmp_save_92_ad, mold=htmp)
+    htmp_save_92_ad(:) = htmp(:)
     htmp = x**2
 
     do i = n, 1, - 1
       htmp_ad(i) = z_ad * y ! z = z + htmp(i) * y
       y_ad = z_ad * htmp(i) + y_ad ! z = z + htmp(i) * y
     end do
-    htmp(:) = htmp_save_93_ad(:)
-    if (allocated(htmp_save_93_ad)) then
-      deallocate(htmp_save_93_ad)
+    htmp(:) = htmp_save_92_ad(:)
+    if (allocated(htmp_save_92_ad)) then
+      deallocate(htmp_save_92_ad)
     end if
     x_ad = htmp_ad * 2.0 * x + x_ad ! htmp = x**2
     do i = n, 1, - 1
@@ -472,23 +472,23 @@ contains
     real, intent(inout) :: x_ad
     real, intent(inout) :: res_ad
     real, allocatable :: arr_ad(:)
-    logical :: return_flag_156_ad
+    logical :: return_flag_155_ad
     integer :: i
     real, allocatable :: arr(:)
 
-    return_flag_156_ad = .true.
+    return_flag_155_ad = .true.
     allocate(arr_ad(n))
     allocate(arr(n))
     if (n <= 0) then
-      return_flag_156_ad = .false.
+      return_flag_155_ad = .false.
     end if
-    if (return_flag_156_ad) then
+    if (return_flag_155_ad) then
       do i = 1, n
         arr(i) = i * x
       end do
     end if
 
-    if (return_flag_156_ad) then
+    if (return_flag_155_ad) then
       do i = n, 1, - 1
         arr_ad(i) = res_ad * x ! res = res + arr(i) * x
         x_ad = res_ad * arr(i) + x_ad ! res = res + arr(i) * x
@@ -499,10 +499,10 @@ contains
       end do
     end if
     if (n <= 0) then
-      return_flag_156_ad = .true. ! return
+      return_flag_155_ad = .true. ! return
       res_ad = 0.0 ! res = 0.0
     end if
-    if (return_flag_156_ad) then
+    if (return_flag_155_ad) then
       if (allocated(arr_ad)) then
         deallocate(arr_ad)
       end if

--- a/examples/call_example_ad.f90
+++ b/examples/call_example_ad.f90
@@ -95,10 +95,10 @@ contains
     real, intent(inout) :: x_ad
     real, intent(in)  :: y
     real, intent(in)  :: y_ad
-    real :: foo_arg1_save_45_ad
+    real :: foo_arg1_save_44_ad
 
-    foo_arg1_save_45_ad = y_ad * 2.0 ! call foo(x, y * 2.0)
-    call foo_fwd_ad(x, x_ad, y * 2.0, foo_arg1_save_45_ad) ! call foo(x, y * 2.0)
+    foo_arg1_save_44_ad = y_ad * 2.0 ! call foo(x, y * 2.0)
+    call foo_fwd_ad(x, x_ad, y * 2.0, foo_arg1_save_44_ad) ! call foo(x, y * 2.0)
 
     return
   end subroutine arg_operation_fwd_ad
@@ -106,11 +106,11 @@ contains
   subroutine arg_operation_rev_ad(x_ad, y_ad)
     real, intent(inout) :: x_ad
     real, intent(inout) :: y_ad
-    real :: foo_arg1_save_45_ad
+    real :: foo_arg1_save_44_ad
 
-    foo_arg1_save_45_ad = 0.0
-    call foo_rev_ad(x_ad, foo_arg1_save_45_ad) ! call foo(x, y * 2.0)
-    y_ad = foo_arg1_save_45_ad * 2.0 + y_ad ! call foo(x, y * 2.0)
+    foo_arg1_save_44_ad = 0.0
+    call foo_rev_ad(x_ad, foo_arg1_save_44_ad) ! call foo(x, y * 2.0)
+    y_ad = foo_arg1_save_44_ad * 2.0 + y_ad ! call foo(x, y * 2.0)
 
     return
   end subroutine arg_operation_rev_ad
@@ -120,11 +120,11 @@ contains
     real, intent(inout) :: x_ad
     real, intent(in)  :: y
     real, intent(in)  :: y_ad
-    real :: foo_arg1_save_54_ad
-    real :: foo_arg1_save_54
+    real :: foo_arg1_save_53_ad
+    real :: foo_arg1_save_53
 
-    call bar_fwd_ad(y, y_ad, foo_arg1_save_54, foo_arg1_save_54_ad) ! call foo(x, bar(y))
-    call foo_fwd_ad(x, x_ad, foo_arg1_save_54, foo_arg1_save_54_ad) ! call foo(x, bar(y))
+    call bar_fwd_ad(y, y_ad, foo_arg1_save_53, foo_arg1_save_53_ad) ! call foo(x, bar(y))
+    call foo_fwd_ad(x, x_ad, foo_arg1_save_53, foo_arg1_save_53_ad) ! call foo(x, bar(y))
 
     return
   end subroutine arg_function_fwd_ad
@@ -133,11 +133,11 @@ contains
     real, intent(inout) :: x_ad
     real, intent(in)  :: y
     real, intent(inout) :: y_ad
-    real :: foo_arg1_save_54_ad
+    real :: foo_arg1_save_53_ad
 
-    foo_arg1_save_54_ad = 0.0
-    call foo_rev_ad(x_ad, foo_arg1_save_54_ad) ! call foo(x, bar(y))
-    call bar_rev_ad(y, y_ad, foo_arg1_save_54_ad) ! call foo(x, bar(y))
+    foo_arg1_save_53_ad = 0.0
+    call foo_rev_ad(x_ad, foo_arg1_save_53_ad) ! call foo(x, bar(y))
+    call bar_rev_ad(y, y_ad, foo_arg1_save_53_ad) ! call foo(x, bar(y))
 
     return
   end subroutine arg_function_rev_ad

--- a/examples/derived_alloc_ad.f90
+++ b/examples/derived_alloc_ad.f90
@@ -115,13 +115,13 @@ contains
     integer :: n0_ad
     integer :: i
     integer :: j
-    real :: obj_arr_save_43_ad(m,n)
+    real :: obj_arr_save_42_ad(m,n)
 
     do n0_ad = ubound(obj, 1), lbound(obj, 1), - 1
       call fautodiff_stack_pop_r(obj(n0_ad)%arr(:))
     end do
     do j = 1, m
-      obj_arr_save_43_ad(j,1:n) = obj(j)%arr(1:n)
+      obj_arr_save_42_ad(j,1:n) = obj(j)%arr(1:n)
       do i = 1, n
         obj(j)%arr(i) = obj(j)%arr(i) * x + j
       end do
@@ -135,7 +135,7 @@ contains
     end do
     res_ad = 0.0 ! res = 0.0
     do j = m, 1, - 1
-      obj(j)%arr(1:n) = obj_arr_save_43_ad(j,1:n)
+      obj(j)%arr(1:n) = obj_arr_save_42_ad(j,1:n)
       do i = n, 1, - 1
         x_ad = obj_ad(j)%arr_ad(i) * obj(j)%arr(i) + x_ad ! obj(j)%arr(i) = obj(j)%arr(i) * x + j
         obj_ad(j)%arr_ad(i) = obj_ad(j)%arr_ad(i) * x ! obj(j)%arr(i) = obj(j)%arr(i) * x + j

--- a/examples/exit_cycle_ad.f90
+++ b/examples/exit_cycle_ad.f90
@@ -55,21 +55,21 @@ contains
     real, intent(inout) :: x_ad
     real, intent(inout) :: res_ad
     real :: res
-    integer :: exit_do_start_32_ad
+    integer :: exit_do_start_31_ad
     integer :: i
-    logical :: exit_flag_19_ad
-    logical :: exit_flag_29_ad
-    logical :: cycle_flag_15_ad
-    logical :: cycle_flag_24_ad
-    real :: res_save_13_ad
-    real :: res_save_17_ad
-    real :: res_save_21_ad
+    logical :: exit_flag_18_ad
+    logical :: exit_flag_28_ad
+    logical :: cycle_flag_14_ad
+    logical :: cycle_flag_23_ad
+    real :: res_save_12_ad
+    real :: res_save_16_ad
+    real :: res_save_20_ad
+    real :: res_save_24_ad
     real :: res_save_25_ad
-    real :: res_save_26_ad
-    real :: res_save_30_ad
+    real :: res_save_29_ad
 
     res = x**2
-    exit_do_start_32_ad = n
+    exit_do_start_31_ad = n
     do i = 1, n
       call fautodiff_stack_push_r(res)
       res = res * x
@@ -78,7 +78,7 @@ contains
       end if
       res = res * x
       if (i == 4) then
-        exit_do_start_32_ad = i
+        exit_do_start_31_ad = i
         exit
       end if
       res = res * x
@@ -89,7 +89,7 @@ contains
       res = res * x
       if (res > 2.0) then
         res = res * x
-        exit_do_start_32_ad = i
+        exit_do_start_31_ad = i
         exit
       end if
       res = res * x
@@ -97,95 +97,95 @@ contains
 
     x_ad = res_ad * res + x_ad ! res = res * x
     res_ad = res_ad * x ! res = res * x
-    exit_flag_19_ad = .true.
-    exit_flag_29_ad = .true.
-    label_32_0_ad: do i = exit_do_start_32_ad, 1, - 1
-      cycle_flag_15_ad = .true.
-      cycle_flag_24_ad = .true.
+    exit_flag_18_ad = .true.
+    exit_flag_28_ad = .true.
+    label_31_0_ad: do i = exit_do_start_31_ad, 1, - 1
+      cycle_flag_14_ad = .true.
+      cycle_flag_23_ad = .true.
       call fautodiff_stack_pop_r(res)
-      if (cycle_flag_15_ad .and. exit_flag_19_ad .and. cycle_flag_24_ad .and. exit_flag_29_ad) then
-        res_save_13_ad = res
+      if (cycle_flag_14_ad .and. exit_flag_18_ad .and. cycle_flag_23_ad .and. exit_flag_28_ad) then
+        res_save_12_ad = res
         res = res * x
         if (i == 2) then
-          cycle_flag_15_ad = .false.
+          cycle_flag_14_ad = .false.
         end if
       end if
-      if (cycle_flag_15_ad .and. exit_flag_19_ad .and. cycle_flag_24_ad .and. exit_flag_29_ad) then
-        res_save_17_ad = res
+      if (cycle_flag_14_ad .and. exit_flag_18_ad .and. cycle_flag_23_ad .and. exit_flag_28_ad) then
+        res_save_16_ad = res
         res = res * x
         if (i == 4) then
-          exit_flag_19_ad = .false.
+          exit_flag_18_ad = .false.
         end if
       end if
-      if (cycle_flag_15_ad .and. exit_flag_19_ad .and. cycle_flag_24_ad .and. exit_flag_29_ad) then
-        res_save_21_ad = res
+      if (cycle_flag_14_ad .and. exit_flag_18_ad .and. cycle_flag_23_ad .and. exit_flag_28_ad) then
+        res_save_20_ad = res
         res = res * x
+        res_save_24_ad = res
+        if (res > 4.0) then
+          res = res * x
+          cycle_flag_23_ad = .false.
+        end if
+      end if
+      if (cycle_flag_14_ad .and. exit_flag_18_ad .and. cycle_flag_23_ad .and. exit_flag_28_ad) then
         res_save_25_ad = res
-        if (res > 4.0) then
-          res = res * x
-          cycle_flag_24_ad = .false.
-        end if
-      end if
-      if (cycle_flag_15_ad .and. exit_flag_19_ad .and. cycle_flag_24_ad .and. exit_flag_29_ad) then
-        res_save_26_ad = res
         res = res * x
-        res_save_30_ad = res
+        res_save_29_ad = res
         if (res > 2.0) then
           res = res * x
-          exit_flag_29_ad = .false.
+          exit_flag_28_ad = .false.
         end if
       end if
-      if (cycle_flag_15_ad .and. exit_flag_19_ad .and. cycle_flag_24_ad .and. exit_flag_29_ad) then
+      if (cycle_flag_14_ad .and. exit_flag_18_ad .and. cycle_flag_23_ad .and. exit_flag_28_ad) then
         x_ad = res_ad * res + x_ad ! res = res * x
         res_ad = res_ad * x ! res = res * x
       end if
-      if (cycle_flag_15_ad .and. exit_flag_19_ad .and. cycle_flag_24_ad) then
-        res = res_save_30_ad
+      if (cycle_flag_14_ad .and. exit_flag_18_ad .and. cycle_flag_23_ad) then
+        res = res_save_29_ad
         if (res > 2.0) then
-          exit_flag_29_ad = .true. ! exit
+          exit_flag_28_ad = .true. ! exit
           x_ad = res_ad * res + x_ad ! res = res * x
           res_ad = res_ad * x ! res = res * x
         end if
       end if
-      if (cycle_flag_15_ad .and. exit_flag_19_ad .and. cycle_flag_24_ad .and. exit_flag_29_ad) then
-        res = res_save_26_ad
-        x_ad = res_ad * res + x_ad ! res = res * x
-        res_ad = res_ad * x ! res = res * x
-      end if
-      if (cycle_flag_15_ad .and. exit_flag_19_ad .and. exit_flag_29_ad) then
+      if (cycle_flag_14_ad .and. exit_flag_18_ad .and. cycle_flag_23_ad .and. exit_flag_28_ad) then
         res = res_save_25_ad
+        x_ad = res_ad * res + x_ad ! res = res * x
+        res_ad = res_ad * x ! res = res * x
+      end if
+      if (cycle_flag_14_ad .and. exit_flag_18_ad .and. exit_flag_28_ad) then
+        res = res_save_24_ad
         if (res > 4.0) then
-          cycle_flag_24_ad = .true. ! cycle
+          cycle_flag_23_ad = .true. ! cycle
           x_ad = res_ad * res + x_ad ! res = res * x
           res_ad = res_ad * x ! res = res * x
         end if
       end if
-      if (cycle_flag_15_ad .and. exit_flag_19_ad .and. cycle_flag_24_ad .and. exit_flag_29_ad) then
-        res = res_save_21_ad
+      if (cycle_flag_14_ad .and. exit_flag_18_ad .and. cycle_flag_23_ad .and. exit_flag_28_ad) then
+        res = res_save_20_ad
         x_ad = res_ad * res + x_ad ! res = res * x
         res_ad = res_ad * x ! res = res * x
       end if
-      if (cycle_flag_15_ad .and. cycle_flag_24_ad .and. exit_flag_29_ad) then
+      if (cycle_flag_14_ad .and. cycle_flag_23_ad .and. exit_flag_28_ad) then
         if (i == 4) then
-          exit_flag_19_ad = .true. ! exit
+          exit_flag_18_ad = .true. ! exit
         end if
       end if
-      if (cycle_flag_15_ad .and. exit_flag_19_ad .and. cycle_flag_24_ad .and. exit_flag_29_ad) then
-        res = res_save_17_ad
+      if (cycle_flag_14_ad .and. exit_flag_18_ad .and. cycle_flag_23_ad .and. exit_flag_28_ad) then
+        res = res_save_16_ad
         x_ad = res_ad * res + x_ad ! res = res * x
         res_ad = res_ad * x ! res = res * x
       end if
-      if (exit_flag_19_ad .and. cycle_flag_24_ad .and. exit_flag_29_ad) then
+      if (exit_flag_18_ad .and. cycle_flag_23_ad .and. exit_flag_28_ad) then
         if (i == 2) then
-          cycle_flag_15_ad = .true. ! cycle
+          cycle_flag_14_ad = .true. ! cycle
         end if
       end if
-      if (cycle_flag_15_ad .and. exit_flag_19_ad .and. cycle_flag_24_ad .and. exit_flag_29_ad) then
-        res = res_save_13_ad
+      if (cycle_flag_14_ad .and. exit_flag_18_ad .and. cycle_flag_23_ad .and. exit_flag_28_ad) then
+        res = res_save_12_ad
         x_ad = res_ad * res + x_ad ! res = res * x
         res_ad = res_ad * x ! res = res * x
       end if
-    end do label_32_0_ad
+    end do label_31_0_ad
     x_ad = res_ad * 2.0 * x + x_ad ! res = x**2
     res_ad = 0.0 ! res = x**2
 
@@ -247,18 +247,18 @@ contains
     real, intent(inout) :: res_ad
     real :: res
     integer :: i
-    logical :: exit_flag_54_ad
-    logical :: exit_flag_65_ad
-    logical :: cycle_flag_50_ad
-    logical :: cycle_flag_60_ad
-    real :: res_save_47_ad
-    integer :: i_save_51_ad
-    real :: res_save_52_ad
-    real :: res_save_56_ad
+    logical :: exit_flag_53_ad
+    logical :: exit_flag_64_ad
+    logical :: cycle_flag_49_ad
+    logical :: cycle_flag_59_ad
+    real :: res_save_46_ad
+    integer :: i_save_50_ad
+    real :: res_save_51_ad
+    real :: res_save_55_ad
+    real :: res_save_60_ad
+    integer :: i_save_60_ad
     real :: res_save_61_ad
-    integer :: i_save_61_ad
-    real :: res_save_62_ad
-    real :: res_save_66_ad
+    real :: res_save_65_ad
 
     res = x**2
     i = 1
@@ -293,102 +293,102 @@ contains
 
     x_ad = res_ad * res + x_ad ! res = res * x
     res_ad = res_ad * x ! res = res * x
-    exit_flag_54_ad = .true.
-    exit_flag_65_ad = .true.
-    label_69_0_ad: do while (fautodiff_stack_l%get())
-      cycle_flag_50_ad = .true.
-      cycle_flag_60_ad = .true.
+    exit_flag_53_ad = .true.
+    exit_flag_64_ad = .true.
+    label_68_0_ad: do while (fautodiff_stack_l%get())
+      cycle_flag_49_ad = .true.
+      cycle_flag_59_ad = .true.
       call fautodiff_stack_pop_r(res)
       call fautodiff_stack_i%pop(i)
-      if (cycle_flag_50_ad .and. exit_flag_54_ad .and. cycle_flag_60_ad .and. exit_flag_65_ad) then
-        res_save_47_ad = res
+      if (cycle_flag_49_ad .and. exit_flag_53_ad .and. cycle_flag_59_ad .and. exit_flag_64_ad) then
+        res_save_46_ad = res
         res = res * x
-        i_save_51_ad = i
+        i_save_50_ad = i
         if (i == 2) then
           i = i + 1
-          cycle_flag_50_ad = .false.
+          cycle_flag_49_ad = .false.
         end if
       end if
-      if (cycle_flag_50_ad .and. exit_flag_54_ad .and. cycle_flag_60_ad .and. exit_flag_65_ad) then
-        res_save_52_ad = res
+      if (cycle_flag_49_ad .and. exit_flag_53_ad .and. cycle_flag_59_ad .and. exit_flag_64_ad) then
+        res_save_51_ad = res
         res = res * x
         if (i == 4) then
-          exit_flag_54_ad = .false.
+          exit_flag_53_ad = .false.
         end if
       end if
-      if (cycle_flag_50_ad .and. exit_flag_54_ad .and. cycle_flag_60_ad .and. exit_flag_65_ad) then
-        res_save_56_ad = res
+      if (cycle_flag_49_ad .and. exit_flag_53_ad .and. cycle_flag_59_ad .and. exit_flag_64_ad) then
+        res_save_55_ad = res
         res = res * x
-        i_save_61_ad = i
+        i_save_60_ad = i
+        res_save_60_ad = res
+        if (res > 4.0) then
+          res = res * x
+          i = i + 1
+          cycle_flag_59_ad = .false.
+        end if
+      end if
+      if (cycle_flag_49_ad .and. exit_flag_53_ad .and. cycle_flag_59_ad .and. exit_flag_64_ad) then
         res_save_61_ad = res
-        if (res > 4.0) then
-          res = res * x
-          i = i + 1
-          cycle_flag_60_ad = .false.
-        end if
-      end if
-      if (cycle_flag_50_ad .and. exit_flag_54_ad .and. cycle_flag_60_ad .and. exit_flag_65_ad) then
-        res_save_62_ad = res
         res = res * x
-        res_save_66_ad = res
+        res_save_65_ad = res
         if (res > 2.0) then
           res = res * x
-          exit_flag_65_ad = .false.
+          exit_flag_64_ad = .false.
         end if
       end if
-      if (cycle_flag_50_ad .and. exit_flag_54_ad .and. cycle_flag_60_ad .and. exit_flag_65_ad) then
+      if (cycle_flag_49_ad .and. exit_flag_53_ad .and. cycle_flag_59_ad .and. exit_flag_64_ad) then
         x_ad = res_ad * res + x_ad ! res = res * x
         res_ad = res_ad * x ! res = res * x
       end if
-      if (cycle_flag_50_ad .and. exit_flag_54_ad .and. cycle_flag_60_ad) then
-        res = res_save_66_ad
+      if (cycle_flag_49_ad .and. exit_flag_53_ad .and. cycle_flag_59_ad) then
+        res = res_save_65_ad
         if (res > 2.0) then
-          exit_flag_65_ad = .true. ! exit
+          exit_flag_64_ad = .true. ! exit
           x_ad = res_ad * res + x_ad ! res = res * x
           res_ad = res_ad * x ! res = res * x
         end if
       end if
-      if (cycle_flag_50_ad .and. exit_flag_54_ad .and. cycle_flag_60_ad .and. exit_flag_65_ad) then
-        res = res_save_62_ad
-        x_ad = res_ad * res + x_ad ! res = res * x
-        res_ad = res_ad * x ! res = res * x
-      end if
-      if (cycle_flag_50_ad .and. exit_flag_54_ad .and. exit_flag_65_ad) then
+      if (cycle_flag_49_ad .and. exit_flag_53_ad .and. cycle_flag_59_ad .and. exit_flag_64_ad) then
         res = res_save_61_ad
+        x_ad = res_ad * res + x_ad ! res = res * x
+        res_ad = res_ad * x ! res = res * x
+      end if
+      if (cycle_flag_49_ad .and. exit_flag_53_ad .and. exit_flag_64_ad) then
+        res = res_save_60_ad
         if (res > 4.0) then
-          cycle_flag_60_ad = .true. ! cycle
+          cycle_flag_59_ad = .true. ! cycle
           x_ad = res_ad * res + x_ad ! res = res * x
           res_ad = res_ad * x ! res = res * x
         end if
-        i = i_save_61_ad
+        i = i_save_60_ad
       end if
-      if (cycle_flag_50_ad .and. exit_flag_54_ad .and. cycle_flag_60_ad .and. exit_flag_65_ad) then
-        res = res_save_56_ad
+      if (cycle_flag_49_ad .and. exit_flag_53_ad .and. cycle_flag_59_ad .and. exit_flag_64_ad) then
+        res = res_save_55_ad
         x_ad = res_ad * res + x_ad ! res = res * x
         res_ad = res_ad * x ! res = res * x
       end if
-      if (cycle_flag_50_ad .and. cycle_flag_60_ad .and. exit_flag_65_ad) then
+      if (cycle_flag_49_ad .and. cycle_flag_59_ad .and. exit_flag_64_ad) then
         if (i == 4) then
-          exit_flag_54_ad = .true. ! exit
+          exit_flag_53_ad = .true. ! exit
         end if
       end if
-      if (cycle_flag_50_ad .and. exit_flag_54_ad .and. cycle_flag_60_ad .and. exit_flag_65_ad) then
-        res = res_save_52_ad
+      if (cycle_flag_49_ad .and. exit_flag_53_ad .and. cycle_flag_59_ad .and. exit_flag_64_ad) then
+        res = res_save_51_ad
         x_ad = res_ad * res + x_ad ! res = res * x
         res_ad = res_ad * x ! res = res * x
       end if
-      if (exit_flag_54_ad .and. cycle_flag_60_ad .and. exit_flag_65_ad) then
-        i = i_save_51_ad
+      if (exit_flag_53_ad .and. cycle_flag_59_ad .and. exit_flag_64_ad) then
+        i = i_save_50_ad
         if (i == 2) then
-          cycle_flag_50_ad = .true. ! cycle
+          cycle_flag_49_ad = .true. ! cycle
         end if
       end if
-      if (cycle_flag_50_ad .and. exit_flag_54_ad .and. cycle_flag_60_ad .and. exit_flag_65_ad) then
-        res = res_save_47_ad
+      if (cycle_flag_49_ad .and. exit_flag_53_ad .and. cycle_flag_59_ad .and. exit_flag_64_ad) then
+        res = res_save_46_ad
         x_ad = res_ad * res + x_ad ! res = res * x
         res_ad = res_ad * x ! res = res * x
       end if
-    end do label_69_0_ad
+    end do label_68_0_ad
     x_ad = res_ad * 2.0 * x + x_ad ! res = x**2
     res_ad = 0.0 ! res = x**2
 
@@ -452,17 +452,17 @@ contains
     integer :: i
     integer :: k
     integer :: j
-    logical :: exit_flag_90_ad
-    logical :: exit_flag_94_ad
-    logical :: cycle_flag_106_ad
-    integer :: exit_do_start_110_ad
-    logical :: exit_flag_98_ad
-    logical :: cycle_flag_102_ad
+    logical :: exit_flag_89_ad
+    logical :: exit_flag_93_ad
+    logical :: cycle_flag_105_ad
     integer :: exit_do_start_109_ad
-    real :: res_save_109_ad
-    real :: res_save_96_ad
-    real :: res_save_100_ad
-    real :: res_save_104_ad
+    logical :: exit_flag_97_ad
+    logical :: cycle_flag_101_ad
+    integer :: exit_do_start_108_ad
+    real :: res_save_108_ad
+    real :: res_save_95_ad
+    real :: res_save_99_ad
+    real :: res_save_103_ad
 
     res = x
     i = 0
@@ -499,168 +499,168 @@ contains
       res = res * x
     end do outer
 
-    exit_flag_90_ad = .true.
-    exit_flag_94_ad = .true.
-    label_112_0_ad: do while (fautodiff_stack_l%get())
-      cycle_flag_106_ad = .true.
+    exit_flag_89_ad = .true.
+    exit_flag_93_ad = .true.
+    label_111_0_ad: do while (fautodiff_stack_l%get())
+      cycle_flag_105_ad = .true.
       call fautodiff_stack_pop_r(res)
-      if (exit_flag_90_ad .and. exit_flag_94_ad .and. cycle_flag_106_ad) then
+      if (exit_flag_89_ad .and. exit_flag_93_ad .and. cycle_flag_105_ad) then
         res = res + 1.0
-        exit_do_start_110_ad = n
-        label_110_1_ad: do j = 1, n
+        exit_do_start_109_ad = n
+        label_109_1_ad: do j = 1, n
           call fautodiff_stack_push_r(res)
           res = res + 10.0
           if (res > 5000.0) then
-            exit_do_start_110_ad = j
-            exit_flag_90_ad = .false.
-            exit label_110_1_ad
+            exit_do_start_109_ad = j
+            exit_flag_89_ad = .false.
+            exit label_109_1_ad
           end if
-          label_109_2_ad: do k = 1, n
+          label_108_2_ad: do k = 1, n
             if (res > 4000.0) then
-              exit_do_start_110_ad = j
-              exit_flag_94_ad = .false.
-              exit label_110_1_ad
+              exit_do_start_109_ad = j
+              exit_flag_93_ad = .false.
+              exit label_109_1_ad
             end if
             res = res + 100.0
             if (res > 2400.0) then
-              exit_do_start_110_ad = j
-              exit label_110_1_ad
+              exit_do_start_109_ad = j
+              exit label_109_1_ad
             end if
             res = res + 100.0
             if (res > 2200.0) then
-              cycle label_110_1_ad
+              cycle label_109_1_ad
             end if
             res = res + 100.0
             if (res > 1000.0) then
-              cycle_flag_106_ad = .false.
-              cycle label_110_1_ad
+              cycle_flag_105_ad = .false.
+              cycle label_109_1_ad
             end if
             res = res * x
-          end do label_109_2_ad
-        end do label_110_1_ad
+          end do label_108_2_ad
+        end do label_109_1_ad
       end if
-      if (exit_flag_90_ad .and. exit_flag_94_ad .and. cycle_flag_106_ad) then
+      if (exit_flag_89_ad .and. exit_flag_93_ad .and. cycle_flag_105_ad) then
         x_ad = res_ad * res + x_ad ! res = res * x
         res_ad = res_ad * x ! res = res * x
       end if
-      exit_flag_90_ad = .true.
-      exit_flag_94_ad = .true.
-      exit_flag_98_ad = .true.
-      label_110_0_ad: do j = exit_do_start_110_ad, 1, - 1
-        cycle_flag_102_ad = .true.
-        cycle_flag_106_ad = .true.
+      exit_flag_89_ad = .true.
+      exit_flag_93_ad = .true.
+      exit_flag_97_ad = .true.
+      label_109_0_ad: do j = exit_do_start_109_ad, 1, - 1
+        cycle_flag_101_ad = .true.
+        cycle_flag_105_ad = .true.
         call fautodiff_stack_pop_r(res)
-        if (exit_flag_90_ad .and. exit_flag_94_ad .and. exit_flag_98_ad .and. cycle_flag_102_ad .and. cycle_flag_106_ad) then
+        if (exit_flag_89_ad .and. exit_flag_93_ad .and. exit_flag_97_ad .and. cycle_flag_101_ad .and. cycle_flag_105_ad) then
           res = res + 10.0
           if (res > 5000.0) then
-            exit_flag_90_ad = .false.
+            exit_flag_89_ad = .false.
           end if
         end if
-        if (exit_flag_90_ad .and. exit_flag_94_ad .and. exit_flag_98_ad .and. cycle_flag_102_ad .and. cycle_flag_106_ad) then
-          res_save_109_ad = res
-          exit_do_start_109_ad = n
-          label_109_1_ad: do k = 1, n
+        if (exit_flag_89_ad .and. exit_flag_93_ad .and. exit_flag_97_ad .and. cycle_flag_101_ad .and. cycle_flag_105_ad) then
+          res_save_108_ad = res
+          exit_do_start_108_ad = n
+          label_108_1_ad: do k = 1, n
             call fautodiff_stack_push_r(res)
             if (res > 4000.0) then
-              exit_do_start_109_ad = k
-              exit_flag_94_ad = .false.
-              exit label_109_1_ad
+              exit_do_start_108_ad = k
+              exit_flag_93_ad = .false.
+              exit label_108_1_ad
             end if
             res = res + 100.0
             if (res > 2400.0) then
-              exit_do_start_109_ad = k
-              exit_flag_98_ad = .false.
-              exit label_109_1_ad
+              exit_do_start_108_ad = k
+              exit_flag_97_ad = .false.
+              exit label_108_1_ad
             end if
             res = res + 100.0
             if (res > 2200.0) then
-              cycle_flag_102_ad = .false.
-              cycle label_109_1_ad
+              cycle_flag_101_ad = .false.
+              cycle label_108_1_ad
             end if
             res = res + 100.0
             if (res > 1000.0) then
-              cycle_flag_106_ad = .false.
-              cycle label_109_1_ad
+              cycle_flag_105_ad = .false.
+              cycle label_108_1_ad
             end if
             res = res * x
-          end do label_109_1_ad
+          end do label_108_1_ad
         end if
-        if (exit_flag_90_ad) then
-          exit_flag_94_ad = .true.
-          exit_flag_98_ad = .true.
-          label_109_0_ad: do k = exit_do_start_109_ad, 1, - 1
-            cycle_flag_102_ad = .true.
-            cycle_flag_106_ad = .true.
+        if (exit_flag_89_ad) then
+          exit_flag_93_ad = .true.
+          exit_flag_97_ad = .true.
+          label_108_0_ad: do k = exit_do_start_108_ad, 1, - 1
+            cycle_flag_101_ad = .true.
+            cycle_flag_105_ad = .true.
             call fautodiff_stack_pop_r(res)
-            if (exit_flag_94_ad .and. exit_flag_98_ad .and. cycle_flag_102_ad .and. cycle_flag_106_ad) then
+            if (exit_flag_93_ad .and. exit_flag_97_ad .and. cycle_flag_101_ad .and. cycle_flag_105_ad) then
               if (res > 4000.0) then
-                exit_flag_94_ad = .false.
+                exit_flag_93_ad = .false.
               end if
             end if
-            if (exit_flag_94_ad .and. exit_flag_98_ad .and. cycle_flag_102_ad .and. cycle_flag_106_ad) then
-              res_save_96_ad = res
+            if (exit_flag_93_ad .and. exit_flag_97_ad .and. cycle_flag_101_ad .and. cycle_flag_105_ad) then
+              res_save_95_ad = res
               res = res + 100.0
               if (res > 2400.0) then
-                exit_flag_98_ad = .false.
+                exit_flag_97_ad = .false.
               end if
             end if
-            if (exit_flag_94_ad .and. exit_flag_98_ad .and. cycle_flag_102_ad .and. cycle_flag_106_ad) then
-              res_save_100_ad = res
+            if (exit_flag_93_ad .and. exit_flag_97_ad .and. cycle_flag_101_ad .and. cycle_flag_105_ad) then
+              res_save_99_ad = res
               res = res + 100.0
               if (res > 2200.0) then
-                cycle_flag_102_ad = .false.
+                cycle_flag_101_ad = .false.
               end if
             end if
-            if (exit_flag_94_ad .and. exit_flag_98_ad .and. cycle_flag_102_ad .and. cycle_flag_106_ad) then
-              res_save_104_ad = res
+            if (exit_flag_93_ad .and. exit_flag_97_ad .and. cycle_flag_101_ad .and. cycle_flag_105_ad) then
+              res_save_103_ad = res
               res = res + 100.0
               if (res > 1000.0) then
-                cycle_flag_106_ad = .false.
+                cycle_flag_105_ad = .false.
               end if
             end if
-            if (exit_flag_94_ad .and. exit_flag_98_ad .and. cycle_flag_102_ad .and. cycle_flag_106_ad) then
+            if (exit_flag_93_ad .and. exit_flag_97_ad .and. cycle_flag_101_ad .and. cycle_flag_105_ad) then
               x_ad = res_ad * res + x_ad ! res = res * x
               res_ad = res_ad * x ! res = res * x
             end if
-            if (exit_flag_94_ad .and. exit_flag_98_ad .and. cycle_flag_102_ad) then
+            if (exit_flag_93_ad .and. exit_flag_97_ad .and. cycle_flag_101_ad) then
               if (res > 1000.0) then
-                cycle_flag_106_ad = .true. ! cycle outer
+                cycle_flag_105_ad = .true. ! cycle outer
               end if
             end if
-            if (exit_flag_94_ad .and. exit_flag_98_ad .and. cycle_flag_102_ad .and. cycle_flag_106_ad) then
-              res = res_save_104_ad
+            if (exit_flag_93_ad .and. exit_flag_97_ad .and. cycle_flag_101_ad .and. cycle_flag_105_ad) then
+              res = res_save_103_ad
             end if
-            if (exit_flag_94_ad .and. exit_flag_98_ad .and. cycle_flag_106_ad) then
+            if (exit_flag_93_ad .and. exit_flag_97_ad .and. cycle_flag_105_ad) then
               if (res > 2200.0) then
-                cycle_flag_102_ad = .true. ! cycle middle
+                cycle_flag_101_ad = .true. ! cycle middle
               end if
             end if
-            if (exit_flag_94_ad .and. exit_flag_98_ad .and. cycle_flag_102_ad .and. cycle_flag_106_ad) then
-              res = res_save_100_ad
+            if (exit_flag_93_ad .and. exit_flag_97_ad .and. cycle_flag_101_ad .and. cycle_flag_105_ad) then
+              res = res_save_99_ad
             end if
-            if (exit_flag_94_ad .and. cycle_flag_102_ad .and. cycle_flag_106_ad) then
+            if (exit_flag_93_ad .and. cycle_flag_101_ad .and. cycle_flag_105_ad) then
               if (res > 2400.0) then
-                exit_flag_98_ad = .true. ! exit middle
+                exit_flag_97_ad = .true. ! exit middle
               end if
             end if
-            if (exit_flag_94_ad .and. exit_flag_98_ad .and. cycle_flag_102_ad .and. cycle_flag_106_ad) then
-              res = res_save_96_ad
+            if (exit_flag_93_ad .and. exit_flag_97_ad .and. cycle_flag_101_ad .and. cycle_flag_105_ad) then
+              res = res_save_95_ad
             end if
-            if (exit_flag_98_ad .and. cycle_flag_102_ad .and. cycle_flag_106_ad) then
+            if (exit_flag_97_ad .and. cycle_flag_101_ad .and. cycle_flag_105_ad) then
               if (res > 4000.0) then
-                exit_flag_94_ad = .true. ! exit outer
+                exit_flag_93_ad = .true. ! exit outer
               end if
             end if
-          end do label_109_0_ad
-          res = res_save_109_ad
+          end do label_108_0_ad
+          res = res_save_108_ad
         end if
-        if (exit_flag_94_ad .and. exit_flag_98_ad .and. cycle_flag_102_ad .and. cycle_flag_106_ad) then
+        if (exit_flag_93_ad .and. exit_flag_97_ad .and. cycle_flag_101_ad .and. cycle_flag_105_ad) then
           if (res > 5000.0) then
-            exit_flag_90_ad = .true. ! exit outer
+            exit_flag_89_ad = .true. ! exit outer
           end if
         end if
-      end do label_110_0_ad
-    end do label_112_0_ad
+      end do label_109_0_ad
+    end do label_111_0_ad
     x_ad = res_ad + x_ad ! res = x
     res_ad = 0.0 ! res = x
 

--- a/examples/macro_multistmt_ad.F90
+++ b/examples/macro_multistmt_ad.F90
@@ -11,9 +11,9 @@ module macro_multistmt_ad
 contains
 
   subroutine foo_fwd_ad(x, y, y_ad)
-    real :: x
-    real :: y
-    real :: y_ad
+    real, intent(inout) :: x
+    real, intent(inout) :: y
+    real, intent(inout) :: y_ad
 
 #ifdef INC
     x = x + 1

--- a/examples/module_vars_ad.f90
+++ b/examples/module_vars_ad.f90
@@ -28,16 +28,16 @@ contains
     real, intent(inout) :: x_ad
     real, intent(inout) :: y_ad
     real :: y
-    real :: a_save_13_ad
+    real :: a_save_12_ad
 
     call fautodiff_stack_pop_r(a)
     y = (c + x) * a
-    a_save_13_ad = a
+    a_save_12_ad = a
     a = a + x
 
     a_ad = y_ad * y + a_ad ! y = y * a
     y_ad = y_ad * a ! y = y * a
-    a = a_save_13_ad
+    a = a_save_12_ad
     x_ad = a_ad + x_ad ! a = a + x
     x_ad = y_ad * a + x_ad ! y = (c + x) * a
     a_ad = y_ad * (c + x) + a_ad ! y = (c + x) * a

--- a/examples/mpi_example_ad.f90
+++ b/examples/mpi_example_ad.f90
@@ -104,7 +104,7 @@ contains
     integer :: size
     integer :: pn
     integer :: pp
-    integer :: reqs_ad_save_389_ad(2)
+    integer :: reqs_ad_save_387_ad(2)
 
     call MPI_Comm_rank(comm, rank, ierr)
     call MPI_Comm_size(comm, size, ierr)
@@ -117,7 +117,7 @@ contains
     if (pp < size) then
       call MPI_Isend_fwd_rev_ad(x_ad(2), 1, MPI_REAL, pp, tag, comm, reqs_ad(2), ierr)
     end if
-    reqs_ad_save_389_ad(:) = reqs_ad(:)
+    reqs_ad_save_387_ad(:) = reqs_ad(:)
     reqs_ad(:) = MPI_REQUEST_NULL
     if (pp < size) then
       call MPI_Irecv_fwd_rev_ad(x_ad(3), 1, MPI_REAL, pp, tag + 1, comm, reqs_ad(1), ierr)
@@ -139,7 +139,7 @@ contains
     if (pp < size) then
       call MPI_Irecv_rev_ad(x_ad(3), 1, MPI_REAL, pp, tag + 1, comm, reqs_ad(1), ierr) ! call MPI_Irecv(x(3), 1, MPI_REAL, pp, tag+1, comm, reqs(1), ierr)
     end if
-    reqs_ad(:) = reqs_ad_save_389_ad(:)
+    reqs_ad(:) = reqs_ad_save_387_ad(:)
     call MPI_Waitall_rev_ad(2, reqs_ad, ierr) ! call MPI_Waitall(2, reqs, MPI_STATUSES_IGNORE, ierr)
     x_ad(2) = y_ad + x_ad(2) ! y = x(2)
     y_ad = 0.0 ! y = x(2)

--- a/examples/omp_loops_ad.f90
+++ b/examples/omp_loops_ad.f90
@@ -121,12 +121,12 @@ contains
     real, intent(inout), allocatable :: x(:)
     real, intent(inout), allocatable :: x_ad(:)
     real, intent(inout) :: y_ad(size(x))
-    real, allocatable :: x_save_54_ad(:)
+    real, allocatable :: x_save_53_ad(:)
 
-    allocate(x_save_54_ad, mold=x)
+    allocate(x_save_53_ad, mold=x)
     !$omp parallel
     !$omp workshare
-    x_save_54_ad(:) = x(:)
+    x_save_53_ad(:) = x(:)
     !$omp end workshare
     !$omp end parallel
 
@@ -134,12 +134,12 @@ contains
     !$omp workshare
     x_ad = y_ad + x_ad ! y = x
     y_ad = 0.0 ! y = x
-    x(:) = x_save_54_ad(:)
+    x(:) = x_save_53_ad(:)
     x_ad = x_ad * 2.0 * x ! x = x**2
     !$omp end workshare
     !$omp end parallel
-    if (allocated(x_save_54_ad)) then
-      deallocate(x_save_54_ad)
+    if (allocated(x_save_53_ad)) then
+      deallocate(x_save_53_ad)
     end if
 
     return

--- a/examples/return_example_ad.f90
+++ b/examples/return_example_ad.f90
@@ -25,14 +25,14 @@ contains
     real, intent(in)  :: x
     real, intent(inout) :: x_ad
     real, intent(inout) :: y_ad
-    logical :: return_flag_11_ad
+    logical :: return_flag_10_ad
 
-    return_flag_11_ad = .true.
+    return_flag_10_ad = .true.
     if (x < 0.0) then
-      return_flag_11_ad = .false.
+      return_flag_10_ad = .false.
     end if
 
-    if (return_flag_11_ad) then
+    if (return_flag_10_ad) then
       x_ad = y_ad * (x + x) + x_ad ! y = x * x
       y_ad = 0.0 ! y = x * x
     end if
@@ -67,15 +67,15 @@ contains
     real, intent(inout) :: x_ad(n)
     real, intent(inout) :: y_ad(n)
     logical, intent(in)  :: f
-    logical :: return_flag_28_ad
+    logical :: return_flag_27_ad
 
-    return_flag_28_ad = .true.
+    return_flag_27_ad = .true.
     if (f) then
-      return_flag_28_ad = .false.
+      return_flag_27_ad = .false.
     end if
 
     if (f) then
-      return_flag_28_ad = .true. ! return
+      return_flag_27_ad = .true. ! return
       x_ad = y_ad * 2.0 * x + x_ad ! y = x ** 2
       y_ad = 0.0 ! y = x ** 2
     end if

--- a/examples/save_vars_ad.f90
+++ b/examples/save_vars_ad.f90
@@ -37,22 +37,22 @@ contains
     real, intent(inout) :: z_ad
     real :: work_ad
     real :: work
-    real :: work_save_13_ad
-    real :: work_save_15_ad
+    real :: work_save_12_ad
+    real :: work_save_14_ad
 
     work = x + 1.0
-    work_save_13_ad = work
+    work_save_12_ad = work
     work = work**2
-    work_save_15_ad = work
+    work_save_14_ad = work
     work = x**2
 
     work_ad = z_ad * x ! z = work * x + z
     x_ad = z_ad * work + x_ad ! z = work * x + z
-    work = work_save_15_ad
+    work = work_save_14_ad
     x_ad = work_ad * 2.0 * x + x_ad ! work = x**2
     work_ad = z_ad * x ! z = work * x + z
     x_ad = z_ad * work + x_ad ! z = work * x + z
-    work = work_save_13_ad
+    work = work_save_12_ad
     work_ad = work_ad * 2.0 * work ! work = work**2
     work_ad = z_ad + work_ad ! z = work + y
     y_ad = z_ad + y_ad ! z = work + y
@@ -108,33 +108,33 @@ contains
     real, intent(inout) :: z_ad
     real :: work_ad
     real :: work
+    real :: work_save_37_ad
+    real :: work_save_29_ad
     real :: work_save_38_ad
-    real :: work_save_30_ad
-    real :: work_save_39_ad
 
     work = x + 1.0
-    work_save_38_ad = work
+    work_save_37_ad = work
     if (work > 0.0) then
       work = work**2
     else if (work < 0.0) then
       work = x
       work = work * x
     end if
-    work_save_39_ad = work
+    work_save_38_ad = work
     work = work * x
 
     work_ad = z_ad * x ! z = work * x + z
     x_ad = z_ad * work + x_ad ! z = work * x + z
-    work = work_save_39_ad
+    work = work_save_38_ad
     x_ad = work_ad * work + x_ad ! work = work * x
     work_ad = work_ad * x ! work = work * x
-    work = work_save_38_ad
+    work = work_save_37_ad
     if (work > 0.0) then
-      work_save_30_ad = work
+      work_save_29_ad = work
       work = work**2
       work_ad = z_ad * x + work_ad ! z = work * x + z
       x_ad = z_ad * work + x_ad ! z = work * x + z
-      work = work_save_30_ad
+      work = work_save_29_ad
       work_ad = work_ad * 2.0 * work ! work = work**2
     else if (work < 0.0) then
       work = x
@@ -150,7 +150,7 @@ contains
       x_ad = z_ad * work + x_ad ! z = work * x
       z_ad = 0.0 ! z = work * x
     end if
-    work = work_save_38_ad
+    work = work_save_37_ad
     work_ad = z_ad * y + work_ad ! z = work * y
     y_ad = z_ad * work + y_ad ! z = work * y
     z_ad = 0.0 ! z = work * y
@@ -214,36 +214,36 @@ contains
     integer :: j
     real :: z(n,m)
     real :: scalar
-    real :: ary_save_60_ad
-    real :: z_save_62_ad
-    real :: scalar_save_64_ad
+    real :: ary_save_59_ad
+    real :: z_save_61_ad
+    real :: scalar_save_63_ad
 
     ary(:,:) = x(:,:)
 
     do j = m, 1, - 1
       do i = n, 1, - 1
         z(i,j) = ary(i,j) * y(i,j)
-        ary_save_60_ad = ary(i,j)
+        ary_save_59_ad = ary(i,j)
         ary(i,j) = x(i,j) * ary(i,j) + z(i,j)
         scalar = ary(i,j) * z(i,j)
-        z_save_62_ad = z(i,j)
+        z_save_61_ad = z(i,j)
         z(i,j) = x(i,j) + scalar
         z(i,j) = y(i,j) * scalar + z(i,j)
-        scalar_save_64_ad = scalar
+        scalar_save_63_ad = scalar
         scalar = z(i,j) * y(i,j)
         scalar_ad = z_ad(i,j) * z(i,j) ! z(i,j) = z(i,j) * scalar
         z_ad(i,j) = z_ad(i,j) * scalar ! z(i,j) = z(i,j) * scalar
-        scalar = scalar_save_64_ad
+        scalar = scalar_save_63_ad
         z_ad(i,j) = scalar_ad * y(i,j) + z_ad(i,j) ! scalar = z(i,j) * y(i,j)
         y_ad(i,j) = scalar_ad * z(i,j) + y_ad(i,j) ! scalar = z(i,j) * y(i,j)
         y_ad(i,j) = z_ad(i,j) * scalar + y_ad(i,j) ! z(i,j) = y(i,j) * scalar + z(i,j)
         scalar_ad = z_ad(i,j) * y(i,j) ! z(i,j) = y(i,j) * scalar + z(i,j)
-        z(i,j) = z_save_62_ad
+        z(i,j) = z_save_61_ad
         x_ad(i,j) = z_ad(i,j) + x_ad(i,j) ! z(i,j) = x(i,j) + scalar
         scalar_ad = z_ad(i,j) + scalar_ad ! z(i,j) = x(i,j) + scalar
         ary_ad(i,j) = scalar_ad * z(i,j) ! scalar = ary(i,j) * z(i,j)
         z_ad(i,j) = scalar_ad * ary(i,j) ! scalar = ary(i,j) * z(i,j)
-        ary(i,j) = ary_save_60_ad
+        ary(i,j) = ary_save_59_ad
         x_ad(i,j) = ary_ad(i,j) * ary(i,j) + x_ad(i,j) ! ary(i,j) = x(i,j) * ary(i,j) + z(i,j)
         z_ad(i,j) = ary_ad(i,j) + z_ad(i,j) ! ary(i,j) = x(i,j) * ary(i,j) + z(i,j)
         ary_ad(i,j) = ary_ad(i,j) * x(i,j) ! ary(i,j) = x(i,j) * ary(i,j) + z(i,j)
@@ -312,7 +312,7 @@ contains
     integer :: j
     real :: ary(n,m)
     real :: z(n,m)
-    real :: ary_save_87_ad(n,m)
+    real :: ary_save_86_ad(n,m)
 
     do j = 1, m
       do i = 1, n
@@ -320,7 +320,7 @@ contains
       end do
     end do
     do j = 1, m
-      ary_save_87_ad(:,j) = ary(:,j)
+      ary_save_86_ad(:,j) = ary(:,j)
       do i = 1, n
         z(i,j) = ary(i,j) * x(i,j)
         ary(i,j) = ary(i,j) + z(i,j) * y(i,j)
@@ -338,7 +338,7 @@ contains
       end do
     end do
     do j = m, 1, - 1
-      ary(:,j) = ary_save_87_ad(:,j)
+      ary(:,j) = ary_save_86_ad(:,j)
       do i = n, 1, - 1
         z(i,j) = ary(i,j) * x(i,j)
         z_ad(i,j) = ary_ad(i,j) * y(i,j) + z_ad(i,j) ! ary(i,j) = ary(i,j) + z(i,j) * y(i,j)
@@ -430,7 +430,7 @@ contains
     real :: work1(2,n,m)
     real :: z(n,m)
     integer :: k
-    real :: work1_save_132_ad(2)
+    real :: work1_save_131_ad(2)
 
     do j = 1, m
       do i = 1, n
@@ -449,7 +449,7 @@ contains
       do i = n, 1, - 1
         z(i,j) = work1(1,i,j) * y(i,j) + work1(2,i,j) * x(i,j)
         do k = 1, 2
-          work1_save_132_ad(k) = work1(k,i,j)
+          work1_save_131_ad(k) = work1(k,i,j)
           work3(k) = work1(k,i,j)
           work1(k,i,j) = x(i,j) * work3(k)
         end do
@@ -461,7 +461,7 @@ contains
         x_ad(i,j) = z_ad(i,j) * work1(2,i,j) + x_ad(i,j) ! z(i,j) = z(i,j) * (work3(1) + work3(2)) + work1(1,i,j) * y(i,j) + work1(2,i,j) * x(i,j)
         z_ad(i,j) = z_ad(i,j) * (work3(1) + work3(2)) ! z(i,j) = z(i,j) * (work3(1) + work3(2)) + work1(1,i,j) * y(i,j) + work1(2,i,j) * x(i,j)
         do k = 2, 1, - 1
-          work1(k,i,j) = work1_save_132_ad(k)
+          work1(k,i,j) = work1_save_131_ad(k)
           work3(k) = work1(k,i,j)
           x_ad(i,j) = work1_ad(k,i,j) * work3(k) + x_ad(i,j) ! work1(k,i,j) = x(i,j) * work3(k)
           work3_ad(k) = work1_ad(k,i,j) * x(i,j) + work3_ad(k) ! work1(k,i,j) = x(i,j) * work3(k)
@@ -529,25 +529,25 @@ contains
     real, intent(inout) :: x(n)
     real, intent(inout) :: x_ad(n)
     integer :: i
-    real :: x_save_148_ad
-    real :: x_save_149_ad(n)
+    real :: x_save_147_ad
+    real :: x_save_148_ad(n)
 
-    x_save_148_ad = x(1)
+    x_save_147_ad = x(1)
     x(1) = x(1) * x(2) * 0.5
     do i = 2, n - 1
-      x_save_149_ad(i) = x(i)
+      x_save_148_ad(i) = x(i)
       x(i) = x(i) * (x(i + 1) - x(i - 1)) * 0.5
     end do
 
     x_ad(n - 1) = - x_ad(n) * x(n) * 0.5 + x_ad(n - 1) ! x(n) = - x(n) * x(n-1) * 0.5
     x_ad(n) = - x_ad(n) * x(n - 1) * 0.5 ! x(n) = - x(n) * x(n-1) * 0.5
     do i = n - 1, 2, - 1
-      x(i) = x_save_149_ad(i)
+      x(i) = x_save_148_ad(i)
       x_ad(i + 1) = x_ad(i) * x(i) * 0.5 + x_ad(i + 1) ! x(i) = x(i) * (x(i+1) - x(i-1)) * 0.5
       x_ad(i - 1) = - x_ad(i) * x(i) * 0.5 + x_ad(i - 1) ! x(i) = x(i) * (x(i+1) - x(i-1)) * 0.5
       x_ad(i) = x_ad(i) * (x(i + 1) - x(i - 1)) * 0.5 ! x(i) = x(i) * (x(i+1) - x(i-1)) * 0.5
     end do
-    x(1) = x_save_148_ad
+    x(1) = x_save_147_ad
     x_ad(2) = x_ad(1) * x(1) * 0.5 + x_ad(2) ! x(1) = x(1) * x(2) * 0.5
     x_ad(1) = x_ad(1) * x(2) * 0.5 ! x(1) = x(1) * x(2) * 0.5
 

--- a/examples/self_reference_ad.f90
+++ b/examples/self_reference_ad.f90
@@ -23,13 +23,13 @@ contains
     integer, intent(in)  :: n
     integer, intent(in)  :: m
     integer, intent(in)  :: i
-    integer :: n1_12_ad
-    real :: tmp_save_12_ad
+    integer :: n1_11_ad
+    real :: tmp_save_11_ad
 
-    do n1_12_ad = n, m
-      tmp_save_12_ad = u_ad(n1_12_ad) ! u(n:m) = u(i:j)
-      u_ad(n1_12_ad) = 0.0 ! u(n:m) = u(i:j)
-      u_ad(i + n1_12_ad - n) = tmp_save_12_ad + u_ad(i + n1_12_ad - n) ! u(n:m) = u(i:j)
+    do n1_11_ad = n, m
+      tmp_save_11_ad = u_ad(n1_11_ad) ! u(n:m) = u(i:j)
+      u_ad(n1_11_ad) = 0.0 ! u(n:m) = u(i:j)
+      u_ad(i + n1_11_ad - n) = tmp_save_11_ad + u_ad(i + n1_11_ad - n) ! u(n:m) = u(i:j)
     end do
 
     return
@@ -76,23 +76,23 @@ contains
     real, pointer :: p_ad(:)
     real, pointer :: q_ad(:)
     integer :: k
-    real :: tmp_save_31_ad
-    integer :: n1_33_ad
-    real :: tmp_save_33_ad
+    real :: tmp_save_30_ad
+    integer :: n1_32_ad
+    real :: tmp_save_32_ad
 
     q_ad => v_ad
     p_ad => u_ad
     q_ad(i:j) = u_ad(n:m) + q_ad(i:j) ! u(n:m) = u(n:m) + q(i:j)
-    do n1_33_ad = n, m
-      tmp_save_33_ad = v_ad(n1_33_ad) ! v(n:m) = p(i:j) + q(i:j)
-      v_ad(n1_33_ad) = 0.0 ! v(n:m) = p(i:j) + q(i:j)
-      p_ad(i + n1_33_ad - n) = tmp_save_33_ad + p_ad(i + n1_33_ad - n) ! v(n:m) = p(i:j) + q(i:j)
-      q_ad(i + n1_33_ad - n) = tmp_save_33_ad + q_ad(i + n1_33_ad - n) ! v(n:m) = p(i:j) + q(i:j)
+    do n1_32_ad = n, m
+      tmp_save_32_ad = v_ad(n1_32_ad) ! v(n:m) = p(i:j) + q(i:j)
+      v_ad(n1_32_ad) = 0.0 ! v(n:m) = p(i:j) + q(i:j)
+      p_ad(i + n1_32_ad - n) = tmp_save_32_ad + p_ad(i + n1_32_ad - n) ! v(n:m) = p(i:j) + q(i:j)
+      q_ad(i + n1_32_ad - n) = tmp_save_32_ad + q_ad(i + n1_32_ad - n) ! v(n:m) = p(i:j) + q(i:j)
     end do
     do k = m, n, - 1
-      tmp_save_31_ad = u_ad(k) ! u(k) = p(i+k-n)
+      tmp_save_30_ad = u_ad(k) ! u(k) = p(i+k-n)
       u_ad(k) = 0.0 ! u(k) = p(i+k-n)
-      p_ad(i + k - n) = tmp_save_31_ad + p_ad(i + k - n) ! u(k) = p(i+k-n)
+      p_ad(i + k - n) = tmp_save_30_ad + p_ad(i + k - n) ! u(k) = p(i+k-n)
     end do
 
     return
@@ -141,25 +141,25 @@ contains
     integer, intent(in)  :: l2
     integer :: k1
     integer :: k2
-    integer :: n2_52_ad
-    integer :: n1_52_ad
-    real :: tmp_save_52_ad
-    real :: tmp_save_55_ad
+    integer :: n2_51_ad
+    integer :: n1_51_ad
+    real :: tmp_save_51_ad
+    real :: tmp_save_54_ad
 
     do k2 = l2, 1, - 1
       do k1 = l1, 1, - 1
-        tmp_save_55_ad = w_ad(n + k1 - 1,m + k2 - 1) ! w(n+k1-1,m+k2-1) = w(i+k1-1,j+k2-1) * v(i+k1-1,j+k2-1)
+        tmp_save_54_ad = w_ad(n + k1 - 1,m + k2 - 1) ! w(n+k1-1,m+k2-1) = w(i+k1-1,j+k2-1) * v(i+k1-1,j+k2-1)
         w_ad(n + k1 - 1,m + k2 - 1) = 0.0 ! w(n+k1-1,m+k2-1) = w(i+k1-1,j+k2-1) * v(i+k1-1,j+k2-1)
-        w_ad(i + k1 - 1,j + k2 - 1) = tmp_save_55_ad * v(i + k1 - 1,j + k2 - 1) + w_ad(i + k1 - 1,j + k2 - 1) ! w(n+k1-1,m+k2-1) = w(i+k1-1,j+k2-1) * v(i+k1-1,j+k2-1)
-        v_ad(i + k1 - 1,j + k2 - 1) = tmp_save_55_ad * w(i + k1 - 1,j + k2 - 1) + v_ad(i + k1 - 1,j + k2 - 1) ! w(n+k1-1,m+k2-1) = w(i+k1-1,j+k2-1) * v(i+k1-1,j+k2-1)
+        w_ad(i + k1 - 1,j + k2 - 1) = tmp_save_54_ad * v(i + k1 - 1,j + k2 - 1) + w_ad(i + k1 - 1,j + k2 - 1) ! w(n+k1-1,m+k2-1) = w(i+k1-1,j+k2-1) * v(i+k1-1,j+k2-1)
+        v_ad(i + k1 - 1,j + k2 - 1) = tmp_save_54_ad * w(i + k1 - 1,j + k2 - 1) + v_ad(i + k1 - 1,j + k2 - 1) ! w(n+k1-1,m+k2-1) = w(i+k1-1,j+k2-1) * v(i+k1-1,j+k2-1)
       end do
     end do
-    do n2_52_ad = m, m + l2 - 1
-      do n1_52_ad = n, n + l1 - 1
-        tmp_save_52_ad = u_ad(n1_52_ad,n2_52_ad) ! u(n:n+l1-1,m:m+l2-1) = v(i:i+l1-1,j:j+l2-1) * u(i:i+l1-1,j:j+l2-1)
-        u_ad(n1_52_ad,n2_52_ad) = 0.0 ! u(n:n+l1-1,m:m+l2-1) = v(i:i+l1-1,j:j+l2-1) * u(i:i+l1-1,j:j+l2-1)
-        v_ad(i + n1_52_ad - n,j + n2_52_ad - m) = tmp_save_52_ad * u(i + n1_52_ad - n,j + n2_52_ad - m) + v_ad(i + n1_52_ad - n,j + n2_52_ad - m) ! u(n:n+l1-1,m:m+l2-1) = v(i:i+l1-1,j:j+l2-1) * u(i:i+l1-1,j:j+l2-1)
-        u_ad(i + n1_52_ad - n,j + n2_52_ad - m) = tmp_save_52_ad * v(i + n1_52_ad - n,j + n2_52_ad - m) + u_ad(i + n1_52_ad - n,j + n2_52_ad - m) ! u(n:n+l1-1,m:m+l2-1) = v(i:i+l1-1,j:j+l2-1) * u(i:i+l1-1,j:j+l2-1)
+    do n2_51_ad = m, m + l2 - 1
+      do n1_51_ad = n, n + l1 - 1
+        tmp_save_51_ad = u_ad(n1_51_ad,n2_51_ad) ! u(n:n+l1-1,m:m+l2-1) = v(i:i+l1-1,j:j+l2-1) * u(i:i+l1-1,j:j+l2-1)
+        u_ad(n1_51_ad,n2_51_ad) = 0.0 ! u(n:n+l1-1,m:m+l2-1) = v(i:i+l1-1,j:j+l2-1) * u(i:i+l1-1,j:j+l2-1)
+        v_ad(i + n1_51_ad - n,j + n2_51_ad - m) = tmp_save_51_ad * u(i + n1_51_ad - n,j + n2_51_ad - m) + v_ad(i + n1_51_ad - n,j + n2_51_ad - m) ! u(n:n+l1-1,m:m+l2-1) = v(i:i+l1-1,j:j+l2-1) * u(i:i+l1-1,j:j+l2-1)
+        u_ad(i + n1_51_ad - n,j + n2_51_ad - m) = tmp_save_51_ad * v(i + n1_51_ad - n,j + n2_51_ad - m) + u_ad(i + n1_51_ad - n,j + n2_51_ad - m) ! u(n:n+l1-1,m:m+l2-1) = v(i:i+l1-1,j:j+l2-1) * u(i:i+l1-1,j:j+l2-1)
       end do
     end do
 

--- a/examples/store_vars_ad.f90
+++ b/examples/store_vars_ad.f90
@@ -38,14 +38,14 @@ contains
     real :: work_ad
     real :: work
     integer :: i
-    real :: work_save_13_ad
-    real :: work_save_18_ad
-    real :: work_save_16_ad
+    real :: work_save_12_ad
+    real :: work_save_17_ad
+    real :: work_save_15_ad
 
     work = 1.0
-    work_save_13_ad = work
+    work_save_12_ad = work
     work = x(1) * work
-    work_save_18_ad = work
+    work_save_17_ad = work
     do i = 1, n
       call fautodiff_stack_push_r(work)
       work = x(i) * work
@@ -55,18 +55,18 @@ contains
 
     do i = n, 1, - 1
       call fautodiff_stack_pop_r(work)
-      work_save_16_ad = work
+      work_save_15_ad = work
       work = x(i) * work
       work_ad = z_ad(i) * 2.0 * work + work_ad ! z(i) = work**2 + z(i)
-      work = work_save_16_ad
+      work = work_save_15_ad
       x_ad(i) = work_ad * work + x_ad(i) ! work = x(i) * work
       work_ad = work_ad * x(i) ! work = x(i) * work
     end do
-    work = work_save_18_ad
+    work = work_save_17_ad
     x_ad(:) = z_ad(:) * work + x_ad(:) ! z(:) = x(:) * work
     work_ad = sum(z_ad(:) * x(:)) + work_ad ! z(:) = x(:) * work
     z_ad(:) = 0.0 ! z(:) = x(:) * work
-    work = work_save_13_ad
+    work = work_save_12_ad
     x_ad(1) = work_ad * work + x_ad(1) ! work = x(1) * work
 
     return
@@ -112,13 +112,13 @@ contains
     real :: y
     real :: z
     real :: a
-    real :: y_save_37_ad
+    real :: y_save_36_ad
 
     y = 0.0
     z = 1.0
     a = y * x
     call fautodiff_stack_l%push(.false.)
-    y_save_37_ad = y
+    y_save_36_ad = y
     do while (y < 10.0)
       call fautodiff_stack_l%push(.true.)
       call fautodiff_stack_push_r(z)
@@ -143,7 +143,7 @@ contains
       a_ad = y_ad + a_ad ! y = y + a
       x_ad = a_ad + x_ad ! a = a + x
     end do
-    y = y_save_37_ad
+    y = y_save_36_ad
     x_ad = a_ad * y + x_ad ! a = y * x
     z_ad = 0.0 ! z = 1.0
     y_ad = 0.0 ! y = 0.0

--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -4360,7 +4360,18 @@ class Allocate(Node):
         else:
             vars = vars.copy()
         for var in self.vars:
-            vars.remove(var)
+            index = var.index
+            if index is None:
+                if self.mold is None:
+                    raise RuntimeError("Index is missing")
+                index = self.mold.dims
+            index_new: List[OpRange] = []
+            for idx in index:
+                if  isinstance(idx, OpRange):
+                    index_new.append(idx)
+                else:
+                    index_new.append(OpRange([OpInt(1), idx]))
+            vars.remove(var.change_index(AryIndex(index_new)))
             index = var.concat_index()
             if index:
                 for idx in index.collect_vars():

--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -2556,7 +2556,7 @@ class Module(Node):
     uses: Optional[Block] = None
     body: Optional[Block] = None
     decls: Optional[Block] = None
-    routines: Block = field(default_factory=Block)
+    routines: List[Routine] = field(default_factory=list)
     directives: dict = field(default_factory=dict)
 
     def iter_children(self):

--- a/fautodiff/code_tree.py
+++ b/fautodiff/code_tree.py
@@ -2664,6 +2664,18 @@ class Routine(Node):
         super().__post_init__()
         self.decls.set_parent(self)
         self.content.set_parent(self)
+        self._ensure_argument_intents()
+
+    def _ensure_argument_intents(self) -> None:
+        """Assume intent(inout) for arguments without explicit intent."""
+        if not self.args:
+            return
+        for arg in self.args:
+            decl = self.decl_map.get(arg) if self.decl_map is not None else None
+            if decl is None:
+                decl = self.decls.find_by_name(arg)
+            if decl is not None and decl.intent is None:
+                decl.intent = "inout"
 
     def __str__(self) -> str:
         header = f"[{self.kind.title()}] name: {self.name}"
@@ -2754,6 +2766,8 @@ class Routine(Node):
         intent = decl.intent
         if self.result == name:
             intent = "out"
+        elif intent is None and name in self.args:
+            intent = "inout"
         return OpVar(
             name,
             var_type=decl.var_type.copy(),

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -2546,6 +2546,14 @@ def generate_ad(
                 else:
                     routine_map[r.name] = routine_info["arg_info"]
 
+        for routine in mod_org.routines:
+            assumed_args = routine.assumed_intent_args
+            if assumed_args:
+                arg_names = ", ".join(assumed_args)
+                warnings.append(
+                    f"Assumed intent(inout) for arguments {arg_names} in routine {routine.name} because no INTENT attribute was specified"
+                )
+
         used_mods = mod_org.find_use_modules()
         const_var_names: List[str] = []
         for name in used_mods:

--- a/fautodiff/generator.py
+++ b/fautodiff/generator.py
@@ -2373,7 +2373,10 @@ def _generate_ad_subroutine(
     mod_all_var_names.extend(const_var_names)
     required_vnames = []
     for var in subroutine.required_vars():
-        if var.name in mod_all_var_names or var.is_constant:
+        if (var.name_ext() in mod_all_var_names or
+            var.is_constant or
+            var.name.endswith("pushpop_ad")
+        ):
             continue
         decl = subroutine.decls.find_by_name(var.name) if subroutine.decls else None
         if decl is not None:

--- a/fautodiff/parser.py
+++ b/fautodiff/parser.py
@@ -565,24 +565,6 @@ def _assignment_with_cpp(
     return PreprocessorIfBlock(cond_blocks, macro_tables)
 
 
-def _apply_macro_name(node: Node, name: str) -> None:
-    """Recursively tag all Operators within ``node`` with ``name``."""
-
-    def _mark(obj: Any) -> None:
-        if isinstance(obj, Operator):
-            obj.macro_name = name
-            for v in vars(obj).values():
-                _mark(v)
-        elif isinstance(obj, Node):
-            for v in vars(obj).values():
-                _mark(v)
-        elif isinstance(obj, list):
-            for item in obj:
-                _mark(item)
-
-    _mark(node)
-
-
 def _stmt_name(stmt):
     """Return the name from a program unit statement.
 

--- a/fautodiff/var_list.py
+++ b/fautodiff/var_list.py
@@ -1555,6 +1555,9 @@ class VarList:
         if not isinstance(var, OpVar):
             raise ValueError(f"Must be OpVar: {type(var)}")
 
+        if var.name == var.macro_name:
+            return
+
         name = var.name_ext()
         # Update dims info
         if name not in self._store:
@@ -1573,6 +1576,9 @@ class VarList:
 
         if not isinstance(var, OpVar):
             raise ValueError("Must be OpVar")
+
+        if var.name == var.macro_name:
+            return
 
         name = var.name_ext()
         if name not in self._store:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -504,9 +504,9 @@ class TestGenerator(unittest.TestCase):
                 src, str(Path(tmp) / "attrs.f90"), warn=False, fadmod_dir=tmp
             )
             self.assertIn("real, save :: a", generated)
-            self.assertIn("integer, value :: b", generated)
-            self.assertIn("real, volatile :: c", generated)
-            self.assertIn("real, asynchronous :: d", generated)
+            self.assertIn("integer, intent(inout), value :: b", generated)
+            self.assertIn("real, intent(inout), volatile :: c", generated)
+            self.assertIn("real, intent(inout), asynchronous :: d", generated)
             self.assertIn("type, abstract, bind(C) :: t_ad", generated)
             self.assertIn("type :: seq_ad_t", generated)
             self.assertIn("sequence", generated)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,5 +1,7 @@
 import sys
 import unittest
+from contextlib import redirect_stderr
+from io import StringIO
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -414,6 +416,26 @@ class TestGenerator(unittest.TestCase):
         generated = gen("examples/macro_multistmt.F90", warn=False)
         expected = Path("examples/macro_multistmt_ad.F90").read_text()
         self.assertEqual(generated, expected)
+
+    def test_warning_for_assumed_intent(self):
+        code_tree.Node.reset()
+        from tempfile import TemporaryDirectory
+
+        src = Path("examples/macro_multistmt.F90").read_text()
+        buf = StringIO()
+        with TemporaryDirectory() as tmp, redirect_stderr(buf):
+            generator.generate_ad(
+                src,
+                "examples/macro_multistmt.F90",
+                warn=True,
+                search_dirs=[".", "examples", "fortran_modules"],
+                fadmod_dir=tmp,
+            )
+        stderr = buf.getvalue()
+        expected_msg = (
+            "Assumed intent(inout) for arguments x, y in routine foo because no INTENT attribute was specified"
+        )
+        self.assertIn(expected_msg, stderr)
 
     def test_deallocate_mod_grad_var_prevents_skip(self):
         code_tree.Node.reset()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -433,7 +433,7 @@ class TestGenerator(unittest.TestCase):
             )
         stderr = buf.getvalue()
         expected_msg = (
-            "Assumed intent(inout) for arguments x, y in routine foo because no INTENT attribute was specified"
+            "macro_multistmt.F90:8: foo - Assumed intent(inout) for arguments x, y because no INTENT attribute was specified"
         )
         self.assertIn(expected_msg, stderr)
 

--- a/tests/test_macro.py
+++ b/tests/test_macro.py
@@ -211,7 +211,7 @@ class TestMacroRename(unittest.TestCase):
     def test_token_with_ad_suffix_renamed(self):
         src = "!$CPP #define BAD foo_ad\n"
         parser._extract_macros(src)
-        expanded = parser._expand_macros("BAD\n")
+        expanded = parser._expand_macros("BAD\n", "<string>")
         line = expanded.strip()
         self.assertEqual(line, "foo_ad_macro ! foo_ad -> foo_ad_macro")
         self.assertTrue(any("foo_ad" in m for m in parser.macro_warnings))


### PR DESCRIPTION
- attach info metadata to routines and OpenMP directives during parsing so warnings map back to their original lines
- normalize warning output to use filename basenames and remove the recursive fallback search
- propagate warning format changes through macro-expansion helpers and tests to keep coverage intact