### PR TITLE
Replace assumed-rank stack wrappers with rank-specific generics

### DIFF
--- a/fortran_modules/fautodiff_stack.f90
+++ b/fortran_modules/fautodiff_stack.f90
@@ -145,10 +145,12 @@ module fautodiff_stack
   type(fautodiff_stack_p_t), save :: fautodiff_stack_p
 
   interface fautodiff_stack_push_r
-    module procedure fautodiff_stack_push_r4, fautodiff_stack_push_r8
+    module procedure fautodiff_stack_push_r4_0d, fautodiff_stack_push_r4_1d, fautodiff_stack_push_r4_2d, fautodiff_stack_push_r4_3d
+    module procedure fautodiff_stack_push_r8_0d, fautodiff_stack_push_r8_1d, fautodiff_stack_push_r8_2d, fautodiff_stack_push_r8_3d
   end interface
   interface fautodiff_stack_pop_r
-    module procedure fautodiff_stack_pop_r4, fautodiff_stack_pop_r8
+    module procedure fautodiff_stack_pop_r4_0d, fautodiff_stack_pop_r4_1d, fautodiff_stack_pop_r4_2d, fautodiff_stack_pop_r4_3d
+    module procedure fautodiff_stack_pop_r8_0d, fautodiff_stack_pop_r8_1d, fautodiff_stack_pop_r8_2d, fautodiff_stack_pop_r8_3d
   end interface
 
 contains
@@ -1354,72 +1356,84 @@ contains
     return
   end subroutine pop_p_r8_3d
 
-  subroutine fautodiff_stack_push_r4(data)
-    real, intent(in), target :: data(..)
-    select rank(data)
-    rank(0)
-      call push_r4_0d(fautodiff_stack_r4, data)
-    rank(1)
-      call push_r4_1d(fautodiff_stack_r4, data)
-    rank(2)
-      call push_r4_2d(fautodiff_stack_r4, data)
-    rank(3)
-      call push_r4_3d(fautodiff_stack_r4, data)
-    rank default
-      print *, 'Rank larger than 3 is not supported'
-      error stop 1
-    end select
-  end subroutine fautodiff_stack_push_r4
+  subroutine fautodiff_stack_push_r4_0d(data)
+    real, intent(in) :: data
+    call push_r4_0d(fautodiff_stack_r4, data)
+  end subroutine fautodiff_stack_push_r4_0d
 
-  subroutine fautodiff_stack_pop_r4(data)
-    real, intent(out), target :: data(..)
-    select rank(data)
-    rank(0)
-      call pop_r4_0d(fautodiff_stack_r4, data)
-    rank(1)
-      call pop_r4_1d(fautodiff_stack_r4, data)
-    rank(2)
-      call pop_r4_2d(fautodiff_stack_r4, data)
-    rank(3)
-      call pop_r4_3d(fautodiff_stack_r4, data)
-    rank default
-      print *, 'Rank larger than 3 is not supported'
-      error stop 1
-    end select
-  end subroutine fautodiff_stack_pop_r4
+  subroutine fautodiff_stack_pop_r4_0d(data)
+    real, intent(out) :: data
+    call pop_r4_0d(fautodiff_stack_r4, data)
+  end subroutine fautodiff_stack_pop_r4_0d
 
-  subroutine fautodiff_stack_push_r8(data)
-    real(8), intent(in), target :: data(..)
-    select rank(data)
-    rank(0)
-      call push_r8_0d(fautodiff_stack_r8, data)
-    rank(1)
-      call push_r8_1d(fautodiff_stack_r8, data)
-    rank(2)
-      call push_r8_2d(fautodiff_stack_r8, data)
-    rank(3)
-      call push_r8_3d(fautodiff_stack_r8, data)
-    rank default
-      print *, 'Rank larger than 3 is not supported'
-      error stop 1
-    end select
-  end subroutine fautodiff_stack_push_r8
+  subroutine fautodiff_stack_push_r4_1d(data)
+    real, intent(in), target :: data(:)
+    call push_r4_1d(fautodiff_stack_r4, data)
+  end subroutine fautodiff_stack_push_r4_1d
 
