### PR TITLE
Ensure validation driver uses AD modules for extent symbols

### DIFF
--- a/fautodiff/validation_driver.py
+++ b/fautodiff/validation_driver.py
@@ -205,7 +205,6 @@ def render_validation_driver(
     program_name = f"run_{mod_org.name}_validation"
     lines: List[str] = [
         f"program {program_name}",
-        f"  use {mod_org.name}",
         f"  use {mod_org.name}{ad_suffix}",
         "  implicit none",
         "",
@@ -220,7 +219,6 @@ def render_validation_driver(
 
     additional_uses: "OrderedDict[Tuple[str, bool], Dict[str, Any]]" = OrderedDict()
     module_use_names = {
-        mod_org.name.lower(),
         f"{mod_org.name}{ad_suffix}".lower(),
     }
 

--- a/fautodiff/validation_driver.py
+++ b/fautodiff/validation_driver.py
@@ -103,8 +103,8 @@ def _collect_extent_symbols(extent: str) -> Set[str]:
 
 def _build_use_lookup(
     mod_org: Module, routine: Routine
-) -> Tuple[Dict[str, List[Use]], List[Use]]:
-    symbol_lookup: Dict[str, List[Use]] = {}
+) -> Tuple[Dict[str, List[Tuple[Use, Optional[str]]]], List[Use]]:
+    symbol_lookup: Dict[str, List[Tuple[Use, Optional[str]]]] = {}
     fallback: List[Use] = []
 
     use_nodes: List[Use] = []
@@ -120,10 +120,11 @@ def _build_use_lookup(
     for use in use_nodes:
         if use.only:
             for entry in use.only:
-                local = entry.split("=>")[0].strip()
+                entry_norm = entry.strip()
+                local = entry_norm.split("=>")[0].strip()
                 if not local:
                     continue
-                symbol_lookup.setdefault(local.lower(), []).append(use)
+                symbol_lookup.setdefault(local.lower(), []).append((use, entry_norm))
         else:
             fallback.append(use)
 
@@ -217,24 +218,51 @@ def render_validation_driver(
             if isinstance(node, Declaration):
                 module_declared_names.add(node.name.lower())
 
-    additional_uses: "OrderedDict[Tuple[str, Optional[Tuple[str, ...]]], Use]" = (
-        OrderedDict()
-    )
+    additional_uses: "OrderedDict[Tuple[str, bool], Dict[str, Any]]" = OrderedDict()
     module_use_names = {
         mod_org.name.lower(),
         f"{mod_org.name}{ad_suffix}".lower(),
     }
 
-    def _record_additional_use(use: Use) -> None:
-        name_lower = use.name.lower()
-        if name_lower in module_use_names:
-            return
-        only_lower: Optional[Tuple[str, ...]] = None
-        if use.only is not None:
-            only_lower = tuple(entry.lower() for entry in use.only)
-        key = (name_lower, only_lower)
-        if key not in additional_uses:
-            additional_uses[key] = use.copy()
+    intrinsic_module_names = {
+        "iso_fortran_env",
+        "iso_c_binding",
+        "ieee_arithmetic",
+        "ieee_exceptions",
+        "ieee_features",
+    }
+    ad_suffix_lower = ad_suffix.lower()
+
+    def _to_ad_module_name(name: str) -> str:
+        name_lower = name.lower()
+        if name_lower in intrinsic_module_names:
+            return name
+        if name_lower.endswith(ad_suffix_lower):
+            return name
+        return f"{name}{ad_suffix}"
+
+    def _record_additional_use(use: Use, entry: Optional[str]) -> None:
+        target_name = _to_ad_module_name(use.name)
+        name_lower = target_name.lower()
+        key = (name_lower, use.only is not None)
+        info = additional_uses.get(key)
+        if info is None:
+            if name_lower in module_use_names and use.only is None:
+                return
+            copy = use.copy()
+            copy.name = target_name
+            entries: Optional["OrderedDict[str, str]"] = None
+            if use.only is not None:
+                copy.only = []
+                entries = OrderedDict()
+            info = {"use": copy, "entries": entries}
+            additional_uses[key] = info
+            module_use_names.add(name_lower)
+        entries = info.get("entries")
+        if entry is not None and entries is not None:
+            entry_lower = entry.lower()
+            if entry_lower not in entries:
+                entries[entry_lower] = entry
 
     routines = list(mod_org.routines)
     if not routines:
@@ -571,10 +599,10 @@ def render_validation_driver(
                     continue
                 uses_for_symbol = use_lookup.get(symbol_lower)
                 if uses_for_symbol is None and len(fallback_uses) == 1:
-                    uses_for_symbol = fallback_uses
+                    uses_for_symbol = [(fallback_uses[0], None)]
                 if uses_for_symbol:
-                    for use in uses_for_symbol:
-                        _record_additional_use(use)
+                    for use, entry in uses_for_symbol:
+                        _record_additional_use(use, entry)
 
         if scalar_real_decls:
             sub_lines.append("")
@@ -877,7 +905,13 @@ def render_validation_driver(
         except ValueError:
             implicit_idx = 3
         use_lines = []
-        for use in additional_uses.values():
+        for info in additional_uses.values():
+            use = info["use"]
+            entries = info["entries"]
+            if entries is not None:
+                if not entries:
+                    continue
+                use.only = list(entries.values())
             rendered = use.render(indent=1)[0].rstrip()
             use_lines.append(rendered)
         lines[implicit_idx:implicit_idx] = use_lines

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -506,7 +506,7 @@ class TestGenerator(unittest.TestCase):
                 validation_driver_name=driver_name,
             )
             driver_text = (tmp_dir / driver_name).read_text().lower()
-            self.assertIn("use ext_constants, only: n", driver_text)
+            self.assertIn("use ext_constants_ad, only: n", driver_text)
 
     def test_module_vars_example_fadmod(self):
         code_tree.Node.reset()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -297,6 +297,42 @@ class TestGenerator(unittest.TestCase):
                 "Transpose check (add_numbers): |v^TJu - u^TJ^Tv|", driver_text
             )
 
+    def test_validation_driver_uses_all_indices_for_delta_reference(self):
+        code_tree.Node.reset()
+        from tempfile import TemporaryDirectory
+
+        src = textwrap.dedent(
+            """
+            module multi_dim_mod
+            contains
+              subroutine spread_values(h, y)
+                real, intent(inout) :: h(2, 3)
+                real, intent(out) :: y(2, 3)
+                y = h
+              end subroutine spread_values
+            end module multi_dim_mod
+            """
+        )
+
+        with TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            src_path = tmp_dir / "multi_dim_mod.f90"
+            src_path.write_text(src)
+            out_file = tmp_dir / "multi_dim_mod_ad.f90"
+            generator.generate_ad(
+                src_path.read_text(),
+                str(src_path),
+                out_file=out_file,
+                warn=False,
+                fadmod_dir=tmp_dir,
+                emit_validation=True,
+            )
+            driver_path = tmp_dir / "run_multi_dim_mod_validation.f90"
+            self.assertTrue(driver_path.exists())
+            driver_text = driver_path.read_text()
+            self.assertIn("delta = sqrt(epsilon(h(1, 1)))", driver_text)
+            self.assertNotIn("delta = sqrt(epsilon(h(1)))", driver_text)
+
     def test_emit_validation_driver_custom_name(self):
         code_tree.Node.reset()
         from tempfile import TemporaryDirectory

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -286,7 +286,7 @@ class TestGenerator(unittest.TestCase):
             self.assertTrue(driver_path.exists())
             driver_text = driver_path.read_text()
             self.assertIn("program run_simple_math_validation", driver_text)
-            self.assertIn("use simple_math", driver_text)
+            self.assertNotIn("use simple_math\n", driver_text)
             self.assertIn("use simple_math_ad", driver_text)
             self.assertIn("call validate_add_numbers()", driver_text)
             self.assertIn("delta = sqrt(epsilon(a))", driver_text)


### PR DESCRIPTION
## Summary
- update validation driver generation to map extent-related USE statements to the AD module variants and retain only the required ONLY symbols
- adjust the validation driver regression test to expect the AD module import

## Testing
- python tests/test_generator.py

------
https://chatgpt.com/codex/tasks/task_b_69043507b3e8832d80a04ee61d880492