-  subroutine fautodiff_stack_pop_r8(data)
-    real(8), intent(out), target :: data(..)
-    select rank(data)
-    rank(0)
-      call pop_r8_0d(fautodiff_stack_r8, data)
-    rank(1)
-      call pop_r8_1d(fautodiff_stack_r8, data)
-    rank(2)
-      call pop_r8_2d(fautodiff_stack_r8, data)
-    rank(3)
-      call pop_r8_3d(fautodiff_stack_r8, data)
-    rank default
-      print *, 'Rank larger than 3 is not supported'
-      error stop 1
-    end select
-  end subroutine fautodiff_stack_pop_r8
+  subroutine fautodiff_stack_pop_r4_1d(data)
+    real, intent(out), target :: data(:)
+    call pop_r4_1d(fautodiff_stack_r4, data)
+  end subroutine fautodiff_stack_pop_r4_1d
+
+  subroutine fautodiff_stack_push_r4_2d(data)
+    real, intent(in), target :: data(:, :)
+    call push_r4_2d(fautodiff_stack_r4, data)
+  end subroutine fautodiff_stack_push_r4_2d
+
+  subroutine fautodiff_stack_pop_r4_2d(data)
+    real, intent(out), target :: data(:, :)
+    call pop_r4_2d(fautodiff_stack_r4, data)
+  end subroutine fautodiff_stack_pop_r4_2d
+
+  subroutine fautodiff_stack_push_r4_3d(data)
+    real, intent(in), target :: data(:, :, :)
+    call push_r4_3d(fautodiff_stack_r4, data)
+  end subroutine fautodiff_stack_push_r4_3d
+
+  subroutine fautodiff_stack_pop_r4_3d(data)
+    real, intent(out), target :: data(:, :, :)
+    call pop_r4_3d(fautodiff_stack_r4, data)
+  end subroutine fautodiff_stack_pop_r4_3d
+
+  subroutine fautodiff_stack_push_r8_0d(data)
+    real(8), intent(in) :: data
+    call push_r8_0d(fautodiff_stack_r8, data)
+  end subroutine fautodiff_stack_push_r8_0d
+
+  subroutine fautodiff_stack_pop_r8_0d(data)
+    real(8), intent(out) :: data
+    call pop_r8_0d(fautodiff_stack_r8, data)
+  end subroutine fautodiff_stack_pop_r8_0d
+
+  subroutine fautodiff_stack_push_r8_1d(data)
+    real(8), intent(in), target :: data(:)
+    call push_r8_1d(fautodiff_stack_r8, data)
+  end subroutine fautodiff_stack_push_r8_1d
+
+  subroutine fautodiff_stack_pop_r8_1d(data)
+    real(8), intent(out), target :: data(:)
+    call pop_r8_1d(fautodiff_stack_r8, data)
+  end subroutine fautodiff_stack_pop_r8_1d
+
+  subroutine fautodiff_stack_push_r8_2d(data)
+    real(8), intent(in), target :: data(:, :)
+    call push_r8_2d(fautodiff_stack_r8, data)
+  end subroutine fautodiff_stack_push_r8_2d
+
+  subroutine fautodiff_stack_pop_r8_2d(data)
+    real(8), intent(out), target :: data(:, :)
+    call pop_r8_2d(fautodiff_stack_r8, data)
+  end subroutine fautodiff_stack_pop_r8_2d
+
+  subroutine fautodiff_stack_push_r8_3d(data)
+    real(8), intent(in), target :: data(:, :, :)
+    call push_r8_3d(fautodiff_stack_r8, data)
+  end subroutine fautodiff_stack_push_r8_3d
+
+  subroutine fautodiff_stack_pop_r8_3d(data)
+    real(8), intent(out), target :: data(:, :, :)
+    call pop_r8_3d(fautodiff_stack_r8, data)
+  end subroutine fautodiff_stack_pop_r8_3d
 
 end module fautodiff_stack


### PR DESCRIPTION
## Summary
- teach gen_fautodiff_stack.py to emit dedicated push/pop wrappers per rank
- list all rank-specific wrappers in the generic interfaces
- regenerate fautodiff_stack.f90 so it no longer uses assumed-rank arguments

## Testing
- not run (no test mandate from change)